### PR TITLE
Revisit primary and accent colors

### DIFF
--- a/mpvqc/startup.py
+++ b/mpvqc/startup.py
@@ -34,7 +34,7 @@ class StartUp:
     def configure_qt_settings():
         from PySide6.QtCore import QSettings
 
-        QSettings.setDefaultFormat(QSettings.IniFormat)
+        QSettings.setDefaultFormat(QSettings.Format.IniFormat)
 
     @staticmethod
     def configure_qt_logging():

--- a/qml/app/MpvqcApplication.qml
+++ b/qml/app/MpvqcApplication.qml
@@ -51,6 +51,9 @@ ApplicationWindow {
     readonly property bool fullscreen: mpvqcWindowVisibilityHandler.fullscreen
     readonly property int windowBorder: root.fullscreen || root.maximized ? 0 : 1
 
+    property color primaryColor: mpvqcSettings.primary
+    property color accentColor: mpvqcSettings.accent
+
     function focusCommentTable() {
         root.mpvqcCommentTable.forceActiveFocus()
     }
@@ -170,7 +173,11 @@ ApplicationWindow {
     }
 
     Material.theme: mpvqcSettings.theme
-    Material.accent: mpvqcSettings.primary
-    Material.primary: mpvqcSettings.primary
+    Material.accent: accentColor
+    Material.primary: primaryColor
+
+    Behavior on color { ColorAnimation { duration: 150 }}
+    Behavior on primaryColor { ColorAnimation { duration: 150 }}
+    Behavior on accentColor { ColorAnimation { duration: 150 }}
 
 }

