### PR TITLE
Run QML test files in parallel

### DIFF
--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -86,7 +86,9 @@ ignore = [
 ]
 
 "testqml/**" = [
-    "T20"         # Allow print statements
+    "T20",        # Allow print statements
+    "S404",       # The parallel runner spawns the test processes
+    "S603",       # ... with arguments it builds itself
 ]
 
 "**/test_*.py" = [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Prepare tests
         run: just prepare-tests
       - name: Execute Qml Tests
-        run: just test-qml
+        run: just test-qml 1
         env:
           MPVQC_TEST_DELAY_MS: 1000
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@
 - Run Python tests via `just test-python ARGS`. `ARGS` is passed to `pytest`.
 - Prepare QML tests via `just prepare-tests` when you've changed production QML, data, or translation files.
 - Run a single QML test file via `just test-qml-debug <TARGET>`.
-- Run all QML tests via `just test-qml`.
+- Run all QML tests via `just test-qml`, one process per file. `just test-qml 1` uses a single process, as Windows
+  and CI always do.
 
 ## Coding
 

--- a/Justfile
+++ b/Justfile
@@ -122,9 +122,10 @@ prepare-tests: build-develop
 test-python *ARGS="build-aux test":
     QT_QPA_PLATFORM=offscreen uv run pytest {{ ARGS }}
 
+# Run all QML tests, JOBS files at a time ('1' = single process)
 [group('test')]
-test-qml:
-    uv run -m testqml.main
+test-qml JOBS='auto':
+    uv run -m testqml.runner --jobs '{{ JOBS }}'
 
 # TARGET = file by name recursively matched under qt/qml
 [group('test')]

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ bundle. Configure your IDE to run it before launching the app.
 | `just test`                   | Run Python tests and QML tests (recompiles resources first)                      |
 | `just prepare-tests`          | Recompile resources for testing (runs `build-develop` then stages it)            |
 | `just test-python`            | Run Python tests only (does **not** recompile)                                   |
-| `just test-qml`               | Run QML tests only (does **not** recompile)                                      |
+| `just test-qml [JOBS]`        | Run QML tests only (does **not** recompile), one process per file                |
 | `just test-qml-debug TARGET`  | Run a single QML test file matched by name (useful for iteration)                |
 | `just fmt`                    | Format and lint Python, QML, JSON, TOML, YAML, Markdown                          |
 | `just lint-qml`               | Run pyside6-qmllint                                                              |

--- a/test/test_qml_runner.py
+++ b/test/test_qml_runner.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+
+from testqml.runner import count_tests, resolve_jobs
+
+
+@pytest.mark.parametrize(
+    ("requested", "shard_count", "platform", "expected"),
+    [
+        ("4", 51, "linux", 4),
+        ("4", 2, "linux", 2),
+        ("1", 51, "linux", 1),
+        ("auto", 1, "linux", 1),
+        ("4", 51, "win32", 1),
+        ("auto", 51, "win32", 1),
+    ],
+)
+def test_resolve_jobs(requested: str, shard_count: int, platform: str, expected: int):
+    assert resolve_jobs(requested, shard_count, platform=platform) == expected
+
+
+@pytest.mark.parametrize("requested", ["banana", "0", "-2", "", "2.5"])
+def test_resolve_jobs_rejects(requested: str):
+    with pytest.raises(SystemExit):
+        resolve_jobs(requested, 51, platform="linux")
+
+
+def test_count_tests_reads_totals():
+    output = "PASS   : some::test()\nTotals: 38 passed, 1 failed, 0 skipped, 0 blacklisted, 6473ms\n"
+    assert count_tests(output) == 38
+
+
+def test_count_tests_without_totals():
+    assert count_tests("qrc:/qt/qml/Foo.qml:3:1: Syntax error\n") == 0

--- a/testqml/injections.py
+++ b/testqml/injections.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -39,8 +40,19 @@ from mpvqc.viewmodels import MpvqcBackupTimerViewModel
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+
+def _temp_root() -> Path:
+    # The parallel runner hands out the directories and deletes them once the processes are gone.
+    configured = os.environ.get("MPVQC_TEST_TEMP_ROOT")
+    if configured:
+        root = Path(configured)
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+    return Path(tempfile.mkdtemp(prefix="mpvqc-qmltest-"))
+
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
-TEMP_ROOT = Path(tempfile.mkdtemp(prefix="mpvqc-qmltest-"))
+TEMP_ROOT = _temp_root()
 TEMP_SAVES_DIR = TEMP_ROOT / "saves"
 TEMP_SAVES_DIR.mkdir()
 

--- a/testqml/main.py
+++ b/testqml/main.py
@@ -49,6 +49,11 @@ def parse_cli() -> argparse.Namespace:
         "--target",
         help="Run a single file by name (matches anywhere under qt/qml/).",
     )
+    parser.add_argument(
+        "--silent",
+        action="store_true",
+        help="Report failures only, leaving out the line per passing test.",
+    )
     return parser.parse_args()
 
 
@@ -89,7 +94,9 @@ def main() -> int:
 
     qt_argv = [sys.argv[0]]
 
-    # qt_argv += ["-silent"]
+    if args.silent:
+        qt_argv += ["-silent"]
+
     # qt_argv += ["-eventdelay", "50"]
 
     if sys.platform == "linux":

