### PR TITLE
fix(comments): improve batch operation performance and view refresh

### DIFF
--- a/mpvqc/models/comments/model.py
+++ b/mpvqc/models/comments/model.py
@@ -118,10 +118,12 @@ class MpvqcCommentModel(QStandardItemModel):
             return
 
         def on_after_undo(row: int):
+            self.layoutChanged.emit()
             self.searchInvalidated.emit()
             self.commentsImportedUndone.emit(row)
 
         def on_after_redo(index: QModelIndex, added_initially: bool):
+            self.layoutChanged.emit()
             self.searchInvalidated.emit()
             self.sort(0)
 
@@ -140,10 +142,12 @@ class MpvqcCommentModel(QStandardItemModel):
 
     def clear_comments(self) -> None:
         def on_after_undo():
+            self.layoutChanged.emit()
             self.searchInvalidated.emit()
             self.commentsClearedUndone.emit()
 
         def on_after_redo():
+            self.layoutChanged.emit()
             self.searchInvalidated.emit()
             self.commentsCleared.emit()
 

--- a/mpvqc/models/comments/undo.py
+++ b/mpvqc/models/comments/undo.py
@@ -80,7 +80,7 @@ class ClearComments(QUndoCommand):
 
     def redo(self):
         self._comments = retrieve_comments_from(self._model)
-        self._model.clear()
+        self._model.removeRows(0, self._model.rowCount())
         self._on_after_redo()
 
 


### PR DESCRIPTION
- Replace clear() with removeRows() in ClearComments to reduce signal overhead when clearing large datasets
- Emit layoutChanged after import/clear to force QML ListView delegate refresh and prevent empty space after undo operations