### PR TITLE
Apply settings changes only on confirmation

### DIFF
--- a/qml/dialogs/appearance/MpvqcColorView.qml
+++ b/qml/dialogs/appearance/MpvqcColorView.qml
@@ -33,6 +33,11 @@ GridView {
     property int itemSize: 52
     property int itemPadding: 8
     property int borderSize: 12
+    property var initialColor: null
+
+    function reset(): void {
+        root.mpvqcSettings.primary = initialColor
+    }
 
     boundsBehavior: Flickable.StopAtBounds
     model: MpvqcAccentColorModel {}
@@ -66,6 +71,10 @@ GridView {
                 parent.onItemClicked()
             }
         }
+    }
+
+    Component.onCompleted: {
+        root.initialColor = root.mpvqcSettings.primary
     }
 
 }

--- a/qml/dialogs/appearance/MpvqcDialogAppearance.qml
+++ b/qml/dialogs/appearance/MpvqcDialogAppearance.qml
@@ -40,6 +40,8 @@ MpvqcDialog {
             }
 
             MpvqcThemeView {
+                id: _themeView
+
                 mpvqcApplication: root.mpvqcApplication
                 width: parent.width
 
@@ -53,10 +55,17 @@ MpvqcDialog {
             }
 
             MpvqcColorView {
+                id: _colorView
+
                 mpvqcApplication: root.mpvqcApplication
                 width: parent.width
             }
         }
+    }
+
+    onRejected: {
+        _themeView.reset()
+        _colorView.reset()
     }
 
 }

--- a/qml/dialogs/appearance/MpvqcThemeView.qml
+++ b/qml/dialogs/appearance/MpvqcThemeView.qml
@@ -31,6 +31,11 @@ ListView {
     property var mpvqcSettings: mpvqcApplication.mpvqcSettings
     property int itemSize: 52
     property int borderSize: 12
+    property var initialTheme: null
+
+    function reset(): void {
+        root.mpvqcSettings.theme = initialTheme
+    }
 
     boundsBehavior: Flickable.StopAtBounds
     model: MpvqcThemeModel {}
@@ -64,6 +69,10 @@ ListView {
                 parent.onItemClicked()
             }
         }
+    }
+
+    Component.onCompleted: {
+        root.initialTheme = root.mpvqcSettings.theme
     }
 
 }

