### PR TITLE
ci: sort qml imports with a prek hook

### DIFF
--- a/.config/prek.toml
+++ b/.config/prek.toml
@@ -98,6 +98,17 @@ hooks = [
 ]
 
 [[repos]]
+repo = "https://github.com/trin94/qml-import-sort"
+rev = "v0.4.0"
+hooks = [
+    {
+        id = "qml-import-sort",
+        name = "sort qml imports",
+        args = ["--group", "io.github.mpvqc.,MpvqcStyle"],
+    },
+]
+
+[[repos]]
 repo = "https://github.com/tomas-krupa/qmlformat-hook.git"
 rev = "1.2.0"
 hooks = [

--- a/qt/qml/MpvqcStyle/Button.qml
+++ b/qt/qml/MpvqcStyle/Button.qml
@@ -6,10 +6,10 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Templates as T
-import QtQuick.Controls.impl
 import QtQuick.Controls.Material
 import QtQuick.Controls.Material.impl
+import QtQuick.Controls.impl
+import QtQuick.Templates as T
 
 import io.github.mpvqc.mpvQC.Utility
 

--- a/qt/qml/MpvqcStyle/DialogButtonBox.qml
+++ b/qt/qml/MpvqcStyle/DialogButtonBox.qml
@@ -4,9 +4,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Templates as T
-import QtQuick.Controls.impl as Impl
 import QtQuick.Controls.Material as M
+import QtQuick.Controls.impl as Impl
+import QtQuick.Templates as T
 
 T.DialogButtonBox {
     id: control

--- a/qt/qml/MpvqcStyle/ToolButton.qml
+++ b/qt/qml/MpvqcStyle/ToolButton.qml
@@ -4,10 +4,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Templates as T
-import QtQuick.Controls.impl
 import QtQuick.Controls.Material
 import QtQuick.Controls.Material.impl
+import QtQuick.Controls.impl
+import QtQuick.Templates as T
 
 import io.github.mpvqc.mpvQC.Utility
 


### PR DESCRIPTION
Keeping import order consistent by hand is easy to get wrong and noisy in review. Let the hook take care of it, with the project's own modules grouped separately. The QML changes are just the hook's first pass over the existing files.