### PR TITLE
style: bring QML in line with the conventions

### DIFF
--- a/.agents/skills/manual-checks/SKILL.md
+++ b/.agents/skills/manual-checks/SKILL.md
@@ -55,6 +55,17 @@ cannot be seen in the app.
 Group by arrangement, then by area. Skip an arrangement no subagent reached: a Linux-only branch gets no Windows
 heading.
 
+Every heading is one arrangement. There is no shared bucket, no `Any arrangement`, no `All platforms`, no item parked
+outside an arrangement. The boxes are how the user records which machine they sat at, so a box that spans arrangements
+records nothing and they have to start over.
+
+Repetition is the point, not waste. Write the same check under every arrangement it reaches, and where an arrangement
+changes what the user should see, say that in its copy rather than bolting a parenthetical onto a shared line.
+
+Lead every arrangement heading with its emoji, so the user finds their machine by shape before they read a word:
+🪟 Windows, 🐧 Linux desktop, 🧱 Linux tiling. An arrangement the catalogue grows later picks up its own emoji and
+keeps it from then on.
+
 Name an area after the thing the user touches: `Window controls`, `Video resize`, `Overlays`. Not after the module.
 
 Write each item as the state that should hold, present tense, one observable per line:
@@ -62,20 +73,31 @@ Write each item as the state that should hold, present tense, one observable per
 ```markdown
 ## Manual checks before merging
 
-### Windows
+### 🪟 Windows
 
 #### Window controls
 
 - [ ] Loading a video resizes the window to fit it
 - [ ] Escape leaves fullscreen
+
+### 🧱 Linux tiling
+
+#### Window controls
+
+- [ ] Escape leaves fullscreen
+- [ ] Known and accepted: loading a video leaves the window alone, the compositor decides the size
 ```
+
+Escape repeats because it reaches both arrangements. Resize is written twice, differently, because the two
+arrangements owe the user different behaviour.
 
 Every line under a heading is a checkbox. Setup a check needs rides inside the item. A quirk the branch knowingly
 leaves behind is still an item, marked `Known and accepted:`.
 
 Boxes ship unchecked. The user ticks them.
 
-Done when every item passes the blast radius filter.
+Done when every item passes the blast radius filter, and every item sits under exactly one emoji-led arrangement
+heading.
 
 ### 5. Place it
 