--- a/qml/dialogs/backup/MpvqcBackupView.qml
+++ b/qml/dialogs/backup/MpvqcBackupView.qml
@@ -37,17 +37,24 @@ ColumnLayout {
     property alias backupIntervalSpinBox: _backupInterval.spinBox
     property alias backupLocationOpenButton: _backupLocationOpenButton
 
+    property bool currentBackupEnabled: root.mpvqcSettings.backupEnabled
+    property int currentBackupInterval: root.mpvqcSettings.backupInterval
+
+    function accept() {
+        mpvqcSettings.backupEnabled = currentBackupEnabled
+        mpvqcSettings.backupInterval = currentBackupInterval
+    }
 
     MpvqcSwitchRow {
         id: _backupEnable
 
         label: qsTranslate("BackupDialog", "Backup Enabled")
         prefWidth: root.width
-        checked: root.mpvqcSettings.backupEnabled
+        checked: currentBackupEnabled
         Layout.topMargin: 20
 
-        onToggled: (state) => {
-            root.mpvqcSettings.backupEnabled = state
+        onToggled: state => {
+            root.currentBackupEnabled = state
         }
     }
 
@@ -57,12 +64,12 @@ ColumnLayout {
         label: qsTranslate("BackupDialog", "Backup Interval")
         suffix: qsTranslate("BackupDialog", "Seconds")
         prefWidth: root.width
-        value: root.mpvqcSettings.backupInterval
+        value: currentBackupInterval
         valueFrom: 15
         valueTo: 5 * 60
 
-        onValueModified: (value) => {
-            root.mpvqcSettings.backupInterval = value
+        onValueModified: value => {
+            root.currentBackupInterval = value
         }
     }
 
@@ -88,7 +95,6 @@ ColumnLayout {
             visible: _backupLocationOpenButton.hovered
             text: root.mpvqcUtilityPyObject.urlToAbsolutePath(_backupLocationOpenButton.backupDirectory)
         }
-
     }
 
 }

--- a/qml/dialogs/backup/MpvqcDialogBackup.qml
+++ b/qml/dialogs/backup/MpvqcDialogBackup.qml
@@ -26,9 +26,16 @@ MpvqcDialog {
     id: root
 
     MpvqcBackupView {
+        id: _backupView
+
         property string title: qsTranslate("BackupDialog", "Backup Settings")
 
         width: root.width
         mpvqcApplication: root.mpvqcApplication
     }
+
+    onAccepted: {
+        _backupView.accept()
+    }
+
 }

--- a/qml/dialogs/backup/tst_MpvqcBackupView.qml
+++ b/qml/dialogs/backup/tst_MpvqcBackupView.qml
@@ -21,54 +21,68 @@ import QtQuick
 import QtTest
 
 
-MpvqcBackupView {
-    id: objectUnderTest
+TestCase {
+    id: testCase
 
-    mpvqcApplication: QtObject {
-        property var mpvqcSettings: QtObject {
-            property bool backupEnabled: true
-            property int backupInterval: 90
-        }
-        property var mpvqcApplicationPathsPyObject: QtObject {
-            property url dir_backup: 'file:///hello.txt'
-        }
-        property var mpvqcUtilityPyObject: QtObject {
-            function urlToAbsolutePath(url) { return `${url}-as-abs-path` }
+    name: "MpvqcBackupView"
+    when: windowShown
+    width: 400
+    height: 400
+    visible: true
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcBackupView {
+            mpvqcApplication: QtObject {
+                property var mpvqcSettings: QtObject {
+                    property bool backupEnabled: true
+                    property int backupInterval: 90
+                }
+                property var mpvqcApplicationPathsPyObject: QtObject {
+                    property url dir_backup: 'file:///hello.txt'
+                }
+                property var mpvqcUtilityPyObject: QtObject {
+                    function urlToAbsolutePath(url) {
+                        return `${ url }-as-abs-path`
+                    }
+                }
+            }
         }
     }
 
-    width: 400
-    height: 400
+    function test_value_change() {
+        const control = createTemporaryObject(objectUnderTest, testCase)
+        verify(control)
 
-    TestCase {
-        name: "MpvqcBackupView"
-        when: windowShown
+        verifyTemporaryValues(control)
 
-        function init() {
-            const settings = objectUnderTest.mpvqcApplication.mpvqcSettings
-            settings.backupEnabled = true
-            settings.backupInterval = 90
-        }
+        control.accept()
 
-        function test_backup_data() {
-            return [
-                {
-                     tag: 'toggle',
-                     exec: () => { objectUnderTest.backupEnabledSwitch.checked = false },
-                     verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.backupEnabled, false) },
-                },
-                {
-                     tag: 'interval',
-                     exec: () => { objectUnderTest.backupIntervalSpinBox.increase() },
-                     verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.backupInterval, 91) },
-                },
-            ]
-        }
+        compare(control.mpvqcApplication.mpvqcSettings.backupEnabled, false)
+        compare(control.mpvqcApplication.mpvqcSettings.backupInterval, 91)
 
-        function test_backup(data) {
-            data.exec()
-            data.verify()
-        }
+    }
+
+    function verifyTemporaryValues(control) {
+        compare(control.mpvqcApplication.mpvqcSettings.backupEnabled, true)
+        compare(control.mpvqcApplication.mpvqcSettings.backupInterval, 90)
+
+        control.backupEnabledSwitch.checked = false
+        compare(control.currentBackupEnabled, false)
+
+        control.backupIntervalSpinBox.increase()
+        compare(control.currentBackupInterval, 91)
+    }
+
+    function test_reset() {
+        const control = createTemporaryObject(objectUnderTest, testCase)
+        verify(control)
+
+        verifyTemporaryValues(control)
+
+        compare(control.mpvqcApplication.mpvqcSettings.backupEnabled, true)
+        compare(control.mpvqcApplication.mpvqcSettings.backupInterval, 90)
     }
 
 }

