### PR TITLE
fix(ui): prevent edit popup from growing off-screen

### DIFF
--- a/qt/qml/views/table/MpvqcCommentList.qml
+++ b/qt/qml/views/table/MpvqcCommentList.qml
@@ -37,7 +37,7 @@ ListView {
 
     highlightMoveDuration: 50
     highlightMoveVelocity: -1
-    highlightResizeDuration: 50
+    highlightResizeDuration: isCurrentlyEditing ? 0 : 50
     highlightResizeVelocity: -1
 
     highlight: Rectangle {
@@ -134,10 +134,29 @@ ListView {
         id: _editLoader
 
         viewModel: root.viewModel
-        onCommentEditPopupHeightChanged: {
-            Qt.callLater(() => {
-                root.positionViewAtIndex(root.currentIndex, ListView.Contain);
-            });
+
+        function _shouldScrollToAccommodateGrowth(heightDelta: int): bool {
+            if (heightDelta <= 0) {
+                return false;
+            }
+
+            const currentItem = root.currentItem;
+            if (!currentItem) {
+                return false;
+            }
+
+            const itemY = currentItem.y - root.contentY;
+            const itemBottom = itemY + currentItem.height;
+            const newItemBottom = itemBottom + heightDelta;
+
+            // Only scroll if the new bottom would overflow the viewport
+            return newItemBottom > root.height;
+        }
+
+        onCommentEditPopupHeightChanged: heightDelta => {
+            if (_shouldScrollToAccommodateGrowth(heightDelta)) {
+                root.contentY += heightDelta;
+            }
         }
     }
 

--- a/qt/qml/views/table/MpvqcEditCommentPopup.qml
+++ b/qt/qml/views/table/MpvqcEditCommentPopup.qml
@@ -15,10 +15,11 @@ Popup {
 
     readonly property bool isOdd: currentListIndex % 2 === 1
 
+    property int previousHeight: 0
     property bool acceptValue: true
 
     signal commentEdited(index: int, newComment: string)
-    signal commentEditPopupHeightChanged
+    signal commentEditPopupHeightChanged(heightDelta: int)
 
     width: root.parent.width
 
@@ -85,7 +86,12 @@ Popup {
     }
 
     onHeightChanged: {
-        root.commentEditPopupHeightChanged();
+        const heightDelta = root.height - root.previousHeight;
+        if (root.previousHeight > 0) {
+            // Skip first change (initialization)
+            root.commentEditPopupHeightChanged(heightDelta);
+        }
+        root.previousHeight = root.height;
     }
 
     Shortcut {

--- a/qt/qml/views/table/MpvqcEditLoader.qml
+++ b/qt/qml/views/table/MpvqcEditLoader.qml
@@ -15,7 +15,7 @@ Loader {
 
     readonly property bool isEditingComment: source === editCommentPopup
 
-    signal commentEditPopupHeightChanged
+    signal commentEditPopupHeightChanged(heightDelta: int)
 
     function _startEditingTime(index: int, time: int, coordinates: point): void {
         asynchronous = true;
@@ -90,8 +90,8 @@ Loader {
             root.viewModel.updateComment(index, newComment);
         }
 
-        function onCommentEditPopupHeightChanged(): void {
-            root.commentEditPopupHeightChanged();
+        function onCommentEditPopupHeightChanged(heightDelta: int): void {
+            root.commentEditPopupHeightChanged(heightDelta);
         }
 
         function onClosed(): void {


### PR DESCRIPTION
Automatically scroll the comment list when editing near the bottom and the popup expands beyond the viewport. Only triggers when growth would push content off-screen.