--- a/testqml/runner.py
+++ b/testqml/runner.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Runs the QML test files, one process per file, several at a time.
+
+Qt Quick Test itself has no parallel mode: a run takes a single `-input` path and walks it in order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+QML_ROOT = Path("qt/qml")
+TOTALS_PATTERN = re.compile(r"^Totals: (\d+) passed", re.MULTILINE)
+INTERRUPTED_EXIT_CODE = 130
+
+
+@dataclass(frozen=True)
+class ShardResult:
+    file: Path
+    passed: bool
+    tests: int
+    seconds: float
+    output: str
+
+
+def parse_cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="testqml.runner")
+    parser.add_argument(
+        "--jobs",
+        default="auto",
+        help="Number of test files to run at once, or 'auto'. One job runs everything in a single process.",
+    )
+    return parser.parse_args()
+
+
+def resolve_jobs(requested: str, shard_count: int, platform: str = sys.platform) -> int:
+    wanted = _requested_jobs(requested, shard_count)
+    if platform == "win32" and wanted > 1:
+        # Windows drives real windows, which would fight over the keyboard focus.
+        print("Windows runs the test files one after another, in a single process", flush=True)
+        return 1
+    return wanted
+
+
+def _requested_jobs(requested: str, shard_count: int) -> int:
+    if requested == "auto":
+        return min(os.process_cpu_count() or 1, shard_count)
+    if not requested.isdigit() or int(requested) < 1:
+        msg = f"--jobs takes 'auto' or a number of at least 1, got '{requested}'"
+        raise SystemExit(msg)
+    return min(int(requested), shard_count)
+
+
+def discover_test_files() -> list[Path]:
+    # Biggest first, because the longest file decides the wall time.
+    files = sorted(QML_ROOT.rglob("tst_*.qml"), key=lambda file: file.stat().st_size, reverse=True)
+    if not files:
+        msg = f"No test files found below '{QML_ROOT}'"
+        raise SystemExit(msg)
+    return files
+
+
+def count_tests(output: str) -> int:
+    return sum(int(match.group(1)) for match in TOTALS_PATTERN.finditer(output))
+
+
+def run_shard(file: Path, temp_root: Path) -> ShardResult:
+    started = time.monotonic()
+    process = subprocess.run(
+        [sys.executable, "-m", "testqml.main", "--silent", "--target", str(file)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=os.environ | {"MPVQC_TEST_TEMP_ROOT": str(temp_root)},
+    )
+    output = process.stdout + process.stderr
+    tests = count_tests(output)
+    return ShardResult(
+        file=file,
+        # A run whose tests never started still reports success.
+        passed=process.returncode == 0 and tests > 0,
+        tests=tests,
+        seconds=time.monotonic() - started,
+        output=output,
+    )
+
+
+def run_in_single_process() -> int:
+    return subprocess.run([sys.executable, "-m", "testqml.main"], check=False).returncode
+
+
+def run_in_parallel(files: list[Path], jobs: int) -> int:
+    print(f"Running {len(files)} test files, {jobs} at a time", flush=True)
+    started = time.monotonic()
+    run_root = Path(tempfile.mkdtemp(prefix="mpvqc-qmltest-"))
+    results: list[ShardResult] = []
+    interrupted = False
+
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures: list[Future[ShardResult]] = [
+            pool.submit(run_shard, file, run_root / f"{index:02d}-{file.stem}") for index, file in enumerate(files)
+        ]
+        try:
+            for future in as_completed(futures):
+                result = future.result()
+                results.append(result)
+                marker = "PASS" if result.passed else "FAIL"
+                print(f"{marker}  {result.seconds:6.1f}s  {result.file.name}", flush=True)
+        except KeyboardInterrupt:
+            interrupted = True
+            for future in futures:
+                future.cancel()
+
+    if interrupted:
+        shutil.rmtree(run_root, ignore_errors=True)
+        print("\nInterrupted", flush=True)
+        return INTERRUPTED_EXIT_CODE
+
+    failures = [result for result in results if not result.passed]
+    for failure in failures:
+        print(f"\n{'=' * 80}\n{failure.file}\n{'=' * 80}\n{failure.output}", flush=True)
+
+    tests = sum(result.tests for result in results)
+    passed = len(results) - len(failures)
+    elapsed = time.monotonic() - started
+    print(f"\n{tests} tests, {passed} of {len(files)} files passed in {elapsed:.1f}s", flush=True)
+
+    if not failures:
+        shutil.rmtree(run_root, ignore_errors=True)
+        return 0
+
+    print(f"Test data of this run is in {run_root}\n\nRe-run the failed files one by one:", flush=True)
+    for failure in failures:
+        print(f"  just test-qml-debug {failure.file.stem}", flush=True)
+    return 1
+
+
+def main() -> int:
+    args = parse_cli()
+    files = discover_test_files()
+    jobs = resolve_jobs(args.jobs, len(files))
+    if jobs == 1:
+        return run_in_single_process()
+    return run_in_parallel(files, jobs)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The QML suite runs every test file in one process, one after another, and most of that time goes into waiting for animations to settle. Qt Quick Test has no parallel mode of its own, so this adds a small runner that starts one process per file and keeps as many going at once as the machine has cores, which takes the suite from 124 seconds down to 18 with the same 647 tests passing. Windows and CI stay on a single process, Windows because real windows would fight over the keyboard focus and CI because a loaded runner would turn the few fixed waits left in the test helpers into flaky failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)