--- a/qml/dialogs/export/MpvqcDialogExport.qml
+++ b/qml/dialogs/export/MpvqcDialogExport.qml
@@ -26,10 +26,16 @@ MpvqcDialog {
     id: root
 
     MpvqcExportView {
+        id: _exportView
+
         property string title: qsTranslate("ExportSettingsDialog", "Export Settings")
 
         width: root.width
         mpvqcApplication: root.mpvqcApplication
+    }
+
+    onAccepted: {
+        _exportView.accept()
     }
 
 }

--- a/qml/dialogs/export/MpvqcExportView.qml
+++ b/qml/dialogs/export/MpvqcExportView.qml
@@ -36,19 +36,33 @@ ColumnLayout {
     property alias nicknameToggle: _nicknameToggle
     property alias pathToggle: _pathToggle
 
+    property string currentNickname: root.mpvqcSettings.nickname
+    property bool currentWriteHeaderDate: root.mpvqcSettings.writeHeaderDate
+    property bool currentWriteHeaderGenerator: root.mpvqcSettings.writeHeaderGenerator
+    property bool currentWriteHeaderNickname: root.mpvqcSettings.writeHeaderNickname
+    property bool currentWriteHeaderVideoPath: root.mpvqcSettings.writeHeaderVideoPath
+
+    function accept() {
+        root.mpvqcSettings.nickname = currentNickname
+        root.mpvqcSettings.writeHeaderDate = currentWriteHeaderDate
+        root.mpvqcSettings.writeHeaderGenerator = currentWriteHeaderGenerator
+        root.mpvqcSettings.writeHeaderNickname = currentWriteHeaderNickname
+        root.mpvqcSettings.writeHeaderVideoPath = currentWriteHeaderVideoPath
+    }
+
     MpvqcTextFieldRow {
         id: _nicknameInput
 
         label: qsTranslate("ExportSettingsDialog", "Nickname")
-        input: root.mpvqcSettings.nickname
+        input: root.currentNickname
         spacing: 16
         fontWeight: Font.DemiBold
         prefWidth: root.width
         implicitTextFieldWidth: 150
         Layout.topMargin: 20
 
-        onTextChanged: (text) => {
-            root.mpvqcSettings.nickname = text
+        onTextChanged: text => {
+            root.currentNickname = text
         }
     }
 
@@ -63,11 +77,11 @@ ColumnLayout {
         id: _dateToggle
 
         label: qsTranslate("ExportSettingsDialog", "Write Date")
-        checked: root.mpvqcSettings.writeHeaderDate
+        checked: root.currentWriteHeaderDate
         prefWidth: root.width
 
-        onToggled: (state) => {
-            root.mpvqcSettings.writeHeaderDate = state
+        onToggled: state => {
+            root.currentWriteHeaderDate = state
         }
     }
 
@@ -76,11 +90,11 @@ ColumnLayout {
 
         //: %1 will be the application name. Most probably 'mpvQC' :)
         label: qsTranslate("ExportSettingsDialog", "Write '%1'").arg(Qt.application.name)
-        checked: root.mpvqcSettings.writeHeaderGenerator
+        checked: root.currentWriteHeaderGenerator
         prefWidth: root.width
 
-        onToggled: (state) => {
-            root.mpvqcSettings.writeHeaderGenerator = state
+        onToggled: state => {
+            root.currentWriteHeaderGenerator = state
         }
     }
 
@@ -88,11 +102,11 @@ ColumnLayout {
         id: _nicknameToggle
 
         label: qsTranslate("ExportSettingsDialog", "Write Nickname")
-        checked: root.mpvqcSettings.writeHeaderNickname
+        checked: root.currentWriteHeaderNickname
         prefWidth: root.width
 
-        onToggled: (state) => {
-            root.mpvqcSettings.writeHeaderNickname = state
+        onToggled: state => {
+            root.currentWriteHeaderNickname = state
         }
     }
 
@@ -100,11 +114,11 @@ ColumnLayout {
         id: _pathToggle
 
         label: qsTranslate("ExportSettingsDialog", "Write Video Path")
-        checked: root.mpvqcSettings.writeHeaderVideoPath
+        checked: root.currentWriteHeaderVideoPath
         prefWidth: root.width
 
-        onToggled: (state) => {
-            root.mpvqcSettings.writeHeaderVideoPath = state
+        onToggled: state => {
+            root.currentWriteHeaderVideoPath = state
         }
     }
 

--- a/qml/dialogs/export/tst_MpvqcExportView.qml
+++ b/qml/dialogs/export/tst_MpvqcExportView.qml
@@ -21,68 +21,75 @@ import QtQuick
 import QtTest
 
 
-MpvqcExportView {
-    id: objectUnderTest
+TestCase {
+    id: testCase
 
-    mpvqcApplication: QtObject {
-        property var mpvqcSettings: QtObject {
-            property string nickname: 'nickname'
-            property bool writeHeaderDate: false
-            property bool writeHeaderGenerator: false
-            property bool writeHeaderNickname: false
-            property bool writeHeaderVideoPath: false
+    name: "MpvqcExportView"
+    when: windowShown
+    width: 400
+    height: 400
+    visible: true
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcExportView {
+            mpvqcApplication: QtObject {
+                property var mpvqcSettings: QtObject {
+                    property string nickname: 'nickname'
+                    property bool writeHeaderDate: false
+                    property bool writeHeaderGenerator: false
+                    property bool writeHeaderNickname: false
+                    property bool writeHeaderVideoPath: false
+                }
+            }
         }
     }
 
-    width: 400
-    height: 400
+    function test_accept() {
+        const control = createTemporaryObject(objectUnderTest, testCase)
+        verify(control)
 
-    TestCase {
-        name: "MpvqcExportView"
-        when: windowShown
+        changeValues(control)
+        control.accept()
 
-        function init() {
-            objectUnderTest.mpvqcApplication.mpvqcSettings.nickname = 'nickname'
-            objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderDate = false
-            objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderGenerator = false
-            objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderNickname = false
-            objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderVideoPath = false
-        }
+        compare(control.mpvqcApplication.mpvqcSettings.nickname, 'nickname-edited')
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderDate, true)
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderGenerator, true)
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderNickname, true)
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderVideoPath, true)
+    }
 
-        function test_export_data() {
-            return [
-                {
-                    tag: 'nickname',
-                    exec: () => { objectUnderTest.nicknameInput.input = 'other-nickname' },
-                    verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.nickname, 'other-nickname') },
-                },
-                {
-                    tag: 'header/date',
-                    exec: () => { objectUnderTest.dateToggle.checked = true },
-                    verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderDate, true) },
-                },
-                {
-                    tag: 'header/generator',
-                    exec: () => { objectUnderTest.generatorToggle.checked = true },
-                    verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderGenerator, true) },
-                },
-                {
-                    tag: 'header/nickname',
-                    exec: () => { objectUnderTest.nicknameToggle.checked = true },
-                    verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderNickname, true) },
-                },
-                {
-                    tag: 'header/nickname',
-                    exec: () => { objectUnderTest.pathToggle.checked = true },
-                    verify: () => { compare(objectUnderTest.mpvqcApplication.mpvqcSettings.writeHeaderVideoPath, true) },
-                },
-            ]
-        }
+    function changeValues(control) {
+        compare(control.currentNickname, 'nickname')
+        compare(control.currentWriteHeaderDate, false)
+        compare(control.currentWriteHeaderGenerator, false)
+        compare(control.currentWriteHeaderNickname, false)
+        compare(control.currentWriteHeaderVideoPath, false)
 
-        function test_export(data) {
-            data.exec()
-            data.verify()
-        }
+        control.nicknameInput.input = 'nickname-edited'
+        control.dateToggle.toggle.toggle()
+        control.generatorToggle.toggle.toggle()
+        control.nicknameToggle.toggle.toggle()
+        control.pathToggle.toggle.toggle()
+
+        compare(control.currentNickname, 'nickname-edited')
+        compare(control.currentWriteHeaderDate, true)
+        compare(control.currentWriteHeaderGenerator, true)
+        compare(control.currentWriteHeaderNickname, true)
+        compare(control.currentWriteHeaderVideoPath, true)
+    }
+
+    function test_reject() {
+        const control = createTemporaryObject(objectUnderTest, testCase)
+        verify(control)
+
+        changeValues(control)
+        compare(control.mpvqcApplication.mpvqcSettings.nickname, 'nickname')
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderDate, false)
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderGenerator, false)
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderNickname, false)
+        compare(control.mpvqcApplication.mpvqcSettings.writeHeaderVideoPath, false)
     }
 
 }