--- a/.agents/skills/writing-qml/SKILL.md
+++ b/.agents/skills/writing-qml/SKILL.md
@@ -16,8 +16,8 @@ import QtQuick.Controls.Material as M
 ```
 
 An unnamespaced `import QtQuick.Controls.Material` resolves controls to Material directly and bypasses the MpvqcStyle
-overrides, whatever the import order and without a warning. The three files in `qt/qml/MpvqcStyle/` are the only ones
-that import it unnamespaced, because they are the overrides.
+overrides, whatever the import order and without a warning. Only the files in `qt/qml/MpvqcStyle/` import it
+unnamespaced, because they are the overrides.
 
 ## Signals
 
@@ -71,12 +71,17 @@ Reactions
 
 Children and motion
 
-21. Child objects, visual or not (`Rectangle`, `RowLayout`, `Shortcut`, `Binding`, `HoverHandler`)
+21. Child objects, written without a property name (`Rectangle`, `RowLayout`, `Shortcut`, `Binding`, `HoverHandler`)
 22. `Behavior`
 23. States
 24. Transitions
 
 Every nested child object descends the same ladder inside its own braces, starting at rung 5.
+
+An assignment stays on rung 17 however big its value is. `contentItem: ColumnLayout {}`,
+`background: Rectangle {}`, `delegate: SelectionDelegate {}` and `model: MpvqcShortcutsModel {}` all
+configure this object, so they sit with the other own bindings and above the attached ones. What tells
+the two apart is the property name, not the braces.
 
 Put anything unlisted on the rung whose group it belongs to: it declares the interface, configures this
 object, reacts to a change, or is a child.
@@ -90,4 +95,5 @@ under the `id`. The rest of the ladder follows from rung 7.
 
 - The Material style is imported under a namespace, unless the file is one of the style overrides.
 - Signal parameters read name first.
+- Object-valued assignments sit with the own bindings, not with the children.
 - You have read the file top to bottom and the rung numbers never decrease.

--- a/qt/qml/MpvqcStyle/Button.qml
+++ b/qt/qml/MpvqcStyle/Button.qml
@@ -16,6 +16,10 @@ import io.github.mpvqc.mpvQC.Utility
 T.Button {
     id: control
 
+    readonly property bool hasIcon: icon.name.length > 0 || icon.source.toString().length > 0
+
+    readonly property color _contentColor: !enabled ? MpvqcTheme.palette.hint : (flat && highlighted) || (checked && !highlighted) ? Material.accentColor : highlighted ? Material.primaryHighlightedTextColor : Material.foreground
+
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, implicitContentWidth + leftPadding + rightPadding)
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, implicitContentHeight + topPadding + bottomPadding)
 
@@ -28,13 +32,6 @@ T.Button {
 
     icon.width: 24
     icon.height: 24
-
-    readonly property bool hasIcon: icon.name.length > 0 || icon.source.toString().length > 0
-
-    readonly property color _contentColor: !enabled ? MpvqcTheme.palette.hint : (flat && highlighted) || (checked && !highlighted) ? Material.accentColor : highlighted ? Material.primaryHighlightedTextColor : Material.foreground
-
-    Material.elevation: control.down ? 8 : 2
-    Material.roundedScale: Material.FullScale
 
     contentItem: IconLabel {
         spacing: control.spacing
@@ -75,4 +72,7 @@ T.Button {
             color: Qt.alpha(control._contentColor, 0.1)
         }
     }
+
+    Material.elevation: control.down ? 8 : 2
+    Material.roundedScale: Material.FullScale
 }

--- a/qt/qml/MpvqcStyle/DialogButtonBox.qml
+++ b/qt/qml/MpvqcStyle/DialogButtonBox.qml
@@ -20,9 +20,6 @@ T.DialogButtonBox {
     alignment: Qt.AlignRight
     buttonLayout: T.DialogButtonBox.AndroidLayout
 
-    M.Material.foreground: M.Material.accent
-    M.Material.roundedScale: M.Material.ExtraLargeScale
-
     delegate: Button {
         flat: true
     }
@@ -45,4 +42,7 @@ T.DialogButtonBox {
         bottomPadding: control.position === T.DialogButtonBox.Header ? -radius : 0
         clip: true
     }
+
+    M.Material.foreground: M.Material.accent
+    M.Material.roundedScale: M.Material.ExtraLargeScale
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/MpvqcLayout.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/MpvqcLayout.qml
@@ -41,6 +41,12 @@ Page {
 
     background: null
 
+    Component.onCompleted: {
+        const width = Math.round(_splitView.width * root.defaultSplitRatio);
+        const height = Math.round(_splitView.height * root.defaultSplitRatio);
+        _tableContainer.setPreferredSizes(width, height);
+    }
+
     SplitView {
         id: _splitView
         objectName: "applicationSplitView"
@@ -64,15 +70,15 @@ Page {
         Column {
             id: _tableContainer
 
+            function setPreferredSizes(width: real, height: real): void {
+                SplitView.preferredWidth = width;
+                SplitView.preferredHeight = height;
+            }
+
             visible: !MpvqcWindowUtility.isFullscreen
 
             SplitView.minimumHeight: root.minContainerHeight
             SplitView.minimumWidth: root.minContainerWidth
-
-            function setPreferredSizes(width, height) {
-                SplitView.preferredWidth = width;
-                SplitView.preferredHeight = height;
-            }
 
             MpvqcTableView {
                 id: _mpvqcCommentTable
@@ -114,11 +120,5 @@ Page {
         onSplitViewTableSizeRequested: (width, height) => {
             _tableContainer.setPreferredSizes(width, height);
         }
-    }
-
-    Component.onCompleted: {
-        const width = Math.round(_splitView.width * root.defaultSplitRatio);
-        const height = Math.round(_splitView.height * root.defaultSplitRatio);
-        _tableContainer.setPreferredSizes(width, height);
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/TestHelpers.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/TestHelpers.qml
@@ -17,37 +17,6 @@ QtObject {
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
     readonly property MpvqcTestSettings settings: MpvqcTestSettings {}
 
-    readonly property Component _contentComponent: Component {
-        MpvqcApplicationContent {
-            anchors.fill: parent
-            windowActive: true
-            windowWidth: root.testCase.width
-        }
-    }
-
-    readonly property Component _signalSpy: Component {
-        SignalSpy {}
-    }
-
-    function resetState(): void {
-        root.bridge.resetState();
-    }
-
-    function makeControl(): MpvqcApplicationContent {
-        const control = root.testCase.createTemporaryObject(root._contentComponent, root.testCase);
-        root.testCase.verify(control);
-        return control;
-    }
-
-    function makeSpy(target, signalName: string): SignalSpy {
-        const spy = root.testCase.createTemporaryObject(root._signalSpy, root.testCase, {
-            target: target,
-            signalName: signalName
-        });
-        root.testCase.verify(spy);
-        return spy;
-    }
-
     readonly property var menu: QtObject {
         function trigger(control: Item, menuName: string, itemName: string): void {
             const menu = root.testCase.findChild(control, menuName);
@@ -250,5 +219,36 @@ QtObject {
             root.testCase.verify(btn, "cancelButton not found");
             root.testCase.mouseClick(btn);
         }
+    }
+
+    readonly property Component _contentComponent: Component {
+        MpvqcApplicationContent {
+            anchors.fill: parent
+            windowActive: true
+            windowWidth: root.testCase.width
+        }
+    }
+
+    readonly property Component _signalSpy: Component {
+        SignalSpy {}
+    }
+
+    function resetState(): void {
+        root.bridge.resetState();
+    }
+
+    function makeControl(): MpvqcApplicationContent {
+        const control = root.testCase.createTemporaryObject(root._contentComponent, root.testCase);
+        root.testCase.verify(control);
+        return control;
+    }
+
+    function makeSpy(target, signalName: string): SignalSpy {
+        const spy = root.testCase.createTemporaryObject(root._signalSpy, root.testCase, {
+            target: target,
+            signalName: signalName
+        });
+        root.testCase.verify(spy);
+        return spy;
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_FileMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_FileMenu.qml
@@ -17,12 +17,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -224,5 +218,11 @@ TestCase {
         it.menu.trigger(control, "fileMenu", "exitMpvqcMenuItem");
 
         tryVerify(() => spy.count === 1);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_HelpMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_HelpMenu.qml
@@ -16,12 +16,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -65,5 +59,11 @@ TestCase {
         it.menu.trigger(control, "helpMenu", "openAboutDialogMenuItem");
 
         it.find.openedDialog(control, "aboutDialog");
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_ImportWizardFlow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_ImportWizardFlow.qml
@@ -16,12 +16,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -150,5 +144,11 @@ TestCase {
         it.expect.commentCount(control, 0);
         it.expect.noOpenedVideo();
         it.expect.openedSubtitleCount(0);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_NewCommentMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_NewCommentMenu.qml
@@ -16,12 +16,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -86,5 +80,11 @@ TestCase {
         tryVerify(() => !menu.opened);
         it.expect.commentCount(control, 0);
         it.expect.commentListHasFocus(control);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_OptionsMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_OptionsMenu.qml
@@ -17,12 +17,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -431,5 +425,11 @@ TestCase {
         const control = it.makeControl();
         it.menu.triggerSubItem(control, "optionsMenu", "languageMenu", `languageMenuItem_${data.identifier}`);
         tryVerify(() => it.settings.language() === data.identifier);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_Shortcuts.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_Shortcuts.qml
@@ -16,12 +16,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -142,5 +136,11 @@ TestCase {
 
         keyClick(Qt.Key_Escape);
         tryVerify(() => !findChild(control, "searchBoxPopup")?.searchActive);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_VideoMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_VideoMenu.qml
@@ -16,12 +16,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -60,5 +54,11 @@ TestCase {
         tryVerify(() => spy.count === 1);
         compare(spy.signalArguments[0][0], 800);
         compare(spy.signalArguments[0][1], 600);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_WindowChrome.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcApplicationContent_WindowChrome.qml
@@ -16,12 +16,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    TestHelpers {
-        id: it
-
-        testCase: testCase
-    }
-
     function init(): void {
         it.resetState();
     }
@@ -120,5 +114,11 @@ TestCase {
         mouseDoubleClickSequence(inputArea, inputArea.width / 2, inputArea.height / 2, Qt.LeftButton);
 
         tryVerify(() => spy.count === 1);
+    }
+
+    TestHelpers {
+        id: it
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcContentKeyHandler.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/App/tst_MpvqcContentKeyHandler.qml
@@ -10,18 +10,6 @@ TestCase {
 
     name: "MpvqcContentKeyHandler"
 
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcContentKeyHandler {}
-    }
-
     function makeControl(): var {
         const control = createTemporaryObject(objectUnderTest, testCase, {});
         verify(control);
@@ -239,5 +227,17 @@ TestCase {
         compare(spy.signalArguments[0][0], data.event.key);
         compare(spy.signalArguments[0][1], data.event.modifiers);
         compare(data.event.accepted, true);
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcContentKeyHandler {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcIconLabel.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcIconLabel.qml
@@ -11,8 +11,9 @@ import io.github.mpvqc.mpvQC.Utility
 IconLabel {
     id: root
 
-    property string toolTipText: ""
     property alias iconColor: root.icon.color
+
+    property string toolTipText: ""
 
     display: IconLabel.IconOnly
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcKeyboardFocusableButtonBox.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcKeyboardFocusableButtonBox.qml
@@ -53,6 +53,9 @@ DialogButtonBox {
         snapMode: ListView.SnapToItem
     }
 
+    LayoutMirroring.enabled: isMirrored
+    LayoutMirroring.childrenInherit: true
+
     Component.onCompleted: {
         _initFocus();
     }
@@ -98,7 +101,4 @@ DialogButtonBox {
             root._updateVisualFocus();
         }
     }
-
-    LayoutMirroring.enabled: isMirrored
-    LayoutMirroring.childrenInherit: true
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcLabelWithToolTip.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcLabelWithToolTip.qml
@@ -19,15 +19,13 @@ RowLayout {
     Label {
         id: _label
 
-        Layout.fillWidth: true
-
         horizontalAlignment: Text.AlignRight
         wrapMode: Text.Wrap
+
+        Layout.fillWidth: true
     }
 
     MpvqcIconLabel {
-        Layout.preferredWidth: visible ? implicitWidth : 0
-
         visible: root.toolTip
         toolTipText: root.toolTip
 
@@ -37,5 +35,7 @@ RowLayout {
             height: 18
             color: MpvqcTheme.palette.hint
         }
+
+        Layout.preferredWidth: visible ? implicitWidth : 0
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcMenu.qml
@@ -13,17 +13,6 @@ Menu {
 
     readonly property bool isMirrored: Application.layoutDirection === Qt.RightToLeft
 
-    z: 2
-    transformOrigin: isMirrored ? Popup.TopRight : Popup.TopLeft
-    popupType: MpvqcConstants.preferredPopupType
-    dim: false
-
-    width: calculateMenuWidths()
-
-    M.Material.background: MpvqcTheme.palette.popupBackground
-    M.Material.foreground: MpvqcTheme.palette.popupText
-    M.Material.roundedScale: M.Material.SmallScale
-
     function calculateMenuWidths(): int {
         // Adapted from: https://martin.rpdev.net/2018/03/13/qt-quick-controls-2-automatically-set-the-width-of-menus.html
         let result = 0;
@@ -42,6 +31,17 @@ Menu {
     function isMenuSeparator(item: Item): bool {
         return item instanceof MenuSeparator;
     }
+
+    z: 2
+    transformOrigin: isMirrored ? Popup.TopRight : Popup.TopLeft
+    popupType: MpvqcConstants.preferredPopupType
+    dim: false
+
+    width: calculateMenuWidths()
+
+    M.Material.background: MpvqcTheme.palette.popupBackground
+    M.Material.foreground: MpvqcTheme.palette.popupText
+    M.Material.roundedScale: M.Material.SmallScale
 
     Binding {
         when: root.popupType === Popup.Window && root.contentItem

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcMessageBox.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcMessageBox.qml
@@ -23,8 +23,6 @@ Dialog {
     anchors.centerIn: Overlay.overlay
     dim: false
 
-    M.Material.background: MpvqcTheme.palette.dialogBackground
-
     contentItem: Label {
         text: root.text
         horizontalAlignment: Text.AlignLeft
@@ -41,6 +39,8 @@ Dialog {
     }
 
     footer: MpvqcKeyboardFocusableButtonBox {}
+
+    M.Material.background: MpvqcTheme.palette.dialogBackground
 
     Binding {
         when: root.popupType === Popup.Window

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcOverlayLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcOverlayLoader.qml
@@ -9,6 +9,11 @@ import QtQuick
 Loader {
     id: root
 
+    enum TeardownTrigger {
+        Closed,
+        AcceptedOrRejected
+    }
+
     property int teardownTrigger: MpvqcOverlayLoader.TeardownTrigger.Closed
 
     // Teardown must never destroy the item while the signal that triggered it
@@ -18,11 +23,6 @@ Loader {
     property int teardownDelay: 0
 
     signal closed
-
-    enum TeardownTrigger {
-        Closed,
-        AcceptedOrRejected
-    }
 
     function open(overlay: url, properties: var): void {
         _teardownTimer.stop();

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcSpinBoxRow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcSpinBoxRow.qml
@@ -11,8 +11,6 @@ RowLayout {
 
     required property int prefWidth
 
-    property int spinBoxWidth: 130
-
     property alias spinBox: _input
     property alias label: _label.text
     property alias suffix: _suffix.text
@@ -20,7 +18,9 @@ RowLayout {
     property alias valueFrom: _input.from
     property alias valueTo: _input.to
 
-    signal valueModified(int value)
+    property int spinBoxWidth: 130
+
+    signal valueModified(value: int)
 
     Label {
         id: _label

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcTextFieldRow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/MpvqcTextFieldRow.qml
@@ -16,7 +16,7 @@ RowLayout {
     property alias fontWeight: _textField.font.weight
     property alias implicitTextFieldWidth: _textField.implicitWidth
 
-    signal textChanged(string text)
+    signal textChanged(text: string)
 
     Label {
         id: _label

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcKeyboardFocusableButtonBox.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcKeyboardFocusableButtonBox.qml
@@ -17,38 +17,6 @@ TestCase {
     when: windowShown
     name: "MpvqcKeyboardFocusableButtonBox"
 
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcKeyboardFocusableButtonBox {
-            property alias acceptButton: _accept
-            property alias rejectButton: _reject
-            property alias destructiveButton: _destructive
-
-            Button {
-                id: _accept
-                text: "Accept"
-                DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
-            }
-            Button {
-                id: _reject
-                text: "Reject"
-                DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
-            }
-            Button {
-                id: _destructive
-                text: "Destructive"
-                DialogButtonBox.buttonRole: DialogButtonBox.DestructiveRole
-            }
-        }
-    }
-
     function makeControl(properties = {}): Item {
         const box = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(box);
@@ -152,5 +120,37 @@ TestCase {
         const startIndex = box._focusedIndex;
         keyPress(Qt.Key_Left);
         compare(box._focusedIndex, (startIndex - 1 + box.count) % box.count);
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcKeyboardFocusableButtonBox {
+            property alias acceptButton: _accept
+            property alias rejectButton: _reject
+            property alias destructiveButton: _destructive
+
+            Button {
+                id: _accept
+                text: "Accept"
+                DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
+            }
+            Button {
+                id: _reject
+                text: "Reject"
+                DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
+            }
+            Button {
+                id: _destructive
+                text: "Destructive"
+                DialogButtonBox.buttonRole: DialogButtonBox.DestructiveRole
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcOverlayLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcOverlayLoader.qml
@@ -18,24 +18,6 @@ TestCase {
 
     readonly property url stubUrl: Qt.resolvedUrl("MpvqcOverlayStub.qml")
 
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcOverlayLoader {}
-    }
-
-    Component {
-        id: timerFactory
-
-        Timer {}
-    }
-
     function makeControl(properties = {}): MpvqcOverlayLoader {
         const control = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(control);
@@ -235,5 +217,23 @@ TestCase {
         compare(control.item.openCalls, 1);
         control.item.emitTrigger("closed");
         compare(spy.count, 2);
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcOverlayLoader {}
+    }
+
+    Component {
+        id: timerFactory
+
+        Timer {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcPositionedMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcPositionedMenu.qml
@@ -19,50 +19,6 @@ TestCase {
     when: windowShown
     name: "MpvqcPositionedMenu"
 
-    Component {
-        id: container
-
-        Item {
-            width: testCase.width
-            height: testCase.height
-        }
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcPositionedMenu {
-            MenuItem {
-                text: "Test Item 1"
-            }
-            MenuItem {
-                text: "Test Item 2"
-            }
-            MenuItem {
-                text: "Test Item 3"
-            }
-        }
-    }
-
-    Component {
-        id: objectUnderTestOverwriteCalculatePosition
-
-        MpvqcPositionedMenu {
-            function calculatePosition(): point {
-                return Qt.point(200, 300);
-            }
-            MenuItem {
-                text: "Test Item 1"
-            }
-            MenuItem {
-                text: "Test Item 2"
-            }
-            MenuItem {
-                text: "Test Item 3"
-            }
-        }
-    }
-
     function makeControl(properties = {}): Item {
         const parent = createTemporaryObject(container, testCase);
         verify(parent);
@@ -205,5 +161,49 @@ TestCase {
         // Menu should use the overridden position
         fuzzyCompare(menu.x, 200, 2);
         fuzzyCompare(menu.y, 300, 2);
+    }
+
+    Component {
+        id: container
+
+        Item {
+            width: testCase.width
+            height: testCase.height
+        }
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcPositionedMenu {
+            MenuItem {
+                text: "Test Item 1"
+            }
+            MenuItem {
+                text: "Test Item 2"
+            }
+            MenuItem {
+                text: "Test Item 3"
+            }
+        }
+    }
+
+    Component {
+        id: objectUnderTestOverwriteCalculatePosition
+
+        MpvqcPositionedMenu {
+            function calculatePosition(): point {
+                return Qt.point(200, 300);
+            }
+            MenuItem {
+                text: "Test Item 1"
+            }
+            MenuItem {
+                text: "Test Item 2"
+            }
+            MenuItem {
+                text: "Test Item 3"
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcSpinBoxRow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcSpinBoxRow.qml
@@ -14,12 +14,12 @@ Item {
     MpvqcSpinBoxRow {
         id: objectUnderTest
 
+        property int newValue: -1
+
         prefWidth: testHelper.width
         valueFrom: 15
         value: 30
         valueTo: 45
-
-        property int newValue: -1
 
         onValueModified: value => {
             objectUnderTest.newValue = value;
@@ -28,12 +28,6 @@ Item {
         TestCase {
             name: "MpvqcSpinBoxRow"
             when: windowShown
-
-            SignalSpy {
-                id: valueModifiedSpy
-                target: objectUnderTest
-                signalName: "valueModified"
-            }
 
             function init() {
                 valueModifiedSpy.clear();
@@ -58,6 +52,12 @@ Item {
                 data.exec();
                 compare(objectUnderTest.newValue, data.value);
                 compare(valueModifiedSpy.count, 1);
+            }
+
+            SignalSpy {
+                id: valueModifiedSpy
+                target: objectUnderTest
+                signalName: "valueModified"
             }
         }
     }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcSwitchRow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcSwitchRow.qml
@@ -14,18 +14,6 @@ TestCase {
     name: "MpvqcSwitchRow"
     visible: true
 
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcSwitchRow {}
-    }
-
     function test_toggle() {
         const control = createTemporaryObject(objectUnderTest, testCase);
         verify(control);
@@ -45,5 +33,17 @@ TestCase {
         mouseClick(control.toggle);
         compare(spy.count, 2);
         verify(!control.checked);
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcSwitchRow {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcTextFieldRow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Components/tst_MpvqcTextFieldRow.qml
@@ -25,12 +25,6 @@ Item {
         TestCase {
             name: "MpvqcTextFieldRow"
 
-            SignalSpy {
-                id: textChangedSpy
-                target: objectUnderTest
-                signalName: "textChanged"
-            }
-
             function init() {
                 objectUnderTest.newText = '';
                 textChangedSpy.clear();
@@ -47,6 +41,12 @@ Item {
                 objectUnderTest.input = secondText;
                 verify(objectUnderTest.newText, secondText);
                 compare(textChangedSpy.count, 2);
+            }
+
+            SignalSpy {
+                id: textChangedSpy
+                target: objectUnderTest
+                signalName: "textChanged"
             }
         }
     }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/MpvqcAboutDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/MpvqcAboutDialog.qml
@@ -18,9 +18,71 @@ MpvqcDialog {
     id: root
     objectName: "aboutDialog"
 
+    readonly property MpvqcAboutDialogViewModel viewModel: MpvqcAboutDialogViewModel {}
+
     readonly property alias currentIndex: _pages.currentIndex
 
-    readonly property MpvqcAboutDialogViewModel viewModel: MpvqcAboutDialogViewModel {}
+    component MpvqcNavigationButton: ToolButton {
+        id: _button
+
+        readonly property color _contentColor: !enabled ? MpvqcTheme.palette.hint : highlighted ? MpvqcTheme.palette.accent : MpvqcTheme.palette.foreground
+        readonly property real _collapsedWidth: leftPadding + icon.width + rightPadding
+        readonly property real _expandedWidth: _collapsedWidth + spacing + _navLabel.implicitWidth
+
+        width: highlighted ? _expandedWidth : _collapsedWidth
+        clip: true
+        leftPadding: 16
+        rightPadding: 16
+
+        contentItem: Row {
+            spacing: _button.spacing
+
+            LayoutMirroring.enabled: _button.mirrored
+
+            MpvqcIconLabel {
+                icon.source: _button.icon.source
+                icon.width: _button.icon.width
+                icon.height: _button.icon.height
+                iconColor: _button._contentColor
+
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Label {
+                id: _navLabel
+
+                text: _button.text
+                color: _button._contentColor
+                visible: _button.highlighted || _widthAnimation.running
+
+                anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+
+        background: MImpl.Ripple {
+            implicitWidth: M.Material.touchTarget
+            implicitHeight: M.Material.touchTarget
+
+            x: (parent.width - width) / 2
+            y: (parent.height - height) / 2
+            width: parent.width
+            height: Math.min(parent.height, 36)
+            clip: true
+            clipRadius: height / 2
+            pressed: _button.pressed
+            anchor: _button
+            active: _button.enabled && (_button.down || _button.visualFocus || _button.hovered || _button.highlighted)
+            color: Qt.alpha(_button._contentColor, 0.1)
+        }
+
+        Behavior on width {
+            NumberAnimation {
+                id: _widthAnimation
+
+                duration: 150
+            }
+        }
+    }
 
     function showPage(index: int): void {
         if (index === _pages.currentIndex) {
@@ -123,67 +185,5 @@ MpvqcDialog {
         to: 1
         duration: 100
         easing.type: Easing.OutCubic
-    }
-
-    component MpvqcNavigationButton: ToolButton {
-        id: _button
-
-        readonly property color _contentColor: !enabled ? MpvqcTheme.palette.hint : highlighted ? MpvqcTheme.palette.accent : MpvqcTheme.palette.foreground
-        readonly property real _collapsedWidth: leftPadding + icon.width + rightPadding
-        readonly property real _expandedWidth: _collapsedWidth + spacing + _navLabel.implicitWidth
-
-        width: highlighted ? _expandedWidth : _collapsedWidth
-        clip: true
-        leftPadding: 16
-        rightPadding: 16
-
-        contentItem: Row {
-            spacing: _button.spacing
-
-            LayoutMirroring.enabled: _button.mirrored
-
-            MpvqcIconLabel {
-                icon.source: _button.icon.source
-                icon.width: _button.icon.width
-                icon.height: _button.icon.height
-                iconColor: _button._contentColor
-
-                anchors.verticalCenter: parent.verticalCenter
-            }
-
-            Label {
-                id: _navLabel
-
-                text: _button.text
-                color: _button._contentColor
-                visible: _button.highlighted || _widthAnimation.running
-
-                anchors.verticalCenter: parent.verticalCenter
-            }
-        }
-
-        background: MImpl.Ripple {
-            implicitWidth: M.Material.touchTarget
-            implicitHeight: M.Material.touchTarget
-
-            x: (parent.width - width) / 2
-            y: (parent.height - height) / 2
-            width: parent.width
-            height: Math.min(parent.height, 36)
-            clip: true
-            clipRadius: height / 2
-            pressed: _button.pressed
-            anchor: _button
-            active: _button.enabled && (_button.down || _button.visualFocus || _button.hovered || _button.highlighted)
-            color: Qt.alpha(_button._contentColor, 0.1)
-        }
-
-        Behavior on width {
-            NumberAnimation {
-                id: _widthAnimation
-
-                duration: 150
-            }
-        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/MpvqcCreditsTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/MpvqcCreditsTab.qml
@@ -63,10 +63,11 @@ ScrollView {
                 model: MpvqcLanguageModel {}
 
                 MpvqcAboutListItem {
+                    objectName: "languageCredit"
+
                     required property string language
                     required property var translators
 
-                    objectName: "languageCredit"
                     visible: translators.length > 0
                     text: qsTranslate("Languages", language)
                     supportingText: root.joinNames(translators)

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/MpvqcLicensesTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/MpvqcLicensesTab.qml
@@ -23,6 +23,32 @@ ScrollView {
 
     readonly property bool isScrollBarShown: contentHeight > height
 
+    component MpvqcSectionTitle: Label {
+        color: MpvqcTheme.palette.accent
+        font.pointSize: root.font.pointSize - 1
+        font.weight: Font.DemiBold
+        horizontalAlignment: Text.AlignLeft
+        leftPadding: 16
+        rightPadding: 16
+        topPadding: 16
+        bottomPadding: 8
+
+        Layout.fillWidth: true
+    }
+
+    component MpvqcLicensesListItem: MpvqcAboutListItem {
+        required property var modelData
+
+        text: modelData.name
+        supportingText: modelData.version ? root.joinDetails([modelData.version, modelData.licence]) : modelData.licence
+        icon.source: modelData.icon
+        link: modelData.url
+
+        Layout.fillWidth: true
+
+        onClicked: root.viewModel.openLink(link)
+    }
+
     function joinDetails(parts): string {
         // Reversed in RTL so the first entry sits rightmost, where reading starts
         return mirrored ? [...parts].reverse().join(" · ") : parts.join(" · ");
@@ -94,31 +120,5 @@ ScrollView {
                 MpvqcLicensesListItem {}
             }
         }
-    }
-
-    component MpvqcSectionTitle: Label {
-        color: MpvqcTheme.palette.accent
-        font.pointSize: root.font.pointSize - 1
-        font.weight: Font.DemiBold
-        horizontalAlignment: Text.AlignLeft
-        leftPadding: 16
-        rightPadding: 16
-        topPadding: 16
-        bottomPadding: 8
-
-        Layout.fillWidth: true
-    }
-
-    component MpvqcLicensesListItem: MpvqcAboutListItem {
-        required property var modelData
-
-        text: modelData.name
-        supportingText: modelData.version ? root.joinDetails([modelData.version, modelData.licence]) : modelData.licence
-        icon.source: modelData.icon
-        link: modelData.url
-
-        Layout.fillWidth: true
-
-        onClicked: root.viewModel.openLink(link)
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutDialog.qml
@@ -17,12 +17,6 @@ TestCase {
     when: windowShown
     name: "MpvqcAboutDialog"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcAboutDialog {}
-    }
-
     function makeDialog(): Dialog {
         const dialog = createTemporaryObject(objectUnderTest, testCase);
         verify(dialog, "dialog not created");
@@ -80,5 +74,11 @@ TestCase {
         mouseClick(find(dialog, "aboutNavigationButton"));
 
         compare(dialog.currentIndex, 0);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcAboutDialog {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutListItem.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutListItem.qml
@@ -17,21 +17,6 @@ TestCase {
     when: windowShown
     name: "MpvqcAboutListItem"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcAboutListItem {
-            width: 360
-            text: "headline"
-        }
-    }
-
-    Component {
-        id: spyComponent
-
-        SignalSpy {}
-    }
-
     function makeControl(properties = {}): Item {
         const control = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(control);
@@ -124,5 +109,20 @@ TestCase {
         mouseClick(control);
 
         compare(spy.count, data.expectedCount);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcAboutListItem {
+            width: 360
+            text: "headline"
+        }
+    }
+
+    Component {
+        id: spyComponent
+
+        SignalSpy {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutTab.qml
@@ -22,15 +22,6 @@ TestCase {
 
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcAboutTab {
-            anchors.fill: parent
-            viewModel: MpvqcAboutDialogViewModel {}
-        }
-    }
-
     function makeTab(): Item {
         const tab = createTemporaryObject(objectUnderTest, testCase);
         verify(tab);
@@ -62,5 +53,14 @@ TestCase {
         compare(copyRow.icon.source, MpvqcIcons.contentCopy);
         mouseClick(copyRow);
         compare(copyRow.icon.source, MpvqcIcons.check);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcAboutTab {
+            anchors.fill: parent
+            viewModel: MpvqcAboutDialogViewModel {}
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcCreditsTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcCreditsTab.qml
@@ -17,14 +17,6 @@ TestCase {
     when: windowShown
     name: "MpvqcCreditsTab"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcCreditsTab {
-            anchors.fill: parent
-        }
-    }
-
     function makeTab(mirrored = false): Item {
         const tab = createTemporaryObject(objectUnderTest, testCase, {
             "LayoutMirroring.enabled": mirrored,
@@ -80,6 +72,14 @@ TestCase {
 
         for (let i = 0; i < rows.length; ++i) {
             compare(rows[i].visible, rows[i].supportingText !== "");
+        }
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcCreditsTab {
+            anchors.fill: parent
         }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcLicensesTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcLicensesTab.qml
@@ -19,15 +19,6 @@ TestCase {
     when: windowShown
     name: "MpvqcLicensesTab"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcLicensesTab {
-            anchors.fill: parent
-            viewModel: MpvqcAboutDialogViewModel {}
-        }
-    }
-
     function makeTab(mirrored = false): Item {
         const tab = createTemporaryObject(objectUnderTest, testCase, {
             "LayoutMirroring.enabled": mirrored,
@@ -55,5 +46,14 @@ TestCase {
     function test_joinDetailsFollowsLayoutDirection(data): void {
         const tab = makeTab(data.mirrored);
         compare(tab.joinDetails(["1.0", "GPL-2.0+"]), data.expected);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcLicensesTab {
+            anchors.fill: parent
+            viewModel: MpvqcAboutDialogViewModel {}
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/CommentTypes/MpvqcCommentTypesDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/CommentTypes/MpvqcCommentTypesDialog.qml
@@ -23,6 +23,50 @@ MpvqcDialog {
     title: qsTranslate("CommentTypesDialog", "Comment Types")
     standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Reset
 
+    contentItem: ColumnLayout {
+        spacing: 10
+
+        MpvqcCommentTypesDraftField {
+            id: _draftField
+
+            validationError: _viewState.validationError
+            addEnabled: _viewState.isAddEnabled
+
+            Layout.fillWidth: true
+            Layout.topMargin: 20
+
+            onAddRequested: _viewState.addType()
+        }
+
+        RowLayout {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+
+            MpvqcCommentTypesListView {
+                id: _listView
+
+                rowHeight: MpvqcConstants.listRowHeight
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+            }
+
+            MpvqcCommentTypesActions {
+                id: _actions
+
+                moveUpEnabled: _viewState.isMoveUpEnabled
+                moveDownEnabled: _viewState.isMoveDownEnabled
+                deleteEnabled: _viewState.isDeleteEnabled
+
+                Layout.alignment: Qt.AlignTop
+
+                onMoveUpRequested: _viewState.moveUp()
+                onMoveDownRequested: _viewState.moveDown()
+                onDeleteRequested: _viewState.deleteCurrent()
+            }
+        }
+    }
+
     onAboutToShow: {
         // trigger the populate animation
         _listView.model = root.viewModel.commentTypesModel;
@@ -74,50 +118,6 @@ MpvqcDialog {
             root.viewModel.move(idx, idx + 1);
             _listView.currentIndex = idx + 1;
             _listView.ensureVisible(-1);
-        }
-    }
-
-    contentItem: ColumnLayout {
-        spacing: 10
-
-        MpvqcCommentTypesDraftField {
-            id: _draftField
-
-            Layout.fillWidth: true
-            Layout.topMargin: 20
-
-            validationError: _viewState.validationError
-            addEnabled: _viewState.isAddEnabled
-
-            onAddRequested: _viewState.addType()
-        }
-
-        RowLayout {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-
-            MpvqcCommentTypesListView {
-                id: _listView
-
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                rowHeight: MpvqcConstants.listRowHeight
-            }
-
-            MpvqcCommentTypesActions {
-                id: _actions
-
-                Layout.alignment: Qt.AlignTop
-
-                moveUpEnabled: _viewState.isMoveUpEnabled
-                moveDownEnabled: _viewState.isMoveDownEnabled
-                deleteEnabled: _viewState.isDeleteEnabled
-
-                onMoveUpRequested: _viewState.moveUp()
-                onMoveDownRequested: _viewState.moveDown()
-                onDeleteRequested: _viewState.deleteCurrent()
-            }
         }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/CommentTypes/MpvqcCommentTypesDraftField.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/CommentTypes/MpvqcCommentTypesDraftField.qml
@@ -39,12 +39,12 @@ ColumnLayout {
             id: _addField
             objectName: "commentTypeTextField"
 
-            Layout.fillWidth: true
-            ContextMenu.menu: null
-
             selectByMouse: true
             horizontalAlignment: Text.AlignLeft
             placeholderText: qsTranslate("CommentTypesDialog", "New comment type")
+
+            Layout.fillWidth: true
+            ContextMenu.menu: null
 
             onAccepted: root.addRequested()
         }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/CommentTypes/MpvqcCommentTypesListView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/CommentTypes/MpvqcCommentTypesListView.qml
@@ -150,11 +150,6 @@ ListView {
         leftInset: LayoutMirroring.enabled ? _scrollBar.visibleWidth : 0
         rightInset: LayoutMirroring.enabled ? 0 : _scrollBar.visibleWidth
 
-        M.Material.foreground: ListView.isCurrentItem ? root.mpvqcTheme.palette.rowSelectedText : foregroundColor
-        M.Material.background: backgroundColor
-
-        onPressed: root.currentIndex = index
-
         background: Rectangle {
             parent: _delegate.parent
             y: _delegate.y
@@ -173,6 +168,11 @@ ListView {
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
         }
+
+        M.Material.foreground: ListView.isCurrentItem ? root.mpvqcTheme.palette.rowSelectedText : foregroundColor
+        M.Material.background: backgroundColor
+
+        onPressed: root.currentIndex = index
     }
 
     ScrollBar.vertical: ScrollBar {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcImportWizardDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcImportWizardDialog.qml
@@ -24,16 +24,6 @@ MpvqcDialog {
     contentHeight: MpvqcConstants.smallDialogContentHeight
     closePolicy: Popup.NoAutoClose
 
-    Connections {
-        target: root.viewModel
-        function onAcceptRequested(): void {
-            root.accept();
-        }
-        function onRejectRequested(): void {
-            root.reject();
-        }
-    }
-
     contentItem: ColumnLayout {
         spacing: 40
 
@@ -41,11 +31,11 @@ MpvqcDialog {
             id: _stepIndicator
             objectName: "stepIndicator"
 
-            Layout.fillWidth: true
-            Layout.topMargin: 32
-
             stepKinds: root.viewModel.stepKinds
             currentStepIndex: root.viewModel.currentStepIndex
+
+            Layout.fillWidth: true
+            Layout.topMargin: 32
 
             onStepClicked: index => root.viewModel.currentStepIndex = index
         }
@@ -53,13 +43,13 @@ MpvqcDialog {
         MpvqcWizardSteps {
             objectName: "stepView"
 
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.topMargin: _stepIndicator.visible ? 0 : 32
-
             clip: true
 
             viewModel: root.viewModel
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.topMargin: _stepIndicator.visible ? 0 : 32
         }
     }
 
@@ -71,5 +61,15 @@ MpvqcDialog {
         onBackClicked: root.viewModel.back()
         onCancelClicked: root.viewModel.cancelClicked()
         onPrimaryClicked: root.viewModel.primaryClicked()
+    }
+
+    Connections {
+        target: root.viewModel
+        function onAcceptRequested(): void {
+            root.accept();
+        }
+        function onRejectRequested(): void {
+            root.reject();
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcImportWizardFooter.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcImportWizardFooter.qml
@@ -20,21 +20,15 @@ Control {
     signal cancelClicked
     signal primaryClicked
 
-    spacing: 8
-    horizontalPadding: 8
-    verticalPadding: 2
-
-    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, implicitContentWidth + leftPadding + rightPadding)
-    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, implicitContentHeight + topPadding + bottomPadding, M.Material.dialogButtonBoxHeight)
-
     component FooterButton: Button {
         required property bool shown
 
         visible: opacity > 0
         opacity: shown ? 1 : 0
-        Layout.preferredWidth: shown ? implicitWidth : 0
         flat: true
         clip: true
+
+        Layout.preferredWidth: shown ? implicitWidth : 0
 
         Behavior on opacity {
             NumberAnimation {
@@ -43,6 +37,13 @@ Control {
             }
         }
     }
+
+    spacing: 8
+    horizontalPadding: 8
+    verticalPadding: 2
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, implicitContentHeight + topPadding + bottomPadding, M.Material.dialogButtonBoxHeight)
 
     contentItem: RowLayout {
         spacing: root.spacing

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardErrorsStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardErrorsStep.qml
@@ -30,9 +30,6 @@ ColumnLayout {
         id: _listView
         objectName: "errorList"
 
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-
         model: root.viewModel.documents
         clip: true
         boundsBehavior: Flickable.StopAtBounds
@@ -60,39 +57,39 @@ ColumnLayout {
                 spacing: 12
 
                 MpvqcIconLabel {
-                    Layout.preferredWidth: _delegate.iconSize
-                    Layout.preferredHeight: _delegate.iconSize
-
                     iconColor: MpvqcTheme.palette.error
                     icon.source: MpvqcIcons.error
                     icon.width: _delegate.iconSize
                     icon.height: _delegate.iconSize
+
+                    Layout.preferredWidth: _delegate.iconSize
+                    Layout.preferredHeight: _delegate.iconSize
                 }
 
                 ColumnLayout {
-                    Layout.fillWidth: true
-
                     spacing: 2
+
+                    Layout.fillWidth: true
 
                     Label {
                         objectName: "filenameLabel"
 
-                        Layout.fillWidth: true
-
                         text: _delegate.filename
                         horizontalAlignment: Text.AlignLeft
                         elide: Text.ElideRight
+
+                        Layout.fillWidth: true
                     }
 
                     Label {
                         objectName: "reasonLabel"
 
-                        Layout.fillWidth: true
-
                         text: _delegate.reason
                         color: MpvqcTheme.palette.hint
                         horizontalAlignment: Text.AlignLeft
                         elide: Text.ElideRight
+
+                        Layout.fillWidth: true
                     }
                 }
             }
@@ -101,6 +98,9 @@ ColumnLayout {
             ToolTip.visible: hovered
             ToolTip.delay: MpvqcConstants.tooltipDelay
         }
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
         ScrollBar.vertical: ScrollBar {
             id: _scrollBar

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardSessionStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardSessionStep.qml
@@ -28,9 +28,6 @@ ColumnLayout {
         id: _listView
         objectName: "sessionOptions"
 
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-
         model: [
             {
                 mode: MpvqcImportWizardSessionMode.SessionMode.MERGE,
@@ -53,6 +50,7 @@ ColumnLayout {
 
         delegate: ItemDelegate {
             id: _delegate
+            objectName: _delegate.modelData.objectName
 
             required property int index
             required property var modelData
@@ -60,7 +58,6 @@ ColumnLayout {
             readonly property bool selected: root.viewModel.mode === _delegate.modelData.mode
             readonly property int iconSize: 24
 
-            objectName: _delegate.modelData.objectName
             width: ListView.view.width
             verticalPadding: 16
 
@@ -79,18 +76,21 @@ ColumnLayout {
                 Label {
                     objectName: "label"
 
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignVCenter
-
                     text: _delegate.modelData.text
                     horizontalAlignment: Text.AlignLeft
                     wrapMode: Text.Wrap
                     maximumLineCount: 2
                     elide: Text.ElideRight
+
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
                 }
             }
 
             onClicked: root.viewModel.mode = _delegate.modelData.mode
         }
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardStepGlyph.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardStepGlyph.qml
@@ -17,9 +17,6 @@ Item {
     property int size: 20
     property int animationDuration: 150
 
-    implicitWidth: root.size
-    implicitHeight: root.size
-
     component StateIcon: MpvqcIconLabel {
         required property bool active
 
@@ -36,6 +33,9 @@ Item {
             }
         }
     }
+
+    implicitWidth: root.size
+    implicitHeight: root.size
 
     StateIcon {
         objectName: "upcomingStateIcon"

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardStepIndicator.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardStepIndicator.qml
@@ -31,13 +31,6 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         height: parent.height
 
-        Binding {
-            target: _list
-            property: "width"
-            value: Math.min(_list.contentWidth, _list.parent.width)
-            delayed: true
-        }
-
         implicitHeight: 28
         cacheBuffer: 100000
 
@@ -139,12 +132,17 @@ Item {
                 }
             }
         }
+
+        Binding {
+            target: _list
+            property: "width"
+            value: Math.min(_list.contentWidth, _list.parent.width)
+            delayed: true
+        }
     }
 
     Rectangle {
         objectName: "leftFade"
-
-        LayoutMirroring.enabled: false
 
         anchors {
             left: _list.left
@@ -166,6 +164,8 @@ Item {
             }
         }
 
+        LayoutMirroring.enabled: false
+
         Behavior on opacity {
             NumberAnimation {
                 duration: root.animationDuration
@@ -175,8 +175,6 @@ Item {
 
     Rectangle {
         objectName: "rightFade"
-
-        LayoutMirroring.enabled: false
 
         anchors {
             right: _list.right
@@ -197,6 +195,8 @@ Item {
                 color: MpvqcTheme.palette.background
             }
         }
+
+        LayoutMirroring.enabled: false
 
         Behavior on opacity {
             NumberAnimation {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardSteps.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardSteps.qml
@@ -13,10 +13,24 @@ StackView {
     id: root
 
     required property MpvqcImportWizardViewModel viewModel
-    property int animationDuration: 120
     readonly property real slideDistance: width / 4
+    property int animationDuration: 120
 
     property int _lastIndex: 0
+
+    function _stepComponentFor(kind: int): Component {
+        switch (kind) {
+        case MpvqcImportWizardStepKind.StepKind.ERRORS:
+            return _errorsStep;
+        case MpvqcImportWizardStepKind.StepKind.SESSION:
+            return _sessionStep;
+        case MpvqcImportWizardStepKind.StepKind.VIDEO:
+            return _videoStep;
+        case MpvqcImportWizardStepKind.StepKind.SUBTITLES:
+            return _subtitlesStep;
+        }
+        return null;
+    }
 
     initialItem: root._stepComponentFor(root.viewModel.stepKinds[0])
 
@@ -109,20 +123,6 @@ StackView {
             }
             root._lastIndex = currentIndex;
         }
-    }
-
-    function _stepComponentFor(kind: int): Component {
-        switch (kind) {
-        case MpvqcImportWizardStepKind.StepKind.ERRORS:
-            return _errorsStep;
-        case MpvqcImportWizardStepKind.StepKind.SESSION:
-            return _sessionStep;
-        case MpvqcImportWizardStepKind.StepKind.VIDEO:
-            return _videoStep;
-        case MpvqcImportWizardStepKind.StepKind.SUBTITLES:
-            return _subtitlesStep;
-        }
-        return null;
     }
 
     Component {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardSubtitlesStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardSubtitlesStep.qml
@@ -50,9 +50,6 @@ ColumnLayout {
         id: _listView
         objectName: "subtitleList"
 
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-
         model: root.viewModel.subtitles
         clip: true
         boundsBehavior: Flickable.StopAtBounds
@@ -99,19 +96,22 @@ ColumnLayout {
                 Label {
                     objectName: "label"
 
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignVCenter
-
                     text: _delegate.filename
                     horizontalAlignment: Text.AlignLeft
                     wrapMode: Text.Wrap
                     maximumLineCount: 2
                     elide: Text.ElideRight
+
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
                 }
             }
 
             onClicked: root.viewModel.toggle(_delegate.index)
         }
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
         ScrollBar.vertical: ScrollBar {
             id: _scrollBar

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardVideoStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardVideoStep.qml
@@ -26,9 +26,6 @@ ColumnLayout {
         id: _listView
         objectName: "videoList"
 
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-
         model: root.viewModel.candidates
         clip: true
         boundsBehavior: Flickable.StopAtBounds
@@ -45,6 +42,9 @@ ColumnLayout {
 
             onClicked: root.viewModel.selectedIndex = index
         }
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
         ScrollBar.vertical: ScrollBar {
             id: _scrollBar

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardVideoStepDelegate.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/MpvqcWizardVideoStepDelegate.qml
@@ -45,29 +45,26 @@ ItemDelegate {
         Label {
             objectName: "label"
 
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-
             text: root.isNoVideo ? qsTranslate("ImportWizardDialog", "Skip video") : root.filename
             horizontalAlignment: Text.AlignLeft
             wrapMode: Text.Wrap
             maximumLineCount: 2
             elide: Text.ElideRight
 
-            HoverHandler {
-                id: _labelHover
-            }
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
 
             ToolTip.text: root.fullPath
             ToolTip.visible: !root.isNoVideo && _labelHover.hovered
             ToolTip.delay: MpvqcConstants.tooltipDelay
+
+            HoverHandler {
+                id: _labelHover
+            }
         }
 
         MpvqcIconLabel {
             objectName: "fromDocumentIcon"
-
-            Layout.preferredWidth: root.iconSize
-            Layout.preferredHeight: root.iconSize
 
             visible: root.foundInDocument
             iconColor: MpvqcTheme.palette.hint
@@ -77,13 +74,13 @@ ItemDelegate {
 
             //: Tooltip on the per-row icon — the candidate video is referenced by one of the QC documents being imported
             toolTipText: qsTranslate("ImportWizardDialog", "Referenced by an imported QC document")
+
+            Layout.preferredWidth: root.iconSize
+            Layout.preferredHeight: root.iconSize
         }
 
         MpvqcIconLabel {
             objectName: "fromSubtitleIcon"
-
-            Layout.preferredWidth: root.iconSize
-            Layout.preferredHeight: root.iconSize
 
             visible: root.foundInSubtitle
             iconColor: MpvqcTheme.palette.hint
@@ -93,6 +90,9 @@ ItemDelegate {
 
             //: Tooltip on the per-row icon — the candidate video is referenced by one of the subtitle files being imported
             toolTipText: qsTranslate("ImportWizardDialog", "Referenced by an imported subtitle file")
+
+            Layout.preferredWidth: root.iconSize
+            Layout.preferredHeight: root.iconSize
         }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcImportWizardDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcImportWizardDialog.qml
@@ -20,10 +20,6 @@ TestCase {
 
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
 
-    readonly property Component _dialogComponent: Component {
-        MpvqcImportWizardDialog {}
-    }
-
     readonly property var open: QtObject {
         function scenario(name: string): QtObject {
             const viewModel = testCase.bridge.buildWizardViewModel(name);
@@ -95,26 +91,6 @@ TestCase {
         }
     }
 
-    function _collectAll(root: Item, objectName: string): list<Item> {
-        const found = [];
-        function visit(item: Item): void {
-            if (!item) {
-                return;
-            }
-            if (item.objectName === objectName) {
-                found.push(item);
-            }
-            const kids = item.children;
-            if (kids) {
-                for (let i = 0; i < kids.length; i++) {
-                    visit(kids[i]);
-                }
-            }
-        }
-        visit(root);
-        return found;
-    }
-
     readonly property var pick: QtObject {
         function video(dlg: QtObject, index: int): void {
             const list = testCase.find.videoList(dlg);
@@ -162,13 +138,6 @@ TestCase {
         }
     }
 
-    function _waitForStepSettled(dlg: QtObject): void {
-        const stepView = findChild(dlg.contentItem, "stepView");
-        verify(stepView, "stepView not found");
-        tryVerify(() => !stepView.busy);
-        waitForRendering(dlg.contentItem);
-    }
-
     readonly property var expect: QtObject {
         function currentStep(dlg: QtObject, index: int): void {
             testCase.tryCompare(dlg.viewModel, "currentStepIndex", index);
@@ -214,6 +183,37 @@ TestCase {
                 return opened.length === names.length && names.every(n => opened.indexOf(n) >= 0);
             });
         }
+    }
+
+    readonly property Component _dialogComponent: Component {
+        MpvqcImportWizardDialog {}
+    }
+
+    function _collectAll(root: Item, objectName: string): list<Item> {
+        const found = [];
+        function visit(item: Item): void {
+            if (!item) {
+                return;
+            }
+            if (item.objectName === objectName) {
+                found.push(item);
+            }
+            const kids = item.children;
+            if (kids) {
+                for (let i = 0; i < kids.length; i++) {
+                    visit(kids[i]);
+                }
+            }
+        }
+        visit(root);
+        return found;
+    }
+
+    function _waitForStepSettled(dlg: QtObject): void {
+        const stepView = findChild(dlg.contentItem, "stepView");
+        verify(stepView, "stepView not found");
+        tryVerify(() => !stepView.busy);
+        waitForRendering(dlg.contentItem);
     }
 
     function init(): void {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardErrorsStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardErrorsStep.qml
@@ -5,7 +5,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls.Material // qmllint disable unused-imports
+import QtQuick.Controls
 import QtTest
 
 TestCase {
@@ -16,26 +16,6 @@ TestCase {
     visible: true
     when: windowShown
     name: "MpvqcWizardErrorsStep"
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardErrorsStep {
-            id: step
-
-            anchors.fill: parent
-
-            property alias documentsModel: _documents
-
-            viewModel: QtObject {
-                readonly property ListModel documents: _documents
-            }
-
-            ListModel {
-                id: _documents
-            }
-        }
-    }
 
     function makeControl(properties = {}): Item {
         const step = createTemporaryObject(objectUnderTest, testCase, properties);
@@ -89,5 +69,25 @@ TestCase {
         const item = list.itemAtIndex(0);
         verify(item);
         compare(item.ToolTip.text, "/full/path/to/broken.qc");
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardErrorsStep {
+            id: step
+
+            property alias documentsModel: _documents
+
+            anchors.fill: parent
+
+            viewModel: QtObject {
+                readonly property ListModel documents: _documents
+            }
+
+            ListModel {
+                id: _documents
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardSessionStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardSessionStep.qml
@@ -18,24 +18,6 @@ TestCase {
     when: windowShown
     name: "MpvqcWizardSessionStep"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardSessionStep {
-            id: _step
-
-            anchors.fill: parent
-
-            property int sessionMode: MpvqcImportWizardSessionMode.SessionMode.MERGE
-            property int incomingCount: 0
-
-            viewModel: QtObject {
-                readonly property int incomingCommentCount: _step.incomingCount
-                property int mode: _step.sessionMode
-            }
-        }
-    }
-
     function makeControl(properties = {}): Item {
         const step = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(step);
@@ -73,5 +55,23 @@ TestCase {
         });
         const header = findChild(step, "question");
         verify(header.text.indexOf("5") >= 0);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardSessionStep {
+            id: _step
+
+            property int sessionMode: MpvqcImportWizardSessionMode.SessionMode.MERGE
+            property int incomingCount: 0
+
+            anchors.fill: parent
+
+            viewModel: QtObject {
+                readonly property int incomingCommentCount: _step.incomingCount
+                property int mode: _step.sessionMode
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardStepGlyph.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardStepGlyph.qml
@@ -16,19 +16,13 @@ TestCase {
     when: windowShown
     name: "MpvqcWizardStepGlyph"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardStepGlyph {}
-    }
+    readonly property var stateIconNames: ["upcomingStateIcon", "currentStateIcon", "completedStateIcon"]
 
     function makeControl(properties = {}): Item {
         const glyph = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(glyph);
         return glyph;
     }
-
-    readonly property var stateIconNames: ["upcomingStateIcon", "currentStateIcon", "completedStateIcon"]
 
     function test_activatesCorrectIcon_data() {
         return [
@@ -63,5 +57,11 @@ TestCase {
             verify(icon, `${name} should exist`);
             compare(icon.active, name === data.expectActive, `${name}.active`);
         }
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardStepGlyph {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardStepIndicator.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardStepIndicator.qml
@@ -18,19 +18,7 @@ TestCase {
     when: windowShown
     name: "MpvqcWizardStepIndicator"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardStepIndicator {
-            anchors.fill: parent
-        }
-    }
-
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
+    readonly property var allKinds: [MpvqcImportWizardStepKind.StepKind.ERRORS, MpvqcImportWizardStepKind.StepKind.SESSION, MpvqcImportWizardStepKind.StepKind.VIDEO, MpvqcImportWizardStepKind.StepKind.SUBTITLES,]
 
     function makeControl(properties = {}): Item {
         const indicator = createTemporaryObject(objectUnderTest, testCase, properties);
@@ -46,8 +34,6 @@ TestCase {
         verify(spy);
         return spy;
     }
-
-    readonly property var allKinds: [MpvqcImportWizardStepKind.StepKind.ERRORS, MpvqcImportWizardStepKind.StepKind.SESSION, MpvqcImportWizardStepKind.StepKind.VIDEO, MpvqcImportWizardStepKind.StepKind.SUBTITLES,]
 
     function collect(root: Item, objectName: string): list<Item> {
         const found = [];
@@ -164,5 +150,19 @@ TestCase {
         verify(connectors[0].visible);
         verify(connectors[1].visible);
         verify(!connectors[2].visible);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardStepIndicator {
+            anchors.fill: parent
+        }
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardSubtitlesStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardSubtitlesStep.qml
@@ -16,41 +16,6 @@ TestCase {
     when: windowShown
     name: "MpvqcWizardSubtitlesStep"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardSubtitlesStep {
-            id: _step
-
-            anchors.fill: parent
-
-            property alias rowsModel: _rows
-            property int triState: Qt.Unchecked
-
-            viewModel: QtObject {
-                readonly property ListModel subtitles: _rows
-                property int selectAllTriState: _step.triState
-
-                property int lastToggleIndex: -1
-                property int toggleCount: 0
-                property int toggleSelectAllCount: 0
-
-                function toggle(index) {
-                    lastToggleIndex = index;
-                    toggleCount += 1;
-                }
-
-                function toggleSelectAll() {
-                    toggleSelectAllCount += 1;
-                }
-            }
-
-            ListModel {
-                id: _rows
-            }
-        }
-    }
-
     function makeControl(properties = {}): Item {
         const step = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(step);
@@ -216,5 +181,40 @@ TestCase {
         const selectAll = findChild(step, "selectAll");
         verify(selectAll);
         tryCompare(selectAll, "visible", data.expectVisible);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardSubtitlesStep {
+            id: _step
+
+            property alias rowsModel: _rows
+            property int triState: Qt.Unchecked
+
+            anchors.fill: parent
+
+            viewModel: QtObject {
+                readonly property ListModel subtitles: _rows
+                property int selectAllTriState: _step.triState
+
+                property int lastToggleIndex: -1
+                property int toggleCount: 0
+                property int toggleSelectAllCount: 0
+
+                function toggle(index) {
+                    lastToggleIndex = index;
+                    toggleCount += 1;
+                }
+
+                function toggleSelectAll() {
+                    toggleSelectAllCount += 1;
+                }
+            }
+
+            ListModel {
+                id: _rows
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardVideoStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardVideoStep.qml
@@ -16,28 +16,6 @@ TestCase {
     when: windowShown
     name: "MpvqcWizardVideoStep"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardVideoStep {
-            id: _step
-
-            anchors.fill: parent
-
-            property alias rowsModel: _rows
-            property int selected: 0
-
-            viewModel: QtObject {
-                readonly property ListModel candidates: _rows
-                property int selectedIndex: _step.selected
-            }
-
-            ListModel {
-                id: _rows
-            }
-        }
-    }
-
     function makeControl(properties = {}): Item {
         const step = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(step);
@@ -98,5 +76,27 @@ TestCase {
         seed(step, [candidate("a.mp4", "/movies/a.mp4"), candidate("b.mkv", "/movies/b.mkv"), candidate("c.mp4", "/movies/c.mp4"),]);
         mouseClick(rowAt(step, data.rowIndex));
         compare(step.viewModel.selectedIndex, data.rowIndex);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardVideoStep {
+            id: _step
+
+            property alias rowsModel: _rows
+            property int selected: 0
+
+            anchors.fill: parent
+
+            viewModel: QtObject {
+                readonly property ListModel candidates: _rows
+                property int selectedIndex: _step.selected
+            }
+
+            ListModel {
+                id: _rows
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardVideoStepDelegate.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardVideoStepDelegate.qml
@@ -5,7 +5,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls.Material // qmllint disable unused-imports
+import QtQuick.Controls
 import QtTest
 
 TestCase {
@@ -16,28 +16,6 @@ TestCase {
     visible: true
     when: windowShown
     name: "MpvqcWizardVideoStepDelegate"
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcWizardVideoStepDelegate {
-            anchors.fill: parent
-
-            index: 0
-            filename: "foobar.mp4"
-            fullPath: "/movies/foobar.mp4"
-            foundInDocument: false
-            foundInSubtitle: false
-            isNoVideo: false
-            selected: false
-        }
-    }
-
-    Component {
-        id: spyComponent
-
-        SignalSpy {}
-    }
 
     function makeControl(properties = {}): Item {
         const delegate = createTemporaryObject(objectUnderTest, testCase, properties);
@@ -160,5 +138,27 @@ TestCase {
         const label = findChild(delegate, "label");
         verify(label);
         compare(label.ToolTip.text, "/movies/foobar.mp4");
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcWizardVideoStepDelegate {
+            anchors.fill: parent
+
+            index: 0
+            filename: "foobar.mp4"
+            fullPath: "/movies/foobar.mp4"
+            foundInDocument: false
+            foundInSubtitle: false
+            isNoVideo: false
+            selected: false
+        }
+    }
+
+    Component {
+        id: spyComponent
+
+        SignalSpy {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcAppearanceDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcAppearanceDialog.qml
@@ -37,11 +37,6 @@ MpvqcDialog {
         readonly property int staggerInterval: 15
     }
 
-    contentHeight: MpvqcConstants.smallDialogContentHeight
-
-    title: qsTranslate("AppearanceDialog", "Appearance")
-    standardButtons: Dialog.Ok | Dialog.Cancel
-
     component SelectionDelegate: ItemDelegate {
         id: delegateRoot
 
@@ -50,7 +45,7 @@ MpvqcDialog {
         required property color displayColor
         required property int index
 
-        signal selected(int index)
+        signal selected(index: int)
 
         width: itemSize
         height: itemSize
@@ -62,6 +57,19 @@ MpvqcDialog {
             width: parent.width - 2 * delegateRoot.borderSize
             color: delegateRoot.displayColor
             radius: M.Material.LargeScale
+        }
+
+        MouseArea {
+            anchors.fill: parent
+
+            onPressed: {
+                delegateRoot.scale = root.animations.scalePressed;
+                delegateRoot.selected(delegateRoot.index);
+            }
+
+            onReleased: delegateRoot.scale = root.animations.scaleNormal
+
+            onCanceled: delegateRoot.scale = root.animations.scaleNormal
         }
 
         Behavior on scale {
@@ -83,19 +91,6 @@ MpvqcDialog {
                 duration: root.animations.appearDuration
                 easing.type: Easing.OutCubic
             }
-        }
-
-        MouseArea {
-            anchors.fill: parent
-
-            onPressed: {
-                delegateRoot.scale = root.animations.scalePressed;
-                delegateRoot.selected(delegateRoot.index);
-            }
-
-            onReleased: delegateRoot.scale = root.animations.scaleNormal
-
-            onCanceled: delegateRoot.scale = root.animations.scaleNormal
         }
     }
 
@@ -146,6 +141,11 @@ MpvqcDialog {
         }
     }
 
+    contentHeight: MpvqcConstants.smallDialogContentHeight
+
+    title: qsTranslate("AppearanceDialog", "Appearance")
+    standardButtons: Dialog.Ok | Dialog.Cancel
+
     contentItem: ScrollView {
         contentWidth: root.contentWidth
 
@@ -161,9 +161,6 @@ MpvqcDialog {
             ListView {
                 id: _themeListView
                 objectName: "themeListView"
-
-                Layout.preferredHeight: root.dimensions.itemSize
-                Layout.fillWidth: true
 
                 model: MpvqcThemePreviewModel {}
                 currentIndex: root.viewModel.themeIndex
@@ -194,6 +191,9 @@ MpvqcDialog {
 
                     onSelected: root.viewModel.setTheme(identifier)
                 }
+
+                Layout.preferredHeight: root.dimensions.itemSize
+                Layout.fillWidth: true
             }
 
             MpvqcHeader {
@@ -205,12 +205,6 @@ MpvqcDialog {
             GridView {
                 id: _gridView
                 objectName: "colorGridView"
-
-                Layout.preferredHeight: {
-                    const d = root.dimensions;
-                    return (d.itemSize + d.itemPadding) * d.colorGridRows;
-                }
-                Layout.fillWidth: true
 
                 model: MpvqcPrimaryColorModel {}
 
@@ -240,6 +234,12 @@ MpvqcDialog {
 
                     onSelected: root.viewModel.setPrimaryColor(identifier)
                 }
+
+                Layout.preferredHeight: {
+                    const d = root.dimensions;
+                    return (d.itemSize + d.itemPadding) * d.colorGridRows;
+                }
+                Layout.fillWidth: true
             }
         }
     }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcBackupDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcBackupDialog.qml
@@ -31,11 +31,11 @@ MpvqcDialog {
         MpvqcSwitchRow {
             objectName: "backupEnabledRow"
 
-            Layout.topMargin: 20
-            Layout.fillWidth: true
-
             label: qsTranslate("BackupDialog", "Backup Enabled")
             checked: root.viewModel.temporaryBackupEnabled
+
+            Layout.topMargin: 20
+            Layout.fillWidth: true
 
             onToggled: state => {
                 root.viewModel.temporaryBackupEnabled = state;
@@ -64,14 +64,15 @@ MpvqcDialog {
             text: qsTranslate("BackupDialog", "Backup Location")
             icon.source: MpvqcIcons.folderOpen
             hoverEnabled: true
+
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: 40
-
-            onPressed: root.viewModel.openBackupDirectory()
 
             ToolTip.delay: 350
             ToolTip.text: root.viewModel.backupDirectory
             ToolTip.visible: hovered
+
+            onPressed: root.viewModel.openBackupDirectory()
         }
 
         Item {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcEditInputDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcEditInputDialog.qml
@@ -19,15 +19,6 @@ MpvqcDialog {
     readonly property MpvqcEditInputDialogViewModel viewModel: MpvqcEditInputDialogViewModel {}
     readonly property var mpvqcTheme: MpvqcTheme
 
-    title: qsTranslate("InputConfEditDialog", "Edit input.conf")
-    contentWidth: Math.min(1080, MpvqcWindowUtility.windowGeometryWidth * 0.75)
-    contentHeight: Math.min(1080, MpvqcWindowUtility.windowGeometryHeight * 0.70)
-    standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Reset
-
-    onAccepted: _textArea.textDocument.save()
-
-    onReset: _textArea.text = viewModel.defaultInputConfiguration
-
     component Separator: Rectangle {
         property int topMargin: 0
 
@@ -37,6 +28,11 @@ MpvqcDialog {
         Layout.preferredHeight: 1
         Layout.fillWidth: true
     }
+
+    title: qsTranslate("InputConfEditDialog", "Edit input.conf")
+    contentWidth: Math.min(1080, MpvqcWindowUtility.windowGeometryWidth * 0.75)
+    contentHeight: Math.min(1080, MpvqcWindowUtility.windowGeometryHeight * 0.70)
+    standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Reset
 
     contentItem: ColumnLayout {
 
@@ -54,15 +50,15 @@ MpvqcDialog {
             Layout.topMargin: 20
             Layout.fillWidth: true
 
+            ToolTip.delay: 350
+            ToolTip.text: url
+            ToolTip.visible: hoveredLink
+
             onLinkActivated: link => root.viewModel.openLink(link)
 
             HoverHandler {
                 cursorShape: _label.hoveredLink ? Qt.PointingHandCursor : undefined
             }
-
-            ToolTip.delay: 350
-            ToolTip.text: url
-            ToolTip.visible: hoveredLink
         }
 
         Separator {
@@ -96,4 +92,8 @@ MpvqcDialog {
 
         Separator {}
     }
+
+    onAccepted: _textArea.textDocument.save()
+
+    onReset: _textArea.text = viewModel.defaultInputConfiguration
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcEditMpvDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcEditMpvDialog.qml
@@ -19,15 +19,6 @@ MpvqcDialog {
     readonly property MpvqcEditMpvDialogViewModel viewModel: MpvqcEditMpvDialogViewModel {}
     readonly property var mpvqcTheme: MpvqcTheme
 
-    title: qsTranslate("MpvConfEditDialog", "Edit mpv.conf")
-    contentWidth: Math.min(1080, MpvqcWindowUtility.windowGeometryWidth * 0.75)
-    contentHeight: Math.min(1080, MpvqcWindowUtility.windowGeometryHeight * 0.70)
-    standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Reset
-
-    onAccepted: _textArea.textDocument.save()
-
-    onReset: _textArea.text = viewModel.defaultMpvConfiguration
-
     component Separator: Rectangle {
         property int topMargin: 0
 
@@ -37,6 +28,11 @@ MpvqcDialog {
         Layout.preferredHeight: 1
         Layout.fillWidth: true
     }
+
+    title: qsTranslate("MpvConfEditDialog", "Edit mpv.conf")
+    contentWidth: Math.min(1080, MpvqcWindowUtility.windowGeometryWidth * 0.75)
+    contentHeight: Math.min(1080, MpvqcWindowUtility.windowGeometryHeight * 0.70)
+    standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Reset
 
     contentItem: ColumnLayout {
 
@@ -54,15 +50,15 @@ MpvqcDialog {
             Layout.topMargin: 20
             Layout.fillWidth: true
 
+            ToolTip.delay: 350
+            ToolTip.text: url
+            ToolTip.visible: hoveredLink
+
             onLinkActivated: link => root.viewModel.openLink(link)
 
             HoverHandler {
                 cursorShape: _label.hoveredLink ? Qt.PointingHandCursor : undefined
             }
-
-            ToolTip.delay: 350
-            ToolTip.text: url
-            ToolTip.visible: hoveredLink
         }
 
         Separator {
@@ -96,4 +92,8 @@ MpvqcDialog {
 
         Separator {}
     }
+
+    onAccepted: _textArea.textDocument.save()
+
+    onReset: _textArea.text = viewModel.defaultMpvConfiguration
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcExportSettingsDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcExportSettingsDialog.qml
@@ -27,8 +27,6 @@ MpvqcDialog {
         MpvqcTextFieldRow {
             objectName: "exportNicknameRow"
 
-            Layout.topMargin: 10
-
             label: qsTranslate("ExportSettingsDialog", "Nickname")
             input: root.viewModel.temporaryNickname
             spacing: 16
@@ -36,27 +34,29 @@ MpvqcDialog {
             prefWidth: root.contentWidth
             implicitTextFieldWidth: 150
 
+            Layout.topMargin: 10
+
             onTextChanged: text => {
                 root.viewModel.temporaryNickname = text;
             }
         }
 
         MpvqcHeader {
+            text: qsTranslate("ExportSettingsDialog", "Document Header")
+            horizontalAlignment: Text.AlignHCenter
+
             Layout.topMargin: 20
             Layout.bottomMargin: 10
             Layout.fillWidth: true
-
-            text: qsTranslate("ExportSettingsDialog", "Document Header")
-            horizontalAlignment: Text.AlignHCenter
         }
 
         MpvqcSwitchRow {
             objectName: "exportWriteDateRow"
 
-            Layout.fillWidth: true
-
             label: qsTranslate("ExportSettingsDialog", "Write Date")
             checked: root.viewModel.temporaryWriteHeaderDate
+
+            Layout.fillWidth: true
 
             onToggled: state => {
                 root.viewModel.temporaryWriteHeaderDate = state;
@@ -66,11 +66,11 @@ MpvqcDialog {
         MpvqcSwitchRow {
             objectName: "exportWriteGeneratorRow"
 
-            Layout.fillWidth: true
-
             //: %1 will be the application name. Most probably 'mpvQC' :)
             label: qsTranslate("ExportSettingsDialog", "Write '%1'").arg(Qt.application.name)
             checked: root.viewModel.temporaryWriteHeaderGenerator
+
+            Layout.fillWidth: true
 
             onToggled: state => {
                 root.viewModel.temporaryWriteHeaderGenerator = state;
@@ -80,10 +80,10 @@ MpvqcDialog {
         MpvqcSwitchRow {
             objectName: "exportWriteNicknameRow"
 
-            Layout.fillWidth: true
-
             label: qsTranslate("ExportSettingsDialog", "Write Nickname")
             checked: root.viewModel.temporaryWriteHeaderNickname
+
+            Layout.fillWidth: true
 
             onToggled: state => {
                 root.viewModel.temporaryWriteHeaderNickname = state;
@@ -93,10 +93,10 @@ MpvqcDialog {
         MpvqcSwitchRow {
             objectName: "exportWriteVideoPathRow"
 
-            Layout.fillWidth: true
-
             label: qsTranslate("ExportSettingsDialog", "Write Video Path")
             checked: root.viewModel.temporaryWriteHeaderVideoPath
+
+            Layout.fillWidth: true
 
             onToggled: state => {
                 root.viewModel.temporaryWriteHeaderVideoPath = state;
@@ -106,12 +106,12 @@ MpvqcDialog {
         MpvqcSwitchRow {
             objectName: "exportWriteSubtitlesRow"
 
-            Layout.fillWidth: true
-
             label: qsTranslate("ExportSettingsDialog", "Write Subtitle Paths")
             //: Tooltip for the "Write Subtitle Paths" export setting.
             labelToolTip: qsTranslate("ExportSettingsDialog", "Include paths of manually imported subtitle files in the document header")
             checked: root.viewModel.temporaryWriteHeaderSubtitles
+
+            Layout.fillWidth: true
 
             onToggled: state => {
                 root.viewModel.temporaryWriteHeaderSubtitles = state;

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcImportSettingsDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/MpvqcImportSettingsDialog.qml
@@ -25,26 +25,27 @@ MpvqcDialog {
         spacing: 10
 
         RowLayout {
-            Layout.topMargin: 20
             spacing: 30
 
-            Label {
-                Layout.preferredWidth: 165
+            Layout.topMargin: 20
 
+            Label {
                 text: qsTranslate("ImportSettingsDialog", "Open video if found")
                 horizontalAlignment: Text.AlignRight
                 wrapMode: Text.Wrap
+
+                Layout.preferredWidth: 165
             }
 
             ComboBox {
                 objectName: "importFoundVideoComboBox"
 
-                Layout.preferredWidth: 165
-
                 textRole: "text"
                 valueRole: "value"
 
                 model: ImportOptionsModel {}
+
+                Layout.preferredWidth: 165
 
                 onActivated: value => {
                     root.viewModel.importFoundVideo = value;

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/Shortcuts/MpvqcShortcutDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/Shortcuts/MpvqcShortcutDialog.qml
@@ -54,9 +54,6 @@ MpvqcDialog {
             clip: true
             boundsBehavior: Flickable.StopAtBounds
 
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-
             model: MpvqcShortcutsModel {
                 query: _searchField.text
             }
@@ -100,6 +97,9 @@ MpvqcDialog {
                     rightPadding: 8
                 }
             }
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
 
             ScrollBar.vertical: ScrollBar {
                 id: _scrollBar

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/Shortcuts/tst_MpvqcShortcutDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/Shortcuts/tst_MpvqcShortcutDialog.qml
@@ -17,12 +17,6 @@ TestCase {
     when: windowShown
     name: "MpvqcShortcutDialog"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcShortcutDialog {}
-    }
-
     function makeDialog(): Dialog {
         const dialog = createTemporaryObject(objectUnderTest, testCase, {
             contentHeight: 540
@@ -113,5 +107,11 @@ TestCase {
 
         searchField.text = "ctrl+n";
         tryCompare(listView, "count", 1);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcShortcutDialog {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/Shortcuts/tst_MpvqcShortcutRow.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/Shortcuts/tst_MpvqcShortcutRow.qml
@@ -18,15 +18,6 @@ TestCase {
     when: windowShown
     name: "MpvqcShortcutRow"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcShortcutRow {
-            width: 380
-            label: "label"
-        }
-    }
-
     function makeControl(properties = {}): Item {
         const control = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(control);
@@ -220,5 +211,14 @@ TestCase {
 
         compare(keycaps[1].text, "Delete");
         verify(keycaps[1].contentItem.icon.source.toString() === "");
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcShortcutRow {
+            width: 380
+            label: "label"
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/tst_MpvqcDialogLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/tst_MpvqcDialogLoader.qml
@@ -20,12 +20,6 @@ TestCase {
 
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcDialogLoader {}
-    }
-
     function makeControl(): MpvqcDialogLoader {
         const control = createTemporaryObject(objectUnderTest, testCase);
         verify(control);
@@ -101,5 +95,11 @@ TestCase {
         waitUntilOpened(control);
         compare(control.item.objectName, data.objectName);
         testCase.bridge.waitForBackgroundJobs();
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcDialogLoader {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/FileDialogs/MpvqcExportCustomDocumentFileDialog.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/FileDialogs/MpvqcExportCustomDocumentFileDialog.qml
@@ -9,9 +9,9 @@ import io.github.mpvqc.mpvQC.Python
 FileDialog {
     objectName: "exportCustomDocumentFileDialog"
 
-    readonly property MpvqcExportFileDialogViewModel viewModel: MpvqcExportFileDialogViewModel {}
-
     required property url exportTemplate
+
+    readonly property MpvqcExportFileDialogViewModel viewModel: MpvqcExportFileDialogViewModel {}
 
     title: qsTranslate("FileInteractionDialogs", "Save QC Document As")
     fileMode: FileDialog.SaveFile

--- a/qt/qml/io/github/mpvqc/mpvQC/FileDialogs/tst_MpvqcFileDialogLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/FileDialogs/tst_MpvqcFileDialogLoader.qml
@@ -20,12 +20,6 @@ TestCase {
 
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcFileDialogLoader {}
-    }
-
     function makeControl(): MpvqcFileDialogLoader {
         const control = createTemporaryObject(objectUnderTest, testCase);
         verify(control);
@@ -109,5 +103,11 @@ TestCase {
         tryVerify(() => !control.item);
         verify(!control.active);
         testCase.bridge.waitForBackgroundJobs();
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcFileDialogLoader {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/MessageBoxes/tst_MpvqcMessageBoxLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/MessageBoxes/tst_MpvqcMessageBoxLoader.qml
@@ -20,12 +20,6 @@ TestCase {
 
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcMessageBoxLoader {}
-    }
-
     function makeControl(): MpvqcMessageBoxLoader {
         const control = createTemporaryObject(objectUnderTest, testCase);
         verify(control);
@@ -76,5 +70,11 @@ TestCase {
         waitUntilOpened(control);
         compare(control.item.objectName, data.objectName);
         testCase.bridge.waitForBackgroundJobs();
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcMessageBoxLoader {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Utility/MpvqcTheme.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Utility/MpvqcTheme.qml
@@ -11,6 +11,9 @@ import io.github.mpvqc.mpvQC.Python
 QtObject {
     id: root
 
+    // Mutable, not readonly: the QML test harness swaps in a fresh view model per test.
+    property MpvqcThemeViewModel _viewModel: MpvqcThemeViewModel {}
+
     readonly property bool isDark: root._viewModel.isDark
 
     readonly property color listStripe: Qt.alpha(palette.foreground, isDark ? 0.04 : 0.08)
@@ -47,19 +50,6 @@ QtObject {
         }
     }
 
-    component AnimatedColor: QtObject {
-        required property color value
-
-        Behavior on value {
-            ColorAnimation {
-                duration: 150
-            }
-        }
-    }
-
-    // Mutable, not readonly: the QML test harness swaps in a fresh view model per test.
-    property MpvqcThemeViewModel _viewModel: MpvqcThemeViewModel {}
-
     // qmlformat off
     readonly property AnimatedColor _background: AnimatedColor { value: root._viewModel.palette.background }
     readonly property AnimatedColor _foreground: AnimatedColor { value: root._viewModel.palette.foreground }
@@ -82,4 +72,14 @@ QtObject {
     readonly property AnimatedColor _rowSelected: AnimatedColor { value: root._viewModel.palette.rowSelected }
     readonly property AnimatedColor _rowSelectedText: AnimatedColor { value: root._viewModel.palette.rowSelectedText }
     // qmlformat on
+
+    component AnimatedColor: QtObject {
+        required property color value
+
+        Behavior on value {
+            ColorAnimation {
+                duration: 150
+            }
+        }
+    }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Utility/tst_MpvqcWindowUtility.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Utility/tst_MpvqcWindowUtility.qml
@@ -11,12 +11,6 @@ TestCase {
     id: testCase
     name: "MpvqcWindowUtility"
 
-    Item {
-        id: frame
-        width: 300
-        height: 200
-    }
-
     function cleanup(): void {
         MpvqcWindowUtility.contentFrame = null;
     }
@@ -108,5 +102,11 @@ TestCase {
         const result = MpvqcWindowUtility.isInBottomRegion(frame, 0, data.y, data.pixels);
 
         compare(result, data.expected);
+    }
+
+    Item {
+        id: frame
+        width: 300
+        height: 200
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/MpvqcFooterContextMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/MpvqcFooterContextMenu.qml
@@ -24,6 +24,15 @@ MpvqcMenu {
 
     modal: true
 
+    // Workaround for QTBUG-145585: on Windows the Popup.Window menu can
+    // deliver a spurious release event while closing, causing MenuItem to
+    // auto-toggle a second time and leaving `checked` out of sync with the
+    // view-model. Force-resync on both lifecycle edges:
+    //   - aboutToShow: pick up any external changes made while closed.
+    //   - closed:      undo the spurious toggle delivered during close.
+    onAboutToShow: _percentMenuItem.checked = root.isPercentChecked
+    onClosed: _percentMenuItem.checked = root.isPercentChecked
+
     MenuItem {
         objectName: "defaultFormatMenuItem"
 
@@ -79,13 +88,4 @@ MpvqcMenu {
 
         onTriggered: root.percentToggled()
     }
-
-    // Workaround for QTBUG-145585: on Windows the Popup.Window menu can
-    // deliver a spurious release event while closing, causing MenuItem to
-    // auto-toggle a second time and leaving `checked` out of sync with the
-    // view-model. Force-resync on both lifecycle edges:
-    //   - aboutToShow: pick up any external changes made while closed.
-    //   - closed:      undo the spurious toggle delivered during close.
-    onAboutToShow: _percentMenuItem.checked = root.isPercentChecked
-    onClosed: _percentMenuItem.checked = root.isPercentChecked
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/MpvqcFooterView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/MpvqcFooterView.qml
@@ -124,8 +124,6 @@ Item {
         active: false
         asynchronous: true
 
-        onLoaded: (item as MpvqcFooterContextMenu).open()
-
         sourceComponent: MpvqcFooterContextMenu {
             x: isMirrored ? _toolButtonContainer.x : _toolButtonContainer.x + _toolButtonContainer.width - width
             y: -height
@@ -143,6 +141,8 @@ Item {
             onHideTimePicked: root.viewModel.timeFormat = MpvqcTimeFormat.TimeFormat.EMPTY
             onPercentToggled: root.viewModel.toggleStatusbarPercentage()
         }
+
+        onLoaded: (item as MpvqcFooterContextMenu).open()
     }
 
     MpvqcFooterContextMenuClickGuard {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/tst_MpvqcFooterView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/tst_MpvqcFooterView.qml
@@ -18,24 +18,6 @@ TestCase {
     when: windowShown
     name: "MpvqcFooterView"
 
-    Component {
-        id: objectUnderTest
-
-        Item {
-            width: testCase.width
-            height: testCase.height
-
-            MpvqcFooterView {
-                objectName: "footer"
-                selectedCommentIndex: 0
-                totalCommentCount: 0
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-            }
-        }
-    }
-
     function makeControl(props): var {
         const control = createTemporaryObject(objectUnderTest, testCase);
         verify(control);
@@ -262,5 +244,23 @@ TestCase {
         mouseClick(button, button.width / 2, button.height / 2);
         tryVerify(() => menuItem.visible);
         compare(menuItem.checked, data.expectedChecked);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        Item {
+            width: testCase.width
+            height: testCase.height
+
+            MpvqcFooterView {
+                objectName: "footer"
+                selectedCommentIndex: 0
+                totalCommentCount: 0
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcHeaderView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcHeaderView.qml
@@ -84,13 +84,14 @@ Item {
         Label {
             id: _title
 
-            Layout.fillWidth: true
-            Layout.preferredHeight: root.menuBarHeight
-            Layout.rightMargin: root.minTitleSpacing
             text: root.viewModel.windowTitle
             elide: Text.ElideLeft
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.menuBarHeight
+            Layout.rightMargin: root.minTitleSpacing
         }
 
         MpvqcHeaderWindowButtons {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcHeaderWindowButtons.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcHeaderWindowButtons.qml
@@ -14,7 +14,7 @@ import io.github.mpvqc.mpvQC.Utility
 Row {
     id: root
 
-    readonly property MpvqcWindowButtonsViewModel windowButtons: MpvqcWindowButtonsViewModel {}
+    readonly property MpvqcWindowButtonsViewModel viewModel: MpvqcWindowButtonsViewModel {}
 
     // Deliberate platform polish: Windows paints its close button in its own
     // caption red, every other desktop uses the theme's error color.
@@ -28,7 +28,7 @@ Row {
         id: _minimizeButton
         objectName: "minimizeButton"
 
-        visible: root.windowButtons.showMinimizeButton
+        visible: root.viewModel.showMinimizeButton
         height: root.height
         focusPolicy: Qt.NoFocus
         icon.width: 20
@@ -50,7 +50,7 @@ Row {
         readonly property url iconMaximize: MpvqcIcons.openInFull
         readonly property url iconNormalize: MpvqcIcons.closeFullscreen
 
-        visible: root.windowButtons.showMaximizeButton
+        visible: root.viewModel.showMaximizeButton
         height: root.height
         focusPolicy: Qt.NoFocus
         icon.width: 18
@@ -73,7 +73,7 @@ Row {
         readonly property color idleIconColor: MpvqcTheme.palette.foreground
         readonly property color backgroundColor: root.isWindows ? "#C42C1E" : MpvqcTheme.palette.error
 
-        visible: root.windowButtons.showCloseButton
+        visible: root.viewModel.showCloseButton
         height: root.height
         focusPolicy: Qt.NoFocus
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcHeaderWindowButtons.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcHeaderWindowButtons.qml
@@ -14,10 +14,11 @@ import io.github.mpvqc.mpvQC.Utility
 Row {
     id: root
 
+    readonly property MpvqcWindowButtonsViewModel windowButtons: MpvqcWindowButtonsViewModel {}
+
     // Deliberate platform polish: Windows paints its close button in its own
     // caption red, every other desktop uses the theme's error color.
     readonly property bool isWindows: Qt.platform.os === "windows"
-    readonly property MpvqcWindowButtonsViewModel windowButtons: MpvqcWindowButtonsViewModel {}
 
     signal minimizeRequested
     signal toggleMaximizeRequested

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcLanguageSubMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcLanguageSubMenu.qml
@@ -14,14 +14,14 @@ MpvqcMenuBarMenu {
     id: root
     objectName: "languageMenu"
 
+    // Applying the language retranslates and reshuffles the menu's geometry;
+    // deferring until onClosed hides that churn from the user.
+    property string _pendingLanguage: ""
+
     signal languageSelected(identifier: string)
 
     title: qsTranslate("MainWindow", "Language")
     icon.source: MpvqcIcons.language
-
-    // Applying the language retranslates and reshuffles the menu's geometry;
-    // deferring until onClosed hides that churn from the user.
-    property string _pendingLanguage: ""
 
     onClosed: {
         if (_pendingLanguage) {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcToolBarView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Header/MpvqcToolBarView.qml
@@ -23,8 +23,6 @@ Item {
 
     readonly property bool anyButtonVisible: root.viewModel.frameStepActive || root.viewModel.subtitleActive || root.viewModel.audioActive
 
-    width: _row.width
-
     component MpvqcToolBarSlot: Item {
         id: _slot
 
@@ -77,6 +75,8 @@ Item {
             }
         }
     }
+
+    width: _row.width
 
     QtObject {
         id: _stagger

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Header/tst_MpvqcHeaderWindowButtons.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Header/tst_MpvqcHeaderWindowButtons.qml
@@ -18,21 +18,6 @@ TestCase {
     when: windowShown
     name: "MpvqcHeaderWindowButtons"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcHeaderWindowButtons {
-            height: 40
-            width: testCase.width
-        }
-    }
-
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
-
     function makeControl(initProperties = {}) {
         const control = createTemporaryObject(objectUnderTest, testCase, initProperties);
         verify(control);
@@ -146,5 +131,20 @@ TestCase {
         const button = findChild(control, "closeButton");
 
         compare(button.idleIconColor, MpvqcTheme.palette.foreground);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcHeaderWindowButtons {
+            height: 40
+            width: testCase.width
+        }
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Player/MpvqcNewCommentMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Player/MpvqcNewCommentMenu.qml
@@ -16,12 +16,12 @@ MpvqcPositionedMenu {
 
     property var viewModel: MpvqcNewCommentMenuViewModel {}
 
+    signal commentTypeChosen(commentType: string)
+
     function calculatePosition(): point {
         const global = viewModel.cursorPosition();
         return parent.mapFromGlobal(global);
     }
-
-    signal commentTypeChosen(commentType: string)
 
     visible: false
     z: 2

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Player/MpvqcPlayerEmbedded.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Player/MpvqcPlayerEmbedded.qml
@@ -9,6 +9,14 @@ import io.github.mpvqc.mpvQC.Python // qmllint disable unused-imports
 WindowContainer {
     id: root
 
+    function _resyncChildGeometry(): void {
+        const w = root.width;
+        if (w > 1) {
+            root.window.width = w - 1;
+            root.window.width = w;
+        }
+    }
+
     window: MpvWindowPyObject {} // qmllint disable import
 
     // Workaround: on Windows, when the top-level transitions through
@@ -22,14 +30,6 @@ WindowContainer {
             if (visibility !== Window.Minimized) {
                 Qt.callLater(root._resyncChildGeometry);
             }
-        }
-    }
-
-    function _resyncChildGeometry(): void {
-        const w = root.width;
-        if (w > 1) {
-            root.window.width = w - 1;
-            root.window.width = w;
         }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Player/MpvqcPlayerInputArea.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Player/MpvqcPlayerInputArea.qml
@@ -16,19 +16,6 @@ MouseArea {
 
     property bool showCursor: true
 
-    signal addNewCommentMenuRequested
-    signal toggleFullScreenRequested
-    signal windowActivationRequested
-
-    signal mouseMoved(real x, real y)
-    signal wheelScrolledUp
-    signal wheelScrolledDown
-    signal leftMousePressed
-    signal leftMouseReleased
-    signal middleMousePressed
-    signal backMousePressed
-    signal forwardMousePressed
-
     property var cursorTimer: Timer {
         running: root.showCursor && root.isFullScreen && root.containsMouse
         repeat: true
@@ -38,6 +25,19 @@ MouseArea {
             root.showCursor = false;
         }
     }
+
+    signal addNewCommentMenuRequested
+    signal toggleFullScreenRequested
+    signal windowActivationRequested
+
+    signal mouseMoved(x: real, y: real)
+    signal wheelScrolledUp
+    signal wheelScrolledDown
+    signal leftMousePressed
+    signal leftMouseReleased
+    signal middleMousePressed
+    signal backMousePressed
+    signal forwardMousePressed
 
     acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton | Qt.BackButton | Qt.ForwardButton
     cursorShape: !root.showCursor && root.isFullScreen ? Qt.BlankCursor : Qt.ArrowCursor

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Player/tst_MpvqcNewCommentMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Player/tst_MpvqcNewCommentMenu.qml
@@ -14,39 +14,6 @@ TestCase {
     when: windowShown
     name: "MpvqcNewCommentMenu"
 
-    Component {
-        id: signalSpy
-
-        SignalSpy {
-            function invocation(invocation: int): var {
-                const inv = signalArguments[invocation];
-                return {
-                    arg: index => inv[index]
-                };
-            }
-        }
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcNewCommentMenu {
-            id: menu
-
-            property int pausePlayerCount: 0
-
-            viewModel: QtObject {
-                readonly property var commentTypes: ["1", "ABC", "3", "4"]
-                function cursorPosition(): point {
-                    return Qt.point(0, 0);
-                }
-                function pausePlayer(): void {
-                    menu.pausePlayerCount += 1;
-                }
-            }
-        }
-    }
-
     function makeControl(): var {
         const control = createTemporaryObject(objectUnderTest, testCase, {});
         verify(control);
@@ -95,5 +62,38 @@ TestCase {
 
         control.close();
         tryCompare(control, "visible", false);
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {
+            function invocation(invocation: int): var {
+                const inv = signalArguments[invocation];
+                return {
+                    arg: index => inv[index]
+                };
+            }
+        }
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcNewCommentMenu {
+            id: menu
+
+            property int pausePlayerCount: 0
+
+            viewModel: QtObject {
+                readonly property var commentTypes: ["1", "ABC", "3", "4"]
+                function cursorPosition(): point {
+                    return Qt.point(0, 0);
+                }
+                function pausePlayer(): void {
+                    menu.pausePlayerCount += 1;
+                }
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Player/tst_MpvqcPlayerInputArea.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Player/tst_MpvqcPlayerInputArea.qml
@@ -14,30 +14,6 @@ TestCase {
     when: windowShown
     name: "MpvqcPlayerInputArea"
 
-    Component {
-        id: objectUnderTest
-
-        MpvqcPlayerInputArea {
-            width: 200
-            height: 200
-
-            embedsNativePlayer: false
-        }
-    }
-
-    Component {
-        id: signalSpy
-
-        SignalSpy {
-            function invocation(invocation: int): var {
-                const inv = signalArguments[invocation];
-                return {
-                    arg: index => inv[index]
-                };
-            }
-        }
-    }
-
     function makeControl(initProperties = {}) {
         const control = createTemporaryObject(objectUnderTest, testCase, initProperties);
         verify(control);
@@ -211,5 +187,29 @@ TestCase {
         compare(control.cursorTimer.running, false);
         compare(control.showCursor, true);
         compare(control.cursorShape, Qt.ArrowCursor);
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcPlayerInputArea {
+            width: 200
+            height: 200
+
+            embedsNativePlayer: false
+        }
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {
+            function invocation(invocation: int): var {
+                const inv = signalArguments[invocation];
+                return {
+                    arg: index => inv[index]
+                };
+            }
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcDeleteConfirmationLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcDeleteConfirmationLoader.qml
@@ -63,8 +63,6 @@ Loader {
                 }
 
                 Label {
-                    Layout.fillWidth: true
-                    Layout.topMargin: 20
                     textFormat: Text.StyledText
                     horizontalAlignment: Text.AlignLeft
                     wrapMode: Label.WordWrap
@@ -83,6 +81,9 @@ Loader {
 
                         return `${time}${separator}${type}${separator}${comment}`;
                     }
+
+                    Layout.fillWidth: true
+                    Layout.topMargin: 20
                 }
             }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditTimePopup.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditTimePopup.qml
@@ -58,10 +58,6 @@ Popup {
     width: 155
     padding: 6
 
-    M.Material.background: MpvqcTheme.palette.popupBackground
-    M.Material.foreground: MpvqcTheme.palette.popupText
-    M.Material.roundedScale: M.Material.SmallScale
-
     contentItem: SpinBox {
         id: _spinBox
         objectName: "timeSpinBox"
@@ -106,6 +102,18 @@ Popup {
         }
     }
 
+    M.Material.background: MpvqcTheme.palette.popupBackground
+    M.Material.foreground: MpvqcTheme.palette.popupText
+    M.Material.roundedScale: M.Material.SmallScale
+
+    onAboutToHide: {
+        if (acceptValue && root.currentTime !== _spinBox.value) {
+            root.timeEdited(root.currentListIndex, _spinBox.value);
+        } else {
+            root.timeKept(root.currentTime);
+        }
+    }
+
     MouseArea {
         anchors.fill: _spinBox.contentItem
         hoverEnabled: true
@@ -118,14 +126,6 @@ Popup {
             } else {
                 root.decrementValue();
             }
-        }
-    }
-
-    onAboutToHide: {
-        if (acceptValue && root.currentTime !== _spinBox.value) {
-            root.timeEdited(root.currentListIndex, _spinBox.value);
-        } else {
-            root.timeKept(root.currentTime);
         }
     }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcSearchBoxLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcSearchBoxLoader.qml
@@ -31,11 +31,11 @@ Loader {
     active: false
     visible: active
 
-    onLoaded: (item as MpvqcSearchBoxPopup).open()
-
     sourceComponent: MpvqcSearchBoxPopup {
         parent: root.parent
         viewModel: root.viewModel
         onClosed: root.closed()
     }
+
+    onLoaded: (item as MpvqcSearchBoxPopup).open()
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcSearchBoxPopup.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcSearchBoxPopup.qml
@@ -22,12 +22,13 @@ Popup {
 
     readonly property int edgeMarginHorizontal: 30
     readonly property int edgeMarginVertical: 15
+
+    property bool searchActive: false
+
     readonly property real _dragScaleFactor: 1.0375
 
     readonly property bool _anyChildHovered: _textFieldHover.hovered || (_previousButton.enabled && _previousButton.hovered) || (_nextButton.enabled && _nextButton.hovered) || _closeButton.hovered
     readonly property bool _shouldScaleUp: _dragHandler.active || (_dragHandler.isPressed && !_anyChildHovered)
-
-    property bool searchActive: false
 
     function closeWithoutAnimation(): void {
         const exitAnimation = exit;
@@ -46,18 +47,7 @@ Popup {
 
     scale: _shouldScaleUp ? _dragScaleFactor : 1
 
-    Behavior on scale {
-        enabled: root.opened
-        NumberAnimation {
-            duration: 75
-        }
-    }
-
     closePolicy: Popup.NoAutoClose
-
-    M.Material.background: MpvqcTheme.palette.popupBackground
-    M.Material.foreground: MpvqcTheme.palette.popupText
-    M.Material.roundedScale: M.Material.SmallScale
 
     enter: Transition {
         NumberAnimation {
@@ -75,6 +65,10 @@ Popup {
             easing.type: Easing.OutCubic
         }
     }
+
+    M.Material.background: MpvqcTheme.palette.popupBackground
+    M.Material.foreground: MpvqcTheme.palette.popupText
+    M.Material.roundedScale: M.Material.SmallScale
 
     onAboutToShow: {
         root.searchActive = true;
@@ -105,8 +99,6 @@ Popup {
 
         MpvqcIconLabel {
             objectName: "searchIconLabel"
-            Layout.leftMargin: 8
-            Layout.rightMargin: 4
 
             icon {
                 source: MpvqcIcons.search
@@ -114,16 +106,20 @@ Popup {
                 width: 24
                 color: MpvqcTheme.palette.hint
             }
+
+            Layout.leftMargin: 8
+            Layout.rightMargin: 4
         }
 
         TextField {
             id: _textField
             objectName: "searchTextField"
 
-            Layout.fillWidth: true
             focus: false
             selectByMouse: true
             horizontalAlignment: Text.AlignLeft
+
+            Layout.fillWidth: true
 
             ContextMenu.menu: null
 
@@ -136,16 +132,16 @@ Popup {
                 }
             }
 
-            HoverHandler {
-                id: _textFieldHover
-                objectName: "searchTextFieldCursorHandler"
-                cursorShape: _dragHandler.active ? Qt.ClosedHandCursor : Qt.IBeamCursor
-            }
-
             Component.onCompleted: {
                 background.fillColor = "transparent";
                 background.outlineColor = "transparent";
                 background.focusedOutlineColor = "transparent";
+            }
+
+            HoverHandler {
+                id: _textFieldHover
+                objectName: "searchTextFieldCursorHandler"
+                cursorShape: _dragHandler.active ? Qt.ClosedHandCursor : Qt.IBeamCursor
             }
         }
 
@@ -234,11 +230,6 @@ Popup {
             id: _closeButton
             objectName: "closeButton"
 
-            Layout.preferredWidth: 36
-            Layout.preferredHeight: 36
-            Layout.leftMargin: 3
-            Layout.rightMargin: 3
-
             focusPolicy: Qt.NoFocus
 
             icon {
@@ -246,6 +237,11 @@ Popup {
                 height: 18
                 source: MpvqcIcons.close
             }
+
+            Layout.preferredWidth: 36
+            Layout.preferredHeight: 36
+            Layout.leftMargin: 3
+            Layout.rightMargin: 3
 
             onClicked: root.close()
 
@@ -302,5 +298,12 @@ Popup {
         target: root
         property: "y"
         value: _dragHandler.snapToBottom && !_dragHandler.active ? _dragHandler.maxY : _dragHandler.targetY
+    }
+
+    Behavior on scale {
+        enabled: root.opened
+        NumberAnimation {
+            duration: 75
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcTableView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcTableView.qml
@@ -11,11 +11,12 @@ Item {
     objectName: "tableView"
 
     property MpvqcCommentTableViewModel viewModel: MpvqcCommentTableViewModel {}
-    property bool backupEnabled: true
 
     readonly property alias commentCount: _commentList.count
     readonly property alias selectedCommentIndex: _commentList.currentIndex
     readonly property alias commentList: _commentList
+
+    property bool backupEnabled: true
 
     function forceActiveFocus(): void {
         _commentList.forceActiveFocus();

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/TestHelpers.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/TestHelpers.qml
@@ -47,6 +47,10 @@ QtObject {
         MpvqcTableView {
             id: _mockVmControl
 
+            function getItem(index: int, property: string): var {
+                return root.bridge.comment(index)[property];
+            }
+
             backupEnabled: false
 
             viewModel: MpvqcCommentTableViewModel {
@@ -93,32 +97,7 @@ QtObject {
                 ]);
                 _mockVmControl.commentList.currentIndex = 0;
             }
-
-            function getItem(index: int, property: string): var {
-                return root.bridge.comment(index)[property];
-            }
         }
-    }
-
-    function initTestCase(): void {
-        MpvqcLabelWidthCalculator.timeLabelWidth = 50;
-        MpvqcLabelWidthCalculator.commentTypesLabelWidth = 150;
-    }
-
-    function makeControl(): var {
-        root.bridge.resetComments();
-        const control = root.testCase.createTemporaryObject(root.objectUnderTest, root.testCase);
-        root.testCase.verify(control);
-        root.testCase.waitForRendering(control);
-        return control;
-    }
-
-    function makeRealCommentTypesControl(): var {
-        root.bridge.resetComments();
-        const control = root.testCase.createTemporaryObject(root.objectWithRealCommentTypes, root.testCase);
-        root.testCase.verify(control);
-        root.testCase.waitForRendering(control);
-        return control;
     }
 
     readonly property var clickHelper: QtObject {
@@ -244,6 +223,12 @@ QtObject {
     readonly property var expect: QtObject {
         id: _expect
 
+        readonly property var _editorObjectNames: ({
+                "timePopup": "editTimePopup",
+                "commentTypeMenu": "editCommentTypeMenu",
+                "commentPopup": "editCommentPopup"
+            })
+
         function _anyEditorOpen(control: MpvqcTableView): bool {
             const tc = root.testCase;
             for (const name of ["editTimePopup", "editCommentPopup", "editCommentTypeMenu"]) {
@@ -331,12 +316,6 @@ QtObject {
         function hasEventuallyCount(control: MpvqcTableView, expected: int): void {
             root.testCase.tryVerify(() => control.commentCount === expected);
         }
-
-        readonly property var _editorObjectNames: ({
-                "timePopup": "editTimePopup",
-                "commentTypeMenu": "editCommentTypeMenu",
-                "commentPopup": "editCommentPopup"
-            })
 
         function isEditorShowing(control: MpvqcTableView, editor: string): void {
             const name = _editorObjectNames[editor];
@@ -465,6 +444,27 @@ QtObject {
             root.testCase.tryVerify(() => !root.testCase.findChild(control, "searchBoxPopup")?.searchActive);
             root.testCase.tryVerify(() => !root.testCase.findChild(control, "searchBoxPopup")?.opened);
         }
+    }
+
+    function initTestCase(): void {
+        MpvqcLabelWidthCalculator.timeLabelWidth = 50;
+        MpvqcLabelWidthCalculator.commentTypesLabelWidth = 150;
+    }
+
+    function makeControl(): var {
+        root.bridge.resetComments();
+        const control = root.testCase.createTemporaryObject(root.objectUnderTest, root.testCase);
+        root.testCase.verify(control);
+        root.testCase.waitForRendering(control);
+        return control;
+    }
+
+    function makeRealCommentTypesControl(): var {
+        root.bridge.resetComments();
+        const control = root.testCase.createTemporaryObject(root.objectWithRealCommentTypes, root.testCase);
+        root.testCase.verify(control);
+        root.testCase.waitForRendering(control);
+        return control;
     }
 
     function typeWord(word: string): void {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcCommentListKeyHandler.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcCommentListKeyHandler.qml
@@ -14,22 +14,6 @@ TestCase {
     visible: true
     when: windowShown
 
-    Component {
-        id: signalSpy
-
-        SignalSpy {}
-    }
-
-    Component {
-        id: objectUnderTest
-
-        MpvqcCommentListKeyHandler {
-            hasComments: true
-            ignoreEvents: false
-            currentIndex: 0
-        }
-    }
-
     function makeControl(properties: var): var {
         const control = createTemporaryObject(objectUnderTest, testCase, properties ?? {});
         verify(control);
@@ -442,5 +426,21 @@ TestCase {
         });
         control.handleKeyPress(data.event);
         data.verify(spy, data.event);
+    }
+
+    Component {
+        id: signalSpy
+
+        SignalSpy {}
+    }
+
+    Component {
+        id: objectUnderTest
+
+        MpvqcCommentListKeyHandler {
+            hasComments: true
+            ignoreEvents: false
+            currentIndex: 0
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView.qml
@@ -10,13 +10,13 @@ import QtTest
 TestCase {
     id: testCase
 
+    width: 600
+    height: 400
+    visible: true
+    when: windowShown
+    name: "MpvqcTableView::Integration"
+
     readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
 
     readonly property Component emptyControl: Component {
         MpvqcTableView {
@@ -26,12 +26,6 @@ TestCase {
             width: testCase.width
         }
     }
-
-    width: 600
-    height: 400
-    visible: true
-    when: windowShown
-    name: "MpvqcTableView::Integration"
 
     function initTestCase(): void {
         _helpers.initTestCase();
@@ -101,5 +95,11 @@ TestCase {
         control.forceActiveFocus();
 
         tryVerify(() => control.commentList.activeFocus);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Backup.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Backup.qml
@@ -13,6 +13,12 @@ import io.github.mpvqc.mpvQC.Utility
 TestCase {
     id: testCase
 
+    width: 600
+    height: 400
+    visible: true
+    when: windowShown
+    name: "MpvqcTableView::Backup"
+
     readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
 
     readonly property Component control: Component {
@@ -23,12 +29,6 @@ TestCase {
             width: testCase.width
         }
     }
-
-    width: 600
-    height: 400
-    visible: true
-    when: windowShown
-    name: "MpvqcTableView::Backup"
 
     function initTestCase(): void {
         MpvqcLabelWidthCalculator.timeLabelWidth = 50;

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_CommentTypes.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_CommentTypes.qml
@@ -10,24 +10,18 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
+    width: 600
+    height: 400
+    visible: true
+    when: windowShown
+    name: "MpvqcTableView::CommentTypes"
 
     readonly property alias _clickHelper: _helpers.clickHelper
     readonly property alias _expect: _helpers.expect
     readonly property alias _find: _helpers.find
     readonly property alias _wait: _helpers.wait
 
-    width: 600
-    height: 400
-    visible: true
-    when: windowShown
-    name: "MpvqcTableView::CommentTypes"
+    readonly property int timeout: 2000
 
     function initTestCase(): void {
         _helpers.initTestCase();
@@ -49,5 +43,11 @@ TestCase {
         for (const commentType of expected) {
             verify(menu.commentTypes.includes(commentType), `Missing comment type: ${commentType}. Menu has types: ${menu.commentTypes.join(", ")} includes`);
         }
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_ContextMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_ContextMenu.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::ContextMenu"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -263,5 +257,11 @@ TestCase {
         _wait.contextMenuClosed(control);
         _expect.hasContextMenuClosed(control);
         _expect.hasActiveFocus(control);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingComment.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingComment.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::EditingComment"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -311,5 +305,11 @@ TestCase {
         keyPress(Qt.Key_Return);
         _wait.editControlOpened(control);
         _expect.isEditing(control);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingCommentScroll.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingCommentScroll.qml
@@ -10,32 +10,26 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::EditingCommentScroll"
 
-    function initTestCase(): void {
-        _helpers.initTestCase();
-    }
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
 
     property var control: null
 
     readonly property string _longComment: "This is a very long comment that should wrap across multiple lines and force the inline editor to grow significantly larger than its initial single-line height, exercising the scroll-on-grow behaviour for the row being edited."
+
+    function initTestCase(): void {
+        _helpers.initTestCase();
+    }
 
     function init(): void {
         control = _helpers.makeControl();
@@ -200,5 +194,11 @@ TestCase {
 
         const bottomAfterTyping = _delegateBottomInViewport(list, newLastIndex);
         verify(bottomAfterTyping <= list.height + 1, `After typing: last delegate bottom (${bottomAfterTyping}) within viewport (${list.height})`);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingCommentType.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingCommentType.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::EditingCommentType"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -230,5 +224,11 @@ TestCase {
         _expect.isNotEditing(control);
         _expect.hasItemCommentType(control, 2, "Comment Type 3");
         _expect.hasActiveFocus(control);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingTime.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingTime.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::EditingTime"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -340,5 +334,11 @@ TestCase {
 
         tryVerify(() => control.commentList.currentIndex === 4);
         _expect.hasItemComment(control, 4, "Comment 3");
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBox.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBox.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::SearchBox"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -352,5 +346,11 @@ TestCase {
         keyPress(Qt.Key_F, Qt.ControlModifier);
         _wait.searchBoxOpened(control);
         _expect.hasSearchBoxOpen(control);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBoxPosition.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBoxPosition.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::SearchBoxPosition"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -312,5 +306,11 @@ TestCase {
 
         mouseRelease(dragArea, cx, cy - 100);
         compare(cursorHandler.cursorShape, Qt.ArrowCursor, "drag-release-enabled");
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Selection.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Selection.qml
@@ -10,30 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::Selection"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -464,5 +458,11 @@ TestCase {
         const items = _helpers.getCommentTypeItems(control);
         const expected = ["Comment Type 1", "Comment Type 2", "Comment Type 3", "Comment Type 4", "Comment Type 5", "Legacy Type"];
         compare(items.map(item => item.commentType), expected);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Undo.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Undo.qml
@@ -10,86 +10,24 @@ import QtTest
 TestCase {
     id: testCase
 
-    readonly property int timeout: 2000
-
-    readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
-    readonly property alias _wait: _helpers.wait
-
-    TestHelpers {
-        id: _helpers
-
-        testCase: testCase
-    }
-
-    QtObject {
-        id: _undoHelpers
-
-        function importMixedComments(count: int): void {
-            const longText = "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.";
-            const filler = [];
-            for (let i = 0; i < count; i++) {
-                const isLong = i % 10 === 0;
-                filler.push({
-                    "time": 100 + i,
-                    "commentType": "Comment Type 1",
-                    "comment": isLong ? `Row ${i}: ${longText}` : `Row ${i}`
-                });
-            }
-            _helpers.bridge.importComments(filler);
-            testCase.waitForRendering(testCase.control);
-        }
-
-        function editComment(row: int, newText: string): string {
-            const originalText = _helpers.bridge.comment(row).comment;
-            testCase.control.commentList.currentIndex = row;
-            testCase.waitForRendering(testCase.control);
-            testCase.control.viewModel.updateComment(row, newText);
-            testCase.waitForRendering(testCase.control);
-            testCase.compare(_helpers.bridge.comment(row).comment, newText);
-            return originalText;
-        }
-
-        function editTime(srcRow: int, newTime: int): var {
-            const original = _helpers.bridge.comment(srcRow);
-            testCase.control.commentList.currentIndex = srcRow;
-            testCase.waitForRendering(testCase.control);
-            testCase.control.viewModel.updateTime(srcRow, newTime);
-            testCase.tryVerify(() => testCase.control.viewModel.selection.selectedRowVisible === true);
-            const dstRow = testCase.control.commentList.currentIndex;
-            testCase.compare(_helpers.bridge.comment(dstRow).time, newTime);
-            return {
-                "dstRow": dstRow,
-                "originalTime": original.time,
-                "originalComment": original.comment
-            };
-        }
-
-        function scrollSelectionOffscreen(): void {
-            const list = testCase.control.commentList;
-            for (let i = 0; i < 20; i++) {
-                if (!testCase.control.viewModel.selection.selectedRowVisible) {
-                    break;
-                }
-                testCase.mouseWheel(list, list.width / 2, list.height / 2, 0, -120, Qt.NoButton, Qt.NoModifier);
-            }
-            testCase.waitForRendering(testCase.control);
-            testCase.tryVerify(() => testCase.control.viewModel.selection.selectedRowVisible === false);
-        }
-    }
-
     width: 600
     height: 400
     visible: true
     when: windowShown
     name: "MpvqcTableView::Undo"
 
+    readonly property alias _clickHelper: _helpers.clickHelper
+    readonly property alias _expect: _helpers.expect
+    readonly property alias _find: _helpers.find
+    readonly property alias _wait: _helpers.wait
+
+    readonly property int timeout: 2000
+
+    property var control: null
+
     function initTestCase(): void {
         _helpers.initTestCase();
     }
-
-    property var control: null
 
     function init(): void {
         control = _helpers.makeControl();
@@ -362,5 +300,67 @@ TestCase {
         tryVerify(() => _helpers.bridge.comment(6).comment === "second");
         compare(_helpers.bridge.comment(6).time, 8 * 1000);
         compare(_helpers.bridge.comment(0).comment, "first edited");
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
+    }
+
+    QtObject {
+        id: _undoHelpers
+
+        function importMixedComments(count: int): void {
+            const longText = "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.";
+            const filler = [];
+            for (let i = 0; i < count; i++) {
+                const isLong = i % 10 === 0;
+                filler.push({
+                    "time": 100 + i,
+                    "commentType": "Comment Type 1",
+                    "comment": isLong ? `Row ${i}: ${longText}` : `Row ${i}`
+                });
+            }
+            _helpers.bridge.importComments(filler);
+            testCase.waitForRendering(testCase.control);
+        }
+
+        function editComment(row: int, newText: string): string {
+            const originalText = _helpers.bridge.comment(row).comment;
+            testCase.control.commentList.currentIndex = row;
+            testCase.waitForRendering(testCase.control);
+            testCase.control.viewModel.updateComment(row, newText);
+            testCase.waitForRendering(testCase.control);
+            testCase.compare(_helpers.bridge.comment(row).comment, newText);
+            return originalText;
+        }
+
+        function editTime(srcRow: int, newTime: int): var {
+            const original = _helpers.bridge.comment(srcRow);
+            testCase.control.commentList.currentIndex = srcRow;
+            testCase.waitForRendering(testCase.control);
+            testCase.control.viewModel.updateTime(srcRow, newTime);
+            testCase.tryVerify(() => testCase.control.viewModel.selection.selectedRowVisible === true);
+            const dstRow = testCase.control.commentList.currentIndex;
+            testCase.compare(_helpers.bridge.comment(dstRow).time, newTime);
+            return {
+                "dstRow": dstRow,
+                "originalTime": original.time,
+                "originalComment": original.comment
+            };
+        }
+
+        function scrollSelectionOffscreen(): void {
+            const list = testCase.control.commentList;
+            for (let i = 0; i < 20; i++) {
+                if (!testCase.control.viewModel.selection.selectedRowVisible) {
+                    break;
+                }
+                testCase.mouseWheel(list, list.width / 2, list.height / 2, 0, -120, Qt.NoButton, Qt.NoModifier);
+            }
+            testCase.waitForRendering(testCase.control);
+            testCase.tryVerify(() => testCase.control.viewModel.selection.selectedRowVisible === false);
+        }
     }
 }


### PR DESCRIPTION
We pinned QML conventions in a skill recently: name-first signal parameters and one declaration order for every file.
The code predates that, so each file had to be read on its own terms. This brings all of it in line.

Almost all of it moves lines around. Every changed file except two is a pure permutation of what it was, checked
mechanically rather than by eye. The two exceptions: `MpvqcHeaderWindowButtons.qml` renames its `windowButtons`
property to `viewModel`, the name every other view uses, and two wizard test files swap an unnamespaced Material import
for `QtQuick.Controls`, which is what they actually needed. The skill also gained the rule that settled the one real
ambiguity: an object-valued assignment like `contentItem:` or `delegate:` is a property binding, not a child.

Both suites pass and qmllint reports the same 116 warnings as before, same files and same lines. That covers behaviour
but not looks, so the checks below are about what a reordering could have moved on screen. Most of it provably cannot:
`background` and `contentItem` are deferred properties, so pushing an attached Material binding past them changes
nothing, and `Behavior` and animation value sources never enter `contentData`. What is left is where that reasoning
does not hold, or where no test looks.

## Manual checks before merging

Three arrangements, one list each. Most items repeat because popups take a different path per platform:
`preferredPopupType` is `Popup.Window` on Windows and `Popup.Item` on Linux, so every popup below renders through
different code on each.

### Windows

#### Theme and appearance

- [x] Switching theme or accent in Options › Appearance cross-fades the whole window over ~150 ms instead of snapping
- [x] Launching the app shows no black or white flash before the theme colour lands
- [x] Opening the Appearance dialog fades the swatches in staggered, not all at once
- [x] Press and hold a swatch: it grows to 110% and springs back on release, both eased
- [x] The selection highlight slides to a newly picked swatch instead of jumping

#### Buttons and dialogs

- [x] Buttons are pill-shaped and their shadow deepens while pressed
- [x] Dialog footer buttons have accent-coloured text on a background rounded only at the bottom
- [x] A message box (Quit is easiest) shows no colour seam between its body and the footer button strip

#### Search box

- [x] Ctrl+F fades and grows the search box in over ~150 ms instead of popping into place
- [x] Pressing and dragging the search box grows and shrinks it smoothly rather than snapping
- [x] The search input shows no Material fill, underline, or focus outline against the popup background

#### Comment table popups

- [x] The search box and the time-edit popup both use the theme popup background with small rounded corners
- [x] The cursor is an I-beam over the digits in the time-edit popup
- [x] Deleting a comment shows the preview line below a clear gap, wrapped to the dialog width

#### Import wizard

- [x] Hovering a filename in the video step shows the full path as a tooltip, and the Skip video row shows none

#### Window layout

- [x] On a fresh launch the comment table pane is about 40% of the split rather than collapsed to its minimum. Restart
      to re-test, the ratio is not persisted

#### Status bar menu

- [x] Toggling Progress in percent, then reopening the menu, shows a checkmark matching the actual state. Known and
      accepted: this is the QTBUG-145585 workaround and cannot be covered on Linux CI

#### Video surface

- [x] Minimising and restoring the window leaves the video aligned with its frame, with no black slivers at the right
      or bottom

#### Right-to-left layout

- [x] In Hebrew, dialog footer buttons run right to left. This is the harder path here, because the dialog pushes the
      mirror flag on with a runtime `Binding` rather than inheriting it
- [x] In Hebrew, the wizard step indicator's fade sits over the clipped edge, not the visible one. Needs a language
      whose step labels overflow the 500 px content width

### Linux desktop

#### Theme and appearance

- [x] Switching theme or accent in Options › Appearance cross-fades the whole window over ~150 ms instead of snapping
- [x] Launching the app shows no black or white flash before the theme colour lands
- [x] Opening the Appearance dialog fades the swatches in staggered, not all at once
- [x] Press and hold a swatch: it grows to 110% and springs back on release, both eased
- [x] The selection highlight slides to a newly picked swatch instead of jumping

#### Buttons and dialogs

- [x] Buttons are pill-shaped and their shadow deepens while pressed
- [x] Dialog footer buttons have accent-coloured text on a background rounded only at the bottom
- [x] A message box (Quit is easiest) shows no colour seam between its body and the footer button strip

#### Search box

- [x] Ctrl+F fades and grows the search box in over ~150 ms instead of popping into place
- [x] Pressing and dragging the search box grows and shrinks it smoothly rather than snapping
- [x] The search input shows no Material fill, underline, or focus outline against the popup background

#### Comment table popups

- [x] The search box and the time-edit popup both use the theme popup background with small rounded corners
- [x] The cursor is an I-beam over the digits in the time-edit popup
- [x] Deleting a comment shows the preview line below a clear gap, wrapped to the dialog width

#### Import wizard

- [x] Hovering a filename in the video step shows the full path as a tooltip, and the Skip video row shows none

#### Window layout

- [x] On a fresh launch the comment table pane is 500 px wide, not collapsed to nothing. The 88 px shadow margin puts
      the 40% target under the 500 px minimum, so the clamp is expected here. Restart to re-test, the ratio is not
      persisted

#### Window controls

- [x] The title bar shows only the buttons the desktop's button-layout setting asks for, and follows a change to that
      setting while the app runs

#### Right-to-left layout

- [x] In Hebrew, dialog footer buttons run right to left
- [x] In Hebrew, the wizard step indicator's fade sits over the clipped edge, not the visible one. Needs a language
      whose step labels overflow the 500 px content width

### Linux tiling

#### Theme and appearance

- [x] Switching theme or accent in Options › Appearance cross-fades the whole window over ~150 ms instead of snapping
- [x] Launching the app shows no black or white flash before the theme colour lands
- [x] Opening the Appearance dialog fades the swatches in staggered, not all at once
- [x] Press and hold a swatch: it grows to 110% and springs back on release, both eased
- [x] The selection highlight slides to a newly picked swatch instead of jumping

#### Buttons and dialogs

- [x] Buttons are pill-shaped and their shadow deepens while pressed
- [x] Dialog footer buttons have accent-coloured text on a background rounded only at the bottom
- [x] A message box (Quit is easiest) shows no colour seam between its body and the footer button strip

#### Search box

- [x] Ctrl+F fades and grows the search box in over ~150 ms instead of popping into place
- [x] Pressing and dragging the search box grows and shrinks it smoothly rather than snapping
- [x] The search input shows no Material fill, underline, or focus outline against the popup background

#### Comment table popups

- [x] The search box and the time-edit popup both use the theme popup background with small rounded corners
- [x] The cursor is an I-beam over the digits in the time-edit popup
- [x] Deleting a comment shows the preview line below a clear gap, wrapped to the dialog width

#### Import wizard

- [x] Hovering a filename in the video step shows the full path as a tooltip, and the Skip video row shows none

#### Window layout

- [x] On a fresh launch the comment table pane is about 40% of the split rather than collapsed to its minimum. Restart
      to re-test, the ratio is not persisted

#### Window controls

- [x] The title bar shows only the buttons the desktop's button-layout setting asks for, and follows a change to that
      setting while the app runs

#### Right-to-left layout

- [x] In Hebrew, dialog footer buttons run right to left
- [x] In Hebrew, the wizard step indicator's fade sits over the clipped edge, not the visible one. Needs a language
      whose step labels overflow the 500 px content width
