### PR TITLE
fix(windows): improve Windows integration with different flags

### DIFF
--- a/mpvqc/services/frameless/service.py
+++ b/mpvqc/services/frameless/service.py
@@ -46,10 +46,11 @@ class FramelessWindowService:
 
             app.installNativeEventFilter(self._event_filter)
 
-            from .win import configure_gwl_style, extend_frame_into_client_area
+            from .win import configure_gwl_style, extend_frame_into_client_area, set_outer_window_size
 
             extend_frame_into_client_area(hwnd_top_lvl)
             configure_gwl_style(hwnd_top_lvl)
+            set_outer_window_size(hwnd_top_lvl, 1280, 720)
 
         if sys.platform == "win32":
             configure_for_windows()

--- a/mpvqc/services/frameless/win/__init__.py
+++ b/mpvqc/services/frameless/win/__init__.py
@@ -18,4 +18,4 @@
 
 # ruff: noqa: F401
 from .event import WindowsEventFilter
-from .utils import configure_gwl_style, extend_frame_into_client_area
+from .utils import configure_gwl_style, extend_frame_into_client_area, set_outer_window_size

--- a/mpvqc/services/frameless/win/utils.py
+++ b/mpvqc/services/frameless/win/utils.py
@@ -38,6 +38,16 @@ def get_window_size(hwnd) -> tuple[int, int, int, int]:
     return left, top, width, height
 
 
+def set_outer_window_size(hwnd, w, h):
+    """Hard-set the OUTER size (frame included)."""
+    SWP_NOMOVE = 0x0002
+    SWP_NOZORDER = 0x0004
+    SWP_NOACTIVATE = 0x0010
+
+    user32 = windll.user32
+    user32.SetWindowPos(hwnd, None, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE)
+
+
 def is_maximized(hwnd):
     window_placement = win32gui.GetWindowPlacement(hwnd)
     if not window_placement:

--- a/qml/app/MpvqcApplication.qml
+++ b/qml/app/MpvqcApplication.qml
@@ -60,6 +60,11 @@ ApplicationWindow {
     readonly property bool fullscreen: _windowVisibilityHandler.fullscreen
     readonly property int windowBorder: root.fullscreen || root.maximized ? 0 : 1
 
+    readonly property var windowsFlags: Qt.CustomizeWindowHint | Qt.Window
+    readonly property var linuxFlags: Qt.FramelessWindowHint | Qt.Window
+
+    flags: Qt.platform.os === "windows" ? windowsFlags : linuxFlags
+
     width: 1280
     height: 720
 
@@ -71,7 +76,6 @@ ApplicationWindow {
         family: 'Noto Sans'
     }
 
-    flags: Qt.FramelessWindowHint | Qt.Window
     color: Material.background
     visible: true
 


### PR DESCRIPTION
Replaced Qt.FramelessWindowHint | Qt.Window with
Qt.CustomizeWindowHint | Qt.Window and explicitly set the size. This makes the window behave more like a native Windows window.