### PR TITLE
perf: optimize Linux event filter for mouse moves

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -103,8 +103,8 @@ test-qml SKIP_PREPARATION='false':
 
 # Lint Python files (type checker only)
 [group('lint')]
-@lint-python:
-    uvx pyrefly@0.39.4 check --ignore missing-attribute
+@lint-python *ARGS:
+    uvx pyrefly@0.39.4 check --ignore missing-attribute {{ ARGS }}
 
 # Lint QML files
 [group('lint')]

--- a/mpvqc/services/frameless/linux/event.py
+++ b/mpvqc/services/frameless/linux/event.py
@@ -9,8 +9,15 @@
 #  - https://gitee.com/Virace/pyside6-qml-frameless-window/tree/main
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from PySide6.QtCore import QEvent, QObject, Qt
-from PySide6.QtGui import QCursor, QGuiApplication, QWindow
+from PySide6.QtGui import QCursor
+
+if TYPE_CHECKING:
+    from PySide6.QtGui import QGuiApplication, QWindow
 
 
 class LinuxEventFilter(QObject):
@@ -21,49 +28,78 @@ class LinuxEventFilter(QObject):
         self._cursor_override_active = False
         self._border_width = 6
 
-    def eventFilter(self, obj, event):
-        if event.type() != QEvent.Type.MouseButtonPress and event.type() != QEvent.Type.MouseMove:
+    def eventFilter(self, _watched: QObject, event: QEvent) -> bool:  # noqa: C901, PLR0912, PLR0915
+        event_type = event.type()
+
+        if event_type != QEvent.Type.MouseButtonPress and event_type != QEvent.Type.MouseMove:  # noqa: PLR1714
             return False
 
-        pos = QCursor.pos() - self._window.position()
-        edges = Qt.Edge(0)
-        if pos.x() < self._border_width:
-            edges |= Qt.Edge.LeftEdge
-        if pos.x() >= self._window.width() - self._border_width:
-            edges |= Qt.Edge.RightEdge
-        if pos.y() < self._border_width:
-            edges |= Qt.Edge.TopEdge
-        if pos.y() >= self._window.height() - self._border_width:
-            edges |= Qt.Edge.BottomEdge
+        is_normal_window_state = self._window.windowState() == Qt.WindowState.WindowNoState
 
-        no_window_state = self._window.windowState() == Qt.WindowState.WindowNoState
-
-        if event.type() == QEvent.Type.MouseMove and no_window_state:
-            self._update_cursor_for_edges(edges)
-
-        if event.type() == QEvent.Type.MouseButtonPress and no_window_state and edges:
-            self._window.startSystemResize(edges)
-            return True
-
-        return super().eventFilter(obj, event)
-
-    def _update_cursor_for_edges(self, edges: Qt.Edge) -> None:
-        cursor_shape = None
-        if edges in {Qt.Edge.LeftEdge | Qt.Edge.TopEdge, Qt.Edge.RightEdge | Qt.Edge.BottomEdge}:
-            cursor_shape = Qt.CursorShape.SizeFDiagCursor
-        elif edges in {Qt.Edge.RightEdge | Qt.Edge.TopEdge, Qt.Edge.LeftEdge | Qt.Edge.BottomEdge}:
-            cursor_shape = Qt.CursorShape.SizeBDiagCursor
-        elif edges in {Qt.Edge.TopEdge, Qt.Edge.BottomEdge}:
-            cursor_shape = Qt.CursorShape.SizeVerCursor
-        elif edges in {Qt.Edge.LeftEdge, Qt.Edge.RightEdge}:
-            cursor_shape = Qt.CursorShape.SizeHorCursor
-
-        if cursor_shape:
-            if self._cursor_override_active:
+        if not is_normal_window_state:
+            if event_type == QEvent.Type.MouseMove and self._cursor_override_active:
                 self._app.restoreOverrideCursor()
-            self._app.setOverrideCursor(cursor_shape)
-            self._cursor_override_active = True
+                self._cursor_override_active = False
+            return False
 
-        elif self._cursor_override_active:
-            self._app.restoreOverrideCursor()
-            self._cursor_override_active = False
+        cursor_pos = QCursor.pos()
+        window_pos = self._window.position()
+        x = cursor_pos.x() - window_pos.x()
+        y = cursor_pos.y() - window_pos.y()
+
+        window_width = self._window.width()
+        window_height = self._window.height()
+        border_width = self._border_width
+
+        is_cursor_in_interior = (
+            border_width <= x < window_width - border_width and border_width <= y < window_height - border_width
+        )
+
+        if is_cursor_in_interior:
+            if event_type == QEvent.Type.MouseMove and self._cursor_override_active:
+                self._app.restoreOverrideCursor()
+                self._cursor_override_active = False
+            return False
+
+        left = x < border_width
+        right = x >= window_width - border_width
+        top = y < border_width
+        bottom = y >= window_height - border_width
+
+        if event_type == QEvent.Type.MouseMove:
+            match (top, bottom, left, right):
+                case (True, _, True, _) | (_, True, _, True):
+                    cursor_shape = Qt.CursorShape.SizeFDiagCursor
+                case (True, _, _, True) | (_, True, True, _):
+                    cursor_shape = Qt.CursorShape.SizeBDiagCursor
+                case (True, _, _, _) | (_, True, _, _):
+                    cursor_shape = Qt.CursorShape.SizeVerCursor
+                case (_, _, True, _) | (_, _, _, True):
+                    cursor_shape = Qt.CursorShape.SizeHorCursor
+                case _:
+                    cursor_shape = None
+
+            if cursor_shape:
+                if self._cursor_override_active:
+                    self._app.restoreOverrideCursor()
+                self._app.setOverrideCursor(cursor_shape)
+                self._cursor_override_active = True
+            elif self._cursor_override_active:
+                self._app.restoreOverrideCursor()
+                self._cursor_override_active = False
+        else:  # MouseButtonPress
+            edges = Qt.Edge(0)
+            if left:
+                edges |= Qt.Edge.LeftEdge
+            if right:
+                edges |= Qt.Edge.RightEdge
+            if top:
+                edges |= Qt.Edge.TopEdge
+            if bottom:
+                edges |= Qt.Edge.BottomEdge
+
+            if edges:
+                self._window.startSystemResize(edges)
+                return True
+
+        return False


### PR DESCRIPTION
Add early exit for cursor in window interior, avoiding unnecessary edge detection for ~95% of mouse events.