### PR TITLE
Make more string localizable

### DIFF
--- a/qml/dialogs/about/MpvqcAboutView.qml
+++ b/qml/dialogs/about/MpvqcAboutView.qml
@@ -75,9 +75,15 @@ Column {
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
 
-        text: 
-            qsTranslate("AboutDialog", "This program comes with absolutely no warranty.") + "<br>" +
-            qsTranslate("AboutDialog", "See the %1 for details.").arg("<a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">" + qsTranslate("AboutDialog","GNU General Public License, version 3 or later") + "</a>") +
+        readonly property url licenseUrl: "https://www.gnu.org/licenses/gpl-3.0.html"
+        //: This text is part of the software license description. This is the name of the license being used.
+        readonly property string licenseText: qsTranslate("AboutDialog", "GNU General Public License, version 3 or later")
+        readonly property string anchor: `<a href="${licenseUrl}">${licenseText}</a>`
+
+            //: This text is part of the software license description
+        text: qsTranslate("AboutDialog", "This program comes with absolutely no warranty.") + "<br>"
+            //: This text is part of the software license description. Argument %1 will be the link to the license
+            + qsTranslate("AboutDialog", "See the %1 for details.").arg(anchor)
 
         onLinkActivated: (link) => {
             Qt.openUrlExternally(link)

--- a/qml/dialogs/about/MpvqcAboutView.qml
+++ b/qml/dialogs/about/MpvqcAboutView.qml
@@ -65,7 +65,7 @@ Column {
     }
 
     Label {
-        text: "Copyright © mpvQC Developers"
+        text: qsTranslate("AboutDialog", "Copyright © mpvQC Developers")
         anchors.horizontalCenter: parent.horizontalCenter
     }
 
@@ -75,7 +75,9 @@ Column {
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
 
-        text: `This program comes with absolutely no warranty.<br>See the <a href="https://www.gnu.org/licenses/gpl-3.0.html">GNU General Public License, version 3 or later</a> for details.`
+        text: 
+            qsTranslate("AboutDialog", "This program comes with absolutely no warranty.") + "<br>" +
+            qsTranslate("AboutDialog", "See the %1 for details.").arg("<a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">" + qsTranslate("AboutDialog","GNU General Public License, version 3 or later") + "</a>") +
 
         onLinkActivated: (link) => {
             Qt.openUrlExternally(link)

--- a/qml/dialogs/about/MpvqcDependenciesView.qml
+++ b/qml/dialogs/about/MpvqcDependenciesView.qml
@@ -76,7 +76,7 @@ ScrollView {
         }
 
         MpvqcHeader {
-            text: 'Other'
+            text: qsTranslate("AboutDialog", "Other")
             anchors.horizontalCenter: parent.horizontalCenter
         }
 


### PR DESCRIPTION
During my translation efforts to Hebrew I noticed some strings are not localizable, and so I added the required annotations around most of the things I deemed to be "localizable". Luckily it's only a few spots. Feel free to leave any feedback.