--- a/qml/dialogs/appearance/MpvqcColorView.qml
+++ b/qml/dialogs/appearance/MpvqcColorView.qml
@@ -33,10 +33,12 @@ GridView {
     property int itemSize: 52
     property int itemPadding: 8
     property int borderSize: 12
-    property var initialColor: null
+    property color initialAccent: null
+    property color initialPrimary: null
 
     function reset(): void {
-        root.mpvqcSettings.primary = initialColor
+        root.mpvqcSettings.accent = initialAccent
+        root.mpvqcSettings.primary = initialPrimary
     }
 
     boundsBehavior: Flickable.StopAtBounds
@@ -47,13 +49,15 @@ GridView {
     cellHeight: itemSize + itemPadding
 
     delegate: MpvqcCircle {
-        required property int primary
+        required property color primary
+        required property color accent
         property bool selected: primary === root.mpvqcSettings.primary
 
         width: root.itemSize
         color: selected ? Material.foreground : 'transparent'
 
         function onItemClicked() {
+            root.mpvqcSettings.accent = accent
             root.mpvqcSettings.primary = primary
         }
 
@@ -63,8 +67,8 @@ GridView {
 
         MpvqcCircle {
             width: parent.width - root.borderSize
-            color: Material.primary
-            Material.primary: parent.primary
+            color: primary
+            Material.primary: primary
             anchors.centerIn: parent
 
             onClicked: {
@@ -74,7 +78,8 @@ GridView {
     }
 
     Component.onCompleted: {
-        root.initialColor = root.mpvqcSettings.primary
+        root.initialAccent = root.mpvqcSettings.accent
+        root.initialPrimary = root.mpvqcSettings.primary
     }
 
 }

--- a/qml/dialogs/appearance/tst_MpvqcColorView.qml
+++ b/qml/dialogs/appearance/tst_MpvqcColorView.qml
@@ -25,7 +25,7 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int initialColor: Material.Teal
+    readonly property color initialColor: "#009688"
 
     name: "MpvqcColorView"
     when: windowShown
@@ -40,11 +40,12 @@ TestCase {
             width: parent.width
             mpvqcApplication: QtObject {
                 property var mpvqcSettings: QtObject {
-                    property int primary: testCase.initialColor
+                    property color accent: "transparent"
+                    property color primary: testCase.initialColor
                 }
             }
 
-            function findSelected() {
+            function findSelected(): variant {
                 for (let idx = 0; idx < this.count; idx++) {
                     const item = this.itemAtIndex(idx)
                     if (item.selected) return item
@@ -52,7 +53,7 @@ TestCase {
                 return null
             }
 
-            function findItemWithColor(primary) {
+            function findItemWithColor(primary: color): variant {
                 for (let idx = 0; idx < this.count; idx++) {
                     const item = this.itemAtIndex(idx)
                     if (item.primary === primary) {
@@ -66,8 +67,8 @@ TestCase {
 
     function test_colorFromSettingsSelected_data() {
         return [
-            { tag: 'indigo', color: Material.Indigo },
-            { tag: 'amber', color: Material.Amber },
+            { tag: 'indigo', color: "#3f51b5" },
+            { tag: 'amber', color: "#ffc107" },
         ]
     }
 
@@ -85,8 +86,8 @@ TestCase {
 
     function test_click_data() {
         return [
-            { tag: 'cyan/teal', firstColor: Material.Cyan, secondColor: Material.Teal },
-            { tag: 'purple/lime', firstColor: Material.Purple, secondColor: Material.Lime },
+            { tag: 'cyan/teal', firstColor: "#00bcd4", secondColor: "#009688" },
+            { tag: 'purple/lime', firstColor: "#9c27b0", secondColor: "#cddc39" },
         ]
     }
 
@@ -113,10 +114,10 @@ TestCase {
 
         compare(control.mpvqcApplication.mpvqcSettings.primary, testCase.initialColor)
 
-        const selection = control.findItemWithColor(Material.Purple)
+        const selection = control.findItemWithColor("#673ab7")
         verify(selection)
         mouseClick(selection)
-        compare(control.mpvqcApplication.mpvqcSettings.primary, Material.Purple)
+        compare(control.mpvqcApplication.mpvqcSettings.primary, "#673ab7")
 
         control.reset()
         compare(control.mpvqcApplication.mpvqcSettings.primary, testCase.initialColor)

--- a/qml/models/MpvqcAccentColorModel.qml
+++ b/qml/models/MpvqcAccentColorModel.qml
@@ -23,60 +23,98 @@ import QtQuick.Controls.Material
 
 ListModel {
     ListElement {
-        primary: Material.Red
+        name: "Material.Red"
+        primary: "#F44336"
+        accent: "#EF9A9A"
     }
     ListElement {
-        primary: Material.Pink
+        name: "Material.Pink"
+        primary: "#E91E63"
+        accent: "#F48FB1"
     }
     ListElement {
-        primary: Material.Purple
+        name: "Material.Purple"
+        primary: "#9C27B0"
+        accent: "#CE93D8"
     }
     ListElement {
-        primary: Material.DeepPurple
+        name: "Material.DeepPurple"
+        primary: "#673AB7"
+        accent: "#B39DDB"
     }
     ListElement {
-        primary: Material.Indigo
+        name: "Material.Indigo"
+        primary: "#3F51B5"
+        accent: "#9FA8DA"
     }
     ListElement {
-        primary: Material.Blue
+        name: "Material.Blue"
+        primary: "#2196F3"
+        accent: "#90CAF9"
     }
     ListElement {
-        primary: Material.LightBlue
+        name: "Material.LightBlue"
+        primary: "#03A9F4"
+        accent: "#81D4FA"
     }
     ListElement {
-        primary: Material.Cyan
+        name: "Material.Cyan"
+        primary: "#00BCD4"
+        accent: "#80DEEA"
     }
     ListElement {
-        primary: Material.Teal
+        name: "Material.Teal"
+        primary: "#009688"
+        accent: "#80CBC4"
     }
     ListElement {
-        primary: Material.Green
+        name: "Material.Green"
+        primary: "#4CAF50"
+        accent: "#A5D6A7"
     }
     ListElement {
-        primary: Material.LightGreen
+        name: "Material.LightGreen"
+        primary: "#8BC34A"
+        accent: "#C5E1A5"
     }
     ListElement {
-        primary: Material.Lime
+        name: "Material.Lime"
+        primary: "#CDDC39"
+        accent: "#E6EE9C"
     }
     ListElement {
-        primary: Material.Yellow
+        name: "Material.Yellow"
+        primary: "#FFEB3B"
+        accent: "#FFF59D"
     }
     ListElement {
-        primary: Material.Amber
+        name: "Material.Amber"
+        primary: "#FFC107"
+        accent: "#FFE082"
     }
     ListElement {
-        primary: Material.Orange
+        name: "Material.Orange"
+        primary: "#FF9800"
+        accent: "#FFCC80"
     }
     ListElement {
-        primary: Material.DeepOrange
+        name: "Material.DeepOrange"
+        primary: "#FF5722"
+        accent: "#FFAB91"
     }
     ListElement {
-        primary: Material.Brown
+        name: "Material.Brown"
+        primary: "#795548"
+        accent: "#BCAAA4"
     }
     ListElement {
-        primary: Material.Grey
+        name: "Material.Grey"
+        primary: "#9E9E9E"
+        accent: "#EEEEEE"
     }
     ListElement {
-        primary: Material.BlueGrey
+        name: "Material.BlueGrey"
+        primary: "#607D8B"
+        accent: "#B0BEC5"
     }
 }

--- a/qml/models/MpvqcAccentColorModel.qml
+++ b/qml/models/MpvqcAccentColorModel.qml
@@ -18,102 +18,100 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import QtQuick
-import QtQuick.Controls.Material
-
 
 ListModel {
     ListElement {
-        name: "Material.Red"
+        // "Material.Red"
         primary: "#F44336"
         accent: "#EF9A9A"
     }
     ListElement {
-        name: "Material.Pink"
+        // "Material.Pink"
         primary: "#E91E63"
         accent: "#F48FB1"
     }
     ListElement {
-        name: "Material.Purple"
+        // "Material.Purple"
         primary: "#9C27B0"
         accent: "#CE93D8"
     }
     ListElement {
-        name: "Material.DeepPurple"
+        // "Material.DeepPurple"
         primary: "#673AB7"
         accent: "#B39DDB"
     }
     ListElement {
-        name: "Material.Indigo"
+        // "Material.Indigo"
         primary: "#3F51B5"
         accent: "#9FA8DA"
     }
     ListElement {
-        name: "Material.Blue"
+        // "Material.Blue"
         primary: "#2196F3"
         accent: "#90CAF9"
     }
     ListElement {
-        name: "Material.LightBlue"
+        // "Material.LightBlue"
         primary: "#03A9F4"
         accent: "#81D4FA"
     }
     ListElement {
-        name: "Material.Cyan"
+        // "Material.Cyan"
         primary: "#00BCD4"
         accent: "#80DEEA"
     }
     ListElement {
-        name: "Material.Teal"
+        // "Material.Teal"
         primary: "#009688"
         accent: "#80CBC4"
     }
     ListElement {
-        name: "Material.Green"
+        // "Material.Green"
         primary: "#4CAF50"
         accent: "#A5D6A7"
     }
     ListElement {
-        name: "Material.LightGreen"
+        // "Material.LightGreen"
         primary: "#8BC34A"
         accent: "#C5E1A5"
     }
     ListElement {
-        name: "Material.Lime"
+        // "Material.Lime"
         primary: "#CDDC39"
         accent: "#E6EE9C"
     }
     ListElement {
-        name: "Material.Yellow"
+        // "Material.Yellow"
         primary: "#FFEB3B"
         accent: "#FFF59D"
     }
     ListElement {
-        name: "Material.Amber"
+        // "Material.Amber"
         primary: "#FFC107"
         accent: "#FFE082"
     }
     ListElement {
-        name: "Material.Orange"
+        // "Material.Orange"
         primary: "#FF9800"
         accent: "#FFCC80"
     }
     ListElement {
-        name: "Material.DeepOrange"
+        // "Material.DeepOrange"
         primary: "#FF5722"
         accent: "#FFAB91"
     }
     ListElement {
-        name: "Material.Brown"
+        // "Material.Brown"
         primary: "#795548"
         accent: "#BCAAA4"
     }
     ListElement {
-        name: "Material.Grey"
+        // "Material.Grey"
         primary: "#9E9E9E"
         accent: "#EEEEEE"
     }
     ListElement {
-        name: "Material.BlueGrey"
+        // "Material.BlueGrey"
         primary: "#607D8B"
         accent: "#B0BEC5"
     }

--- a/qml/settings/MpvqcSettings.qml
+++ b/qml/settings/MpvqcSettings.qml
@@ -150,11 +150,16 @@ QtObject {
 
     readonly property Settings _themeSettings: Settings {
         property alias theme: root.theme
-        property alias accent: root.accent
-        property alias primary: root.primary
+        property string color: root.primary
+        property string colorLighter: root.accent
 
         category: 'Theme'
         location: root.settingsFile
+
+        Component.onCompleted: {
+            root.primary = color
+            root.accent = colorLighter
+        }
     }
 
     property int theme: Material.Dark

--- a/qml/settings/MpvqcSettings.qml
+++ b/qml/settings/MpvqcSettings.qml
@@ -121,9 +121,11 @@ Item {
         location: root.settingsFile
         category: 'Theme'
         property int theme: Material.Dark
-        property int primary: Material.Indigo
+        property color accent: "#9FA8DA"
+        property color primary: "#3F51B5"
     }
     property alias theme: _themeSettings.theme
+    property alias accent: _themeSettings.accent
     property alias primary: _themeSettings.primary
 
 

--- a/qml/settings/MpvqcSettings.qml
+++ b/qml/settings/MpvqcSettings.qml
@@ -157,8 +157,8 @@ QtObject {
         location: root.settingsFile
 
         Component.onCompleted: {
-            root.primary = color
-            root.accent = colorLighter
+            root.primary = color;
+            root.accent = colorLighter;
         }
     }
 

--- a/qml/settings/MpvqcSettings.qml
+++ b/qml/settings/MpvqcSettings.qml
@@ -23,8 +23,7 @@ import QtQuick.Controls.Material
 
 import models
 
-
-Item {
+QtObject {
     id: root
 
     required property var mpvqcApplication
@@ -33,120 +32,149 @@ Item {
     readonly property var settingsFile: mpvqcApplicationPathsPyObject.settings
     readonly property var mpvqcUtilityPyObject: mpvqcApplication.mpvqcUtilityPyObject
 
-    Settings {
-        id: _backupSettings
-        location: root.settingsFile
-        category: 'Backup'
-        property bool enabled: true
-        property int interval: 60
-    }
-    property alias backupEnabled: _backupSettings.enabled
-    property alias backupInterval: _backupSettings.interval
-
-
     readonly property MpvqcLanguageModel _languageModel: MpvqcLanguageModel {}
-    Settings {
-        id: _commonSettings
+
+    // Backup
+
+    readonly property Settings _backupSettings: Settings {
+        property alias enabled: root.backupEnabled
+        property alias interval: root.backupInterval
+
+        category: 'Backup'
         location: root.settingsFile
-        category: 'Common'
-        property string language: root._languageModel.systemLanguage
-        property list<string> commentTypes: root.getDefaultCommentTypes()
     }
-    property alias language: _commonSettings.language
-    property alias commentTypes: _commonSettings.commentTypes
+
+    property bool backupEnabled: true
+    property int backupInterval: 60
+
+    // Common
+
+    readonly property Settings _commonSettings: Settings {
+        property alias language: root.language
+        property alias commentTypes: root.commentTypes
+
+        category: 'Common'
+        location: root.settingsFile
+    }
+    property string language: _languageModel.systemLanguage
+    property list<string> commentTypes: root.getDefaultCommentTypes()
 
     function getDefaultCommentTypes(): list<string> {
-        return ['Translation', 'Spelling', 'Punctuation', 'Phrasing', 'Timing', 'Typeset', 'Note']
+        return ['Translation', 'Spelling', 'Punctuation', 'Phrasing', 'Timing', 'Typeset', 'Note'];
     }
 
+    readonly property list<string> forTranslationTool: [
+        qsTranslate('CommentTypes', 'Translation'),
+        qsTranslate('CommentTypes', 'Spelling'),
+        qsTranslate('CommentTypes', 'Punctuation'),
+        qsTranslate('CommentTypes', 'Phrasing'),
+        qsTranslate('CommentTypes', 'Timing'),
+        qsTranslate('CommentTypes', 'Typeset'),
+        qsTranslate('CommentTypes', 'Note'),
+    ]
 
-    Settings {
-        id: _exportSettings
-        location: root.settingsFile
+    // Export
+
+    readonly property Settings _exportSettings: Settings {
+        property alias nickname: root.nickname
+        property alias writeHeaderDate: root.writeHeaderDate
+        property alias writeHeaderGenerator: root.writeHeaderGenerator
+        property alias writeHeaderNickname: root.writeHeaderNickname
+        property alias writeHeaderVideoPath: root.writeHeaderVideoPath
+
         category: 'Export'
-        property string nickname: root.mpvqcUtilityPyObject.getEnviornmentVariable('USERNAME')
-            || root.mpvqcUtilityPyObject.getEnviornmentVariable('USER')
-            || 'nickname'
-        property bool writeHeaderDate: true
-        property bool writeHeaderGenerator: true
-        property bool writeHeaderNickname: false
-        property bool writeHeaderVideoPath: true
-    }
-    property alias nickname: _exportSettings.nickname
-    property alias writeHeaderDate: _exportSettings.writeHeaderDate
-    property alias writeHeaderGenerator: _exportSettings.writeHeaderGenerator
-    property alias writeHeaderNickname: _exportSettings.writeHeaderNickname
-    property alias writeHeaderVideoPath: _exportSettings.writeHeaderVideoPath
-
-
-    enum TimeFormat { EMPTY, CURRENT_TIME, REMAINING_TIME, CURRENT_TOTAL_TIME }
-    Settings {
-        id: _statusBarSettings
         location: root.settingsFile
+    }
+
+    property string nickname: root.mpvqcUtilityPyObject.getEnviornmentVariable('USERNAME') || root.mpvqcUtilityPyObject.getEnviornmentVariable('USER') || 'nickname'
+    property bool writeHeaderDate: true
+    property bool writeHeaderGenerator: true
+    property bool writeHeaderNickname: false
+    property bool writeHeaderVideoPath: true
+
+    // Statusbar
+
+    enum TimeFormat {
+        EMPTY,
+        CURRENT_TIME,
+        REMAINING_TIME,
+        CURRENT_TOTAL_TIME
+    }
+
+    readonly property Settings _statusBarSettings: Settings {
+        property alias statusbarPercentage: root.statusbarPercentage
+        property alias timeFormat: root.timeFormat
+
         category: 'StatusBar'
-        property bool statusbarPercentage: true
-        property int timeFormat: MpvqcSettings.TimeFormat.CURRENT_TOTAL_TIME
-    }
-    property alias statusbarPercentage: _statusBarSettings.statusbarPercentage
-    property alias timeFormat: _statusBarSettings.timeFormat
-
-
-    enum ImportWhenVideoLinkedInDocument { ALWAYS, ASK_EVERY_TIME, NEVER }
-    Settings {
-        id: _importSettings
         location: root.settingsFile
+    }
+
+    property bool statusbarPercentage: true
+    property int timeFormat: MpvqcSettings.TimeFormat.CURRENT_TOTAL_TIME
+
+    // Import
+
+    enum ImportWhenVideoLinkedInDocument {
+        ALWAYS,
+        ASK_EVERY_TIME,
+        NEVER
+    }
+
+    readonly property Settings _importSettings: Settings {
+        property alias lastDirectoryVideo: root.lastDirectoryVideo
+        property alias lastDirectoryDocuments: root.lastDirectoryDocuments
+        property alias lastDirectorySubtitles: root.lastDirectorySubtitles
+        property alias importWhenVideoLinkedInDocument: root.importWhenVideoLinkedInDocument
+
         category: 'Import'
-        property var lastDirectoryVideo: StandardPaths.writableLocation(StandardPaths.MoviesLocation)
-        property var lastDirectoryDocuments: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
-        property var lastDirectorySubtitles: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
-        property var importWhenVideoLinkedInDocument: MpvqcSettings.ImportWhenVideoLinkedInDocument.ASK_EVERY_TIME
-    }
-    property alias importWhenVideoLinkedInDocument: _importSettings.importWhenVideoLinkedInDocument
-    property alias lastDirectoryVideo: _importSettings.lastDirectoryVideo
-    property alias lastDirectoryDocuments: _importSettings.lastDirectoryDocuments
-    property alias lastDirectorySubtitles: _importSettings.lastDirectorySubtitles
-
-
-    Settings {
-        id: _splitViewSettings
         location: root.settingsFile
+    }
+
+    property string lastDirectoryVideo: StandardPaths.writableLocation(StandardPaths.MoviesLocation)
+    property string lastDirectoryDocuments: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+    property string lastDirectorySubtitles: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+    property int importWhenVideoLinkedInDocument: MpvqcSettings.ImportWhenVideoLinkedInDocument.ASK_EVERY_TIME
+
+    // Splitview
+
+    readonly property Settings _splitViewSettings: Settings {
+        property alias layoutOrientation: root.layoutOrientation
+
         category: 'SplitView'
-        property int layoutOrientation: Qt.Vertical
-    }
-    property alias layoutOrientation: _splitViewSettings.layoutOrientation
-
-
-    Settings {
-        id: _themeSettings
         location: root.settingsFile
+    }
+
+    property int layoutOrientation: Qt.Vertical
+
+    // Theme
+
+    readonly property Settings _themeSettings: Settings {
+        property alias theme: root.theme
+        property alias accent: root.accent
+        property alias primary: root.primary
+
         category: 'Theme'
-        property int theme: Material.Dark
-        property color accent: "#9FA8DA"
-        property color primary: "#3F51B5"
-    }
-    property alias theme: _themeSettings.theme
-    property alias accent: _themeSettings.accent
-    property alias primary: _themeSettings.primary
-
-
-    enum WindowTitleFormat { DEFAULT, FILE_NAME, FILE_PATH }
-    Settings {
-        id: _windowSettings
         location: root.settingsFile
-        category: 'Window'
-        property int titleFormat: MpvqcSettings.WindowTitleFormat.DEFAULT
     }
-    property alias windowTitleFormat: _windowSettings.titleFormat
 
-    QtObject {
-        readonly property list<string> forTranslationTool: [
-            qsTranslate('CommentTypes', 'Translation'),
-            qsTranslate('CommentTypes', 'Spelling'),
-            qsTranslate('CommentTypes', 'Punctuation'),
-            qsTranslate('CommentTypes', 'Phrasing'),
-            qsTranslate('CommentTypes', 'Timing'),
-            qsTranslate('CommentTypes', 'Typeset'),
-            qsTranslate('CommentTypes', 'Note'),
-        ]
+    property int theme: Material.Dark
+    property color accent: "#9FA8DA"
+    property color primary: "#3F51B5"
+
+    // Window Title
+
+    enum WindowTitleFormat {
+        DEFAULT,
+        FILE_NAME,
+        FILE_PATH
     }
+
+    readonly property Settings _windowSettings: Settings {
+        property alias titleFormat: root.windowTitleFormat
+
+        category: 'Window'
+        location: root.settingsFile
+    }
+
+    property int windowTitleFormat: MpvqcSettings.WindowTitleFormat.DEFAULT
 }

--- a/qml/shared/MpvqcMenu.qml
+++ b/qml/shared/MpvqcMenu.qml
@@ -24,8 +24,7 @@ import QtQuick.Controls
 Menu {
     id: root
 
-    property real additionalPadding
-    property bool mMirrored: root.count > 0 && itemAt(0).mirrored
+    readonly property bool mMirrored: root.count > 0 && itemAt(0).mirrored
 
     z: 2
     x: mMirrored ? -width + parent.width : 0


### PR DESCRIPTION
Previously, we used Qt's Material colors:
https://doc.qt.io/qt-6/qtquickcontrols-material.html#pre-defined-material-colors

Now, colors are stored as hex codes in `settings.ini`, allowing
custom color configurations via the settings file. In the future,
UI-based color selection may be supported.

Additionally, color changes are now animated.