### PR TITLE
fix: use translate noop if possible

### DIFF
--- a/qml/models/MpvqcLanguageModel.qml
+++ b/qml/models/MpvqcLanguageModel.qml
@@ -20,14 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import QtQuick
 
 ListModel {
-    readonly property var languagesForTranslationTool: [
-        qsTranslate("Languages", "English"),
-        qsTranslate("Languages", "German"),
-        qsTranslate("Languages", "Hebrew"),
-        qsTranslate("Languages", "Italian"),
-        qsTranslate("Languages", "Spanish"),
-    ]
-
     readonly property string systemLanguage: {
         const uiLanguages = Qt.locale().uiLanguages;
         return _identifiers().find(language => uiLanguages.includes(language)) ?? "en-US";
@@ -42,25 +34,25 @@ ListModel {
     }
 
     ListElement {
-        language: "German"
+        language: QT_TRANSLATE_NOOP("Languages", "German")
         identifier: "de-DE"
     }
     ListElement {
-        language: "English"
+        language: QT_TRANSLATE_NOOP("Languages", "English")
         identifier: "en-US"
     }
     ListElement {
-        language: "Spanish"
+        language: QT_TRANSLATE_NOOP("Languages", "Spanish")
         identifier: "es-ES"
         translator: "RcUchiha"
     }
     ListElement {
-        language: "Hebrew"
+        language: QT_TRANSLATE_NOOP("Languages", "Hebrew")
         identifier: "he-IL"
         translator: "cN3rd"
     }
     ListElement {
-        language: "Italian"
+        language: QT_TRANSLATE_NOOP("Languages", "Italian")
         identifier: "it-IT"
         translator: "maddo"
     }

--- a/qml/settings/MpvqcSettings.qml
+++ b/qml/settings/MpvqcSettings.qml
@@ -59,18 +59,16 @@ QtObject {
     property list<string> commentTypes: root.getDefaultCommentTypes()
 
     function getDefaultCommentTypes(): list<string> {
-        return ["Translation", "Spelling", "Punctuation", "Phrasing", "Timing", "Typeset", "Note"];
+        return [
+            QT_TRANSLATE_NOOP("CommentTypes", "Translation"),
+            QT_TRANSLATE_NOOP("CommentTypes", "Spelling"),
+            QT_TRANSLATE_NOOP("CommentTypes", "Punctuation"),
+            QT_TRANSLATE_NOOP("CommentTypes", "Phrasing"),
+            QT_TRANSLATE_NOOP("CommentTypes", "Timing"),
+            QT_TRANSLATE_NOOP("CommentTypes", "Typeset"),
+            QT_TRANSLATE_NOOP("CommentTypes", "Note"),
+        ]
     }
-
-    readonly property list<string> forTranslationTool: [
-        qsTranslate("CommentTypes", "Translation"),
-        qsTranslate("CommentTypes", "Spelling"),
-        qsTranslate("CommentTypes", "Punctuation"),
-        qsTranslate("CommentTypes", "Phrasing"),
-        qsTranslate("CommentTypes", "Timing"),
-        qsTranslate("CommentTypes", "Typeset"),
-        qsTranslate("CommentTypes", "Note"),
-    ]
 
     // Export
 


### PR DESCRIPTION
Apparently, there exists a method that can mark strings for translation
but does not replace them in the code. This allows us to remove 
dead code.