--- a/qml/dialogs/import/MpvqcDialogImport.qml
+++ b/qml/dialogs/import/MpvqcDialogImport.qml
@@ -26,10 +26,16 @@ MpvqcDialog {
     id: root
 
     MpvqcImportView {
+        id: _importView
+
         property string title: qsTranslate("ImportSettingsDialog", "Import Settings")
 
         width: root.width
         mpvqcApplication: root.mpvqcApplication
+    }
+
+    onAccepted: {
+        _importView.accept()
     }
 
 }

--- a/qml/dialogs/import/MpvqcImportView.qml
+++ b/qml/dialogs/import/MpvqcImportView.qml
@@ -31,6 +31,14 @@ ColumnLayout {
 
     property var mpvqcSettings: mpvqcApplication.mpvqcSettings
 
+    readonly property alias importPolicyComboBox: _importPolicyComboBox
+
+    property int currentImportPolicy: root.mpvqcSettings.importWhenVideoLinkedInDocument
+
+    function accept() {
+        root.mpvqcSettings.importWhenVideoLinkedInDocument = currentImportPolicy
+    }
+
     RowLayout {
         Layout.topMargin: 20
         spacing: 30
@@ -43,6 +51,8 @@ ColumnLayout {
         }
 
         ComboBox {
+            id: _importPolicyComboBox
+
             Layout.preferredWidth: 165
 
             textRole: 'text'
@@ -63,12 +73,12 @@ ColumnLayout {
                 }
             ]
 
-            onActivated: {
-                root.mpvqcSettings.importWhenVideoLinkedInDocument = currentValue
+            onActivated: value => {
+                root.currentImportPolicy = value
             }
 
             Component.onCompleted: {
-                currentIndex = indexOfValue(root.mpvqcSettings.importWhenVideoLinkedInDocument)
+                currentIndex = indexOfValue(root.currentImportPolicy)
             }
         }
 

--- a/qml/dialogs/import/tst_MpvqcImportView.qml
+++ b/qml/dialogs/import/tst_MpvqcImportView.qml
@@ -1,0 +1,73 @@
+/*
+mpvQC
+
+Copyright (C) 2022 mpvQC developers
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import QtQuick
+import QtTest
+
+
+TestCase {
+    id: testCase
+
+    readonly property int initialImportPolicy: 1 // Ask every time
+
+    name: "MpvqcImportView"
+    when: windowShown
+    width: 400
+    height: 400
+    visible: true
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcImportView {
+            mpvqcApplication: QtObject {
+                property var mpvqcSettings: QtObject {
+                    property int importWhenVideoLinkedInDocument: testCase.initialImportPolicy
+                }
+            }
+        }
+    }
+
+    function test_accept() {
+        const control = createTemporaryObject(objectUnderTest, testCase)
+        verify(control)
+
+        compare(control.mpvqcSettings.importWhenVideoLinkedInDocument, testCase.initialImportPolicy)
+        compare(control.currentImportPolicy, testCase.initialImportPolicy)
+
+        control.importPolicyComboBox.activated(0)
+        compare(control.currentImportPolicy, 0)
+
+        control.accept()
+        compare(control.mpvqcSettings.importWhenVideoLinkedInDocument, 0)
+    }
+
+    function test_reject() {
+        const control = createTemporaryObject(objectUnderTest, testCase)
+        verify(control)
+
+        compare(control.mpvqcSettings.importWhenVideoLinkedInDocument, testCase.initialImportPolicy)
+        compare(control.currentImportPolicy, testCase.initialImportPolicy)
+
+        control.importPolicyComboBox.activated(0)
+        compare(control.currentImportPolicy, 0)
+
+        compare(control.mpvqcSettings.importWhenVideoLinkedInDocument, testCase.initialImportPolicy)
+    }
+}


### PR DESCRIPTION
Previously, changes in appearance, backup, import, and export 
settings dialogs were applied directly to the settings object.

Now, for appearance settings, we still apply changes directly 
but reset them if the user does not click "Ok". For the other 
three dialogs, changes are stored temporarily and applied only 
when "Ok" is clicked.