### PR TITLE
feat: hide 'check for update' on Linux

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,8 @@
+# Configuring mpvQC
+
+mpvQC can be configured using the following environment variables:
+
+| **Name**                     | **Default Value** | **Operating System** | **Description**                                                                                                                                                                        |
+| ---------------------------- | ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MPVQC_DEBUG`                | _No default_      | All                  | Enables debug mode, intended primarily for developers and testing.                                                                                                                     |
+| `MPVQC_VIDEO_SCALING_FACTOR` | `1.0`             | Linux                | Specifies the desktop scaling factor. Because Linux does not provide a universal method to retrieve fractional scaling from the desktop environment, Linux users must set it manually. |

--- a/qml/header/MpvqcMenuHelp.qml
+++ b/qml/header/MpvqcMenuHelp.qml
@@ -22,18 +22,23 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Controls
 
-import dialogs
-import shared
+import "../dialogs"
+import "../shared"
 
 MpvqcMenu {
     id: root
 
     required property var mpvqcApplication
 
+    readonly property var mpvqcUtilityPyObject: mpvqcApplication.mpvqcUtilityPyObject
+
     readonly property alias updateAction: _updateAction
     readonly property alias shortcutAction: _shortcutAction
     readonly property alias extendedExportsAction: _extendedExportsAction
     readonly property alias aboutAction: _aboutAction
+
+    readonly property bool isMpvqcDebugEnabled: mpvqcUtilityPyObject.getEnvironmentVariable("MPVQC_DEBUG")
+    readonly property bool isUpdateMenuItemEnabled: Qt.platform.os === "windows" || isMpvqcDebugEnabled
 
     readonly property var factoryMessageBoxVersionCheck: Component {
         MpvqcMessageBoxVersionCheck {
@@ -61,16 +66,21 @@ MpvqcMenu {
 
     title: qsTranslate("MainWindow", "Help")
 
-    Action {
-        id: _updateAction
+    MenuItem {
 
         text: qsTranslate("MainWindow", "Check for Updates...")
         icon.source: "qrc:/data/icons/update_black_24dp.svg"
+        visible: root.isUpdateMenuItemEnabled
+        height: visible ? implicitHeight : 0
 
-        onTriggered: {
-            const dialog = root.factoryMessageBoxVersionCheck.createObject(root);
-            dialog.closed.connect(dialog.destroy);
-            dialog.open();
+        action: Action {
+            id: _updateAction
+
+            onTriggered: {
+                const dialog = root.factoryMessageBoxVersionCheck.createObject(root);
+                dialog.closed.connect(dialog.destroy);
+                dialog.open();
+            }
         }
     }
 

--- a/qml/header/tst_MpvqcMenuHelp.qml
+++ b/qml/header/tst_MpvqcMenuHelp.qml
@@ -86,6 +86,9 @@ TestCase {
                     property string mpv_version: "any-version"
                     property string ffmpeg_version: "any-version"
                 }
+                property var mpvqcUtilityPyObject: QtObject {
+                    function getEnvironmentVariable(name: string): string { return "some-value" }
+                }
             }
         }
     }


### PR DESCRIPTION
On Linux, users receive updates automatically over the app store. There's no need to include a Windows-like update check in the help menu.

The menu action can still be accessed by setting 'MPVQC_DEBUG' on Linux. This is solely for testing and debugging the application.