### PR TITLE
perf: load Qt resources from a binary rcc file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,7 @@ jobs:
             --include-data-files=.venv/Lib/site-packages/PySide6/translations/qtbase_pt_BR.qm=PySide6/translations/ \
             --include-data-files=LICENSES/*.txt=LICENSES/ \
             --include-data-files=NOTICE.txt=NOTICE.txt \
+            --include-data-files=project.rcc=project.rcc \
             --include-qt-plugins=qml,platforms \
             --include-windows-runtime-dlls=yes \
             --mode=onefile \

--- a/.gitignore
+++ b/.gitignore
@@ -548,6 +548,7 @@ $RECYCLE.BIN/
 /test.sh
 
 rc_project.py
+project.rcc
 
 # Share the PyCharm inspection profiles
 !.idea/

--- a/Justfile
+++ b/Justfile
@@ -80,12 +80,13 @@ set-build-info:
     mkdir -p build/release
     cp -r mpvqc build/release
     cp main.py build/release
-    cp rc_project.py build/release
+    cp project.rcc build/release
 
 # Build and compile resources into source directory
 [group('build')]
 @build-develop: _update_pyproject_file
     uv run pyside6-project build
+    uv run pyside6-rcc --binary project.qrc -o project.rcc
     grep -qxF 'depends QtQml.Models' io/github/mpvqc/mpvQC/Python/qmldir || echo 'depends QtQml.Models' >> io/github/mpvqc/mpvQC/Python/qmldir
 
 # Remove ALL generated files
@@ -93,7 +94,7 @@ set-build-info:
 @clean:
     find i18n -name "*.qm" -type f -delete
     find qt/qml -name "*.qmlc" -type f -delete
-    rm -rf build io test/rc_project.py testqml/rc_project.py rc_project.py project.json project.qrc
+    rm -rf build io test/project.rcc testqml/project.rcc project.rcc test/rc_project.py testqml/rc_project.py rc_project.py project.json project.qrc
 
 # Build release artifact (⚠️ modifies working tree)
 [group('ci')]
@@ -120,8 +121,8 @@ build-release:
 [group('test')]
 prepare-tests: build-develop
     rm -f test/rc_project.py testqml/rc_project.py
-    cp rc_project.py test/rc_project.py
-    cp rc_project.py testqml/rc_project.py
+    cp project.rcc test/project.rcc
+    cp project.rcc testqml/project.rcc
 
 # Run Python and QML tests
 [group('test')]
@@ -158,8 +159,8 @@ test-qml-debug TARGET:
 
 @_prepare-tests: build-develop
     rm -f test/rc_project.py testqml/rc_project.py
-    cp rc_project.py test/rc_project.py
-    cp rc_project.py testqml/rc_project.py
+    cp project.rcc test/project.rcc
+    cp project.rcc testqml/project.rcc
 
 @_update_pyproject_file: _generate-qrc-file
     uv run python build-aux/update_pyproject_file.py \
@@ -169,8 +170,7 @@ test-qml-debug TARGET:
         --include-directory mpvqc \
         --include-directory testqml \
         --include-directory i18n \
-        --include-file main.py \
-        --include-file project.qrc
+        --include-file main.py
 
 _generate-qrc-file:
     #!/usr/bin/env bash

--- a/build-aux/update_pyproject_file.py
+++ b/build-aux/update_pyproject_file.py
@@ -42,7 +42,7 @@ class ArgumentValidator:
 
 class ProjectFileUpdater:
     _FILENAME = "pyproject.toml"
-    _EXTENSIONS_IGNORED = frozenset({".pyc", ".qm"})
+    _EXTENSIONS_IGNORED = frozenset({".pyc", ".qm", ".rcc"})
     _NAMES_IGNORED = frozenset({"rc_project.py"})
 
     def __init__(self, root_dir: Path) -> None:

--- a/docs/adr/0001-ship-resources-as-binary-rcc.md
+++ b/docs/adr/0001-ship-resources-as-binary-rcc.md
@@ -1,0 +1,22 @@
+<!--
+SPDX-FileCopyrightText: mpvQC developers
+
+SPDX-License-Identifier: MIT
+-->
+
+# Ship Qt resources as a binary .rcc bundle
+
+The standard `pyside6-project` flow compiles `project.qrc` into a generated Python module (`rc_project.py`, ~8.4 MB)
+that the application imports at startup. Parsing that module cost ~100 ms per launch, paid in full on read-only
+deployments such as Flatpak, where bytecode caches are absent. We compile the same `project.qrc` with
+`pyside6-rcc --binary` into `project.rcc` (~2.9 MB) instead and register it at startup with
+`QResource.registerResource()`, which costs almost nothing.
+
+## Consequences
+
+- Registration must run before the first `qrc:/` read. `perform_startup()` reads `:/data/build-info.toml`, so
+  registering resources is the first thing `main()` does after path setup.
+- Every packaging path must place `project.rcc` next to `main.py`: the `build` recipe in the `Justfile`, the Nuitka
+  `--include-data-files` flag in `release.yml`, and the install line in the Flatpak manifest (`mpvQC-flatpak` repo).
+- The test harnesses register staged copies (`test/project.rcc`, `testqml/project.rcc`) instead of importing a staged
+  module.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,12 +113,13 @@ shape that fits its scope.
 
 ## Build & resources
 
-QML, icons, fonts, default configs, and translations are bundled into a single Python file via Qt's resource compiler:
+QML, icons, fonts, default configs, and translations are bundled into a single binary file via Qt's resource compiler:
 
-- `just build-develop` runs Qt's resource compiler to produce a generated Python module (`rc_project.py`) at the repo
-  root that bundles every asset behind `qrc:/...` URLs. The application imports this module on startup. The file is
-  gitignored. It is a build artifact and can be regenerated from sources.
-- `just prepare-tests` rebuilds the bundle and stages it for the test harnesses, so they can import it the same way the
+- `just build-develop` runs `pyside6-rcc --binary` to produce a resource bundle (`project.rcc`) at the repo root that
+  packs every asset behind `qrc:/...` URLs. On startup, `main.py` registers the file with
+  `QResource.registerResource()` before anything reads from `qrc:/`. The file is gitignored. It is a build artifact and
+  can be regenerated from sources.
+- `just prepare-tests` rebuilds the bundle and stages copies for the test harnesses, which register it the same way the
   application does.
 - Release builds pre-compile QML files to bytecode for faster startup. Development and test runs load plain QML
   directly.

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,7 +26,7 @@ Clone the repository, then from the repo root:
 
 ```shell
 just init           # install dependencies and configure dev tooling
-just build-develop  # compile QML, data, and translations into rc_project.py
+just build-develop  # compile QML, data, and translations into project.rcc
 uv run main.py      # launch the application
 ```
 

--- a/main.py
+++ b/main.py
@@ -12,10 +12,22 @@ def main() -> Never:
     if sys.platform == "win32":
         _add_directory_to_path()
 
-    import rc_project  # noqa: F401
+    _register_resources()
+
     from mpvqc.startup import perform_startup
 
     perform_startup()
+
+
+def _register_resources() -> None:
+    from pathlib import Path
+
+    from PySide6.QtCore import QResource
+
+    resources = Path(__file__).resolve().parent / "project.rcc"
+    if not QResource.registerResource(str(resources)):
+        msg = f"Can not register resource file '{resources}'"
+        raise FileNotFoundError(msg)
 
 
 def _add_directory_to_path() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,6 @@ files = [
     "mpvqc/views/__init__.py",
     "mpvqc/views/player_framebuffer_object.py",
     "mpvqc/views/player_win_id.py",
-    "project.qrc",
     "qt/qml/io/github/mpvqc/mpvQC/App/MpvqcApplicationContent.qml",
     "qt/qml/io/github/mpvqc/mpvQC/App/MpvqcContentKeyHandler.qml",
     "qt/qml/io/github/mpvqc/mpvQC/App/MpvqcFileDropArea.qml",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,12 +4,12 @@
 
 from collections import deque
 from collections.abc import Callable, Generator
-from importlib.util import find_spec
+from pathlib import Path
 from typing import Any
 
 import inject
 import pytest
-from PySide6.QtCore import QByteArray, QCoreApplication, QLocale, QObject, Signal, SignalInstance
+from PySide6.QtCore import QByteArray, QCoreApplication, QLocale, QObject, QResource, Signal, SignalInstance
 from PySide6.QtTest import QSignalSpy
 
 from mpvqc.application import MpvqcApplication
@@ -181,13 +181,13 @@ def qt_app() -> Generator[MpvqcApplication, Any]:
 
 @pytest.fixture(scope="session", autouse=True)
 def check_generated_resources():
-    if find_spec("test.rc_project") is None:
+    resources = Path(__file__).resolve().parent / "project.rcc"
+    if not QResource.registerResource(str(resources)):
         message = (
-            "Can not find resource module 'test.rc_project'\n"
+            f"Can not register resource file '{resources}'\n"
             "To execute individual tests, please run 'just test-python' once before"
         )
         raise FileNotFoundError(message)
-    import test.rc_project  # noqa: F401
 
 
 @pytest.fixture(scope="session")

--- a/testqml/main.py
+++ b/testqml/main.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import sys
 
-from PySide6.QtCore import QCoreApplication, QObject, Qt, Slot
+from PySide6.QtCore import QCoreApplication, QObject, QResource, Qt, Slot
 from PySide6.QtQml import QQmlEngine
 from PySide6.QtQuickTest import QUICK_TEST_MAIN_WITH_SETUP
 
@@ -17,9 +17,11 @@ from testqml.injections import TEMP_ROOT, configure_injections
 
 
 class MpvqcTestSetup(QObject):
+    _resources_registered = False
+
     @Slot(QQmlEngine)
     def qmlEngineAvailable(self, engine: QQmlEngine) -> None:
-        import testqml.rc_project  # noqa: F401
+        self._register_resources()
 
         startup.configure_qt_application_data()
         startup.configure_qt_settings()
@@ -29,6 +31,16 @@ class MpvqcTestSetup(QObject):
         startup.import_mpvqc_bindings()
 
         engine.rootContext().setContextProperty("mpvqcTestMode", True)
+
+    @classmethod
+    def _register_resources(cls) -> None:
+        if cls._resources_registered:
+            return
+        resources = pathlib.Path(__file__).resolve().parent / "project.rcc"
+        if not QResource.registerResource(str(resources)):
+            msg = f"Can not register resource file '{resources}'"
+            raise FileNotFoundError(msg)
+        cls._resources_registered = True
 
 
 def parse_cli() -> argparse.Namespace:


### PR DESCRIPTION
Parsing the generated rc_project.py module cost about 100ms on every startup, and that cost was paid in full on read-only deployments like Flatpak, where no bytecode cache survives between runs. Compiling project.qrc into a binary project.rcc file and registering it with QResource.registerResource() skips that parsing step, so startup gets faster without changing what the app does.

## Measured results

### Flatpak (Linux)

A/B comparison of two local Flatpak builds on the same machine and runtime: the unchanged manifest (0.9.0-beta5, rc_project.py, no bytecode caches) against this change plus baked-in bytecode caches (the mpvQC-flatpak companion change). Launch time runs from `flatpak run` to a fixed startup log line. Warm starts, median of 5 runs, first run discarded.

| | Baseline | This change + caches |
|---|---|---|
| Launch to startup log line | 388 ms | 299 ms (-23%) |
| Resource setup | 58 ms (import rc_project) | ~0 ms (registerResource) |
| Importing the full mpvqc package | 167 ms (150 modules, from source) | 124 ms (158 modules, from .pyc) |
| Resource artifact size | 7.3 MB | 2.6 MB |

Notes on reading the numbers:

- The two component savings (58 ms resource setup, ~45 ms bytecode caches) add up to the end-to-end difference, so the gain comes from the intended mechanism, not from noise.
- The 88 ms launch delta includes the Flatpak bytecode-cache companion change. This PR on its own contributes the resource-setup half; on Windows and bare checkouts it also removes the parse of the generated module.
- The newer build imports eight more modules than the 0.9.0-beta5 baseline and still comes out faster.
- Both sides pay the same constant flatpak/bwrap launch overhead, so the app-side improvement is larger than the headline 23%.
- Absolute numbers are machine-specific; the ratios are what should transfer.
- Cold starts should gain more: the baseline parses 7 MB of Python source, the new path maps a 2.6 MB binary file into memory. Not measured yet.

### Windows (packaged app, Nuitka onefile)

In the packaged app, the baseline never parsed rc_project.py at runtime: Nuitka compiles it to C like every other module. This change removes the compiled module and ships project.rcc as a data file in the onefile payload instead. Measured as an A/B of the real CI artifacts (MSVC builds from the release pipeline) on a Windows 11 machine: the official 0.9.0-beta5 release (e4dbf522) against the CI build of this branch (630899c0). Launch time runs from process spawn to a fixed startup log line emitted just before the QML engine loads. Cold runs wipe the onefile extraction cache, so the bootstrap re-extracts and the first launch after an install or update is simulated. Median of 7 warm and 5 cold runs, interleaved.

| | Baseline (beta5 release) | This change (CI build) |
|---|---|---|
| First launch after install or update (fresh extraction) | 655 ms | 630 ms (even) |
| Later launches (payload cached) | 449 ms | 451 ms (even) |
| Compressed exe, extracted payload | 29.7 MB, 111.8 MB | 29.2 MB, 109.7 MB (even) |

Notes:

- No startup change in either direction. The payload does not shrink either: the resource bytes are zlib-compressed the same way inside the compiled module and inside the rcc file.
- The baseline is the month-older release, so the comparison carries the same code-drift caveat as the Flatpak one. A controlled same-tree A/B (both variants rebuilt locally with identical release flags) confirms the warm result: 422 ms vs 422 ms.
- One measurement-method warning for anyone repeating this: the local same-tree rebuild had to use zig as the C compiler (no Visual Studio on the machine), and those two exes showed a reproducible ~300 ms cold-launch gap that the MSVC CI artifacts do not have. It traced to Windows Defender's first-execution scan, whose duration depends on exe content: the zig-built exe without the embedded resource blob scanned ~300 ms slower than the one with it. First-launch numbers for freshly built exes measure the scanner as much as the app.

Verified with the full Python and QML test suites, an offscreen smoke boot, and a complete local Flatpak build and launch. Bytecode caches in the image were confirmed hash-based and actually used at runtime (checked with python -v inside the sandbox).
