### PR TITLE
chore: bump dependencies

### DIFF
--- a/.config/prek.toml
+++ b/.config/prek.toml
@@ -15,7 +15,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/biomejs/pre-commit"
-rev = "v2.5.3"
+rev = "v2.5.6"
 hooks = [
     {
         id = "biome-check",
@@ -28,7 +28,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/tombi-toml/tombi-pre-commit"
-rev = "v1.2.0"
+rev = "v1.2.4"
 hooks = [
     {
         id = "tombi-format",
@@ -53,7 +53,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/rvben/rumdl-pre-commit"
-rev = "v0.2.32"
+rev = "v0.2.46"
 hooks = [
     {
         id = "rumdl",

--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -9,11 +9,10 @@ target-version = "py313"
 preview = true
 extend-select = [
     "F",           # Pyflakes – basic errors like unused imports, undefined names
-    "FLY",         # Flynt – suggests f-string conversion
     "FURB",        # Refurb – style suggestions from the `refurb` tool
     "I",           # Isort – enforces import sorting
     "PERF",        # Performance – flags suboptimal code patterns
-    "PGH",         # Pygrep-hooks – enforces commit hook conventions (if any)
+    "PGH",         # Pygrep-hooks – flags blanket `type: ignore` and `noqa` comments
     "PL",          # Pylint – a broad range of static analysis rules
     "RUF",         # Ruff-specific – catches issues unique to ruff (e.g. mutable ClassVar, Optional vs X | Y)
     "S",           # Bandit – security issues (e.g. eval, subprocess, etc.)
@@ -24,19 +23,16 @@ extend-select = [
     "ANN",         # Annotations – checks for missing type annotations on arguments and return types
     "ARG",         # Unused Arguments – flags unused function arguments
     "B",           # Bugbear – finds common bugs and design problems (mutable defaults, missing raise-from, etc.)
-    "C",           # Cyclomatic complexity (mccabe) – flags overly complex code
+    "C",           # Comprehensions & mccabe – flags clumsy comprehensions and overly complex code
     "CPY",         # Copyright – checks for required copyright notices
-    "DTZ",         # datetime-timezone – flags naive datetime usage
     "EM",          # Error Messages – ensures proper string formatting in exception messages
     "EXE",         # Executable – checks for shebangs and file permissions
-    "FA",          # Future Annotations – flags issues with postponed evaluation of annotations
     "FIX",         # Fixme – flags TODO, FIXME, and similar comments
     "G",           # Logging – ensures proper usage of logging practices
     "ICN",         # Import Conventions – checks for naming and import rules
     "INP",         # No PEP 420 – flags implicit namespace packages (missing __init__.py)
     "ISC",         # Implicit String Concatenation – disallows adjacent string literals without +
     "LOG",         # Logging Format – flags improper logging string formatting
-    "PIE",         # Pie – miscellaneous Python code style improvements
     "PT",          # Pytest – checks for pytest best practices
     "PTH",         # Pathlib – encourages use of `pathlib` over `os.path`
     "PYI",         # Pyi – rules for stub (`.pyi`) files
@@ -46,23 +42,21 @@ extend-select = [
     "SIM",         # Simplify – flags code that can be simplified
     "SLF",         # Self – restricts access to private members
     "SLOT",        # Slots – enforces use of `__slots__` where appropriate
-    "T10",         # Debugger – flags debugger imports and breakpoint() calls
     "T20",         # Print – flags print() statements
     "TC",          # Type-checking – ensures proper usage of `TYPE_CHECKING` blocks
     "TD",          # TODO – flags TODO comments with optional enforcement
-    "TID",         # Tidiness – general code tidiness rules
-    "YTT",         # flake8-2020 – flags incorrect sys.version comparisons
+    "TID",         # Tidy Imports – flags relative and banned imports
 ]
 
 ignore = [
-    "PLC0415",  # `import` should be at top of file
-    "PLR0904",  # Too many public methods
-    "PLR0911",  # Too many return statements
-    "PLR0913",  # Too many arguments
-    "PLR0914",  # Too many local variables
-    "PLR0917",  # Too many positional arguments
-    "PLR6301",  # Method could be a function
-    "PLW0108",  # Statement has no effect
+    "import-outside-top-level",
+    "no-self-use",
+    "too-many-arguments",
+    "too-many-locals",
+    "too-many-positional-arguments",
+    "too-many-public-methods",
+    "too-many-return-statements",
+    "unnecessary-lambda",
 ]
 
 [lint.extend-per-file-ignores]
@@ -71,14 +65,13 @@ ignore = [
     "INP",          # build-aux is not a package
 ]
 
-"test/**" = [  # Adjust rules for test files
-    "ANN",     # Ignore missing type annotations in tests
-    "ARG",     # Ignore unused arguments (common in fixtures)
-    "FBT",     # Ignore boolean positional argument check (e.g. in parametrize)
-    "PLR",     # Ignore complexity/readability issues
-    "RUF067",  # Allow __init__ files to contain implementation in tests (e.g. fixtures)
-    "S101",    # Allow `assert` in tests
-    "SLF",     # Ignore access to private members
+"test/**" = [                 # Adjust rules for test files
+    "ANN",                    # Ignore missing type annotations in tests
+    "ARG",                    # Ignore unused arguments (common in fixtures)
+    "PLR",                    # Ignore complexity/readability issues
+    "SLF",                    # Ignore access to private members
+    "assert",                 # Allow `assert` in tests
+    "non-empty-init-module",  # Allow __init__ files to hold implementation (e.g. fixtures)
 ]
 
 "main.py" = [
@@ -86,14 +79,14 @@ ignore = [
 ]
 
 "testqml/**" = [
-    "T20",        # Allow print statements
-    "S404",       # The parallel runner spawns the test processes
-    "S603",       # ... with arguments it builds itself
+    "T20",                                   # Allow print statements
+    "suspicious-subprocess-import",          # The parallel runner spawns the test processes
+    "subprocess-without-shell-equals-true",  # ... with arguments it builds itself
 ]
 
 "**/test_*.py" = [
     "ANN",          # Ignore missing type annotations in tests
-    "S101",         # Allow `assert` in tests
+    "assert",       # Allow `assert` in tests
 ]
 
 [lint.isort]

--- a/mpvqc/enums/dialog_kind.py
+++ b/mpvqc/enums/dialog_kind.py
@@ -13,6 +13,7 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcDialogKind(QObject):
+    @QEnum
     class DialogKind(IntEnum):
         ABOUT = auto()
         APPEARANCE = auto()
@@ -24,8 +25,6 @@ class MpvqcDialogKind(QObject):
         IMPORT_SETTINGS = auto()
         IMPORT_WIZARD = auto()
         KEYBOARD_SHORTCUTS = auto()
-
-    QEnum(DialogKind)
 
 
 DialogKind = MpvqcDialogKind.DialogKind

--- a/mpvqc/enums/file_dialog_kind.py
+++ b/mpvqc/enums/file_dialog_kind.py
@@ -13,6 +13,7 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcFileDialogKind(QObject):
+    @QEnum
     class FileDialogKind(IntEnum):
         EXPORT_CLASSIC_DOCUMENT = auto()
         EXPORT_CUSTOM_DOCUMENT = auto()
@@ -20,8 +21,6 @@ class MpvqcFileDialogKind(QObject):
         IMPORT_SUBTITLES = auto()
         IMPORT_VIDEO = auto()
         SAVE_DOCUMENT = auto()
-
-    QEnum(FileDialogKind)
 
 
 FileDialogKind = MpvqcFileDialogKind.FileDialogKind

--- a/mpvqc/enums/import_found_video.py
+++ b/mpvqc/enums/import_found_video.py
@@ -13,12 +13,11 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcImportFoundVideo(QObject):
+    @QEnum
     class ImportFoundVideo(IntEnum):
         ALWAYS = 0
         ASK_EVERY_TIME = 1
         NEVER = 2
-
-    QEnum(ImportFoundVideo)
 
 
 ImportFoundVideo = MpvqcImportFoundVideo.ImportFoundVideo

--- a/mpvqc/enums/import_wizard_session_mode.py
+++ b/mpvqc/enums/import_wizard_session_mode.py
@@ -13,11 +13,10 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcImportWizardSessionMode(QObject):
+    @QEnum
     class SessionMode(IntEnum):
         MERGE = auto()
         REPLACE = auto()
-
-    QEnum(SessionMode)
 
 
 SessionMode = MpvqcImportWizardSessionMode.SessionMode

--- a/mpvqc/enums/import_wizard_step_kind.py
+++ b/mpvqc/enums/import_wizard_step_kind.py
@@ -13,13 +13,12 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcImportWizardStepKind(QObject):
+    @QEnum
     class StepKind(IntEnum):
         ERRORS = auto()
         SESSION = auto()
         VIDEO = auto()
         SUBTITLES = auto()
-
-    QEnum(StepKind)
 
 
 StepKind = MpvqcImportWizardStepKind.StepKind

--- a/mpvqc/enums/message_box_kind.py
+++ b/mpvqc/enums/message_box_kind.py
@@ -13,14 +13,13 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcMessageBoxKind(QObject):
+    @QEnum
     class MessageBoxKind(IntEnum):
         CUSTOM_EXPORT = auto()
         EXPORT_ERROR = auto()
         QUIT = auto()
         RESET = auto()
         VERSION_CHECK = auto()
-
-    QEnum(MessageBoxKind)
 
 
 MessageBoxKind = MpvqcMessageBoxKind.MessageBoxKind

--- a/mpvqc/enums/time_format.py
+++ b/mpvqc/enums/time_format.py
@@ -13,13 +13,12 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcTimeFormat(QObject):
+    @QEnum
     class TimeFormat(IntEnum):
         EMPTY = 0
         CURRENT_TIME = 1
         REMAINING_TIME = 2
         CURRENT_TOTAL_TIME = 3
-
-    QEnum(TimeFormat)
 
 
 TimeFormat = MpvqcTimeFormat.TimeFormat

--- a/mpvqc/enums/window_title_format.py
+++ b/mpvqc/enums/window_title_format.py
@@ -13,12 +13,11 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcWindowTitleFormat(QObject):
+    @QEnum
     class WindowTitleFormat(IntEnum):
         DEFAULT = 0
         FILE_NAME = 1
         FILE_PATH = 2
-
-    QEnum(WindowTitleFormat)
 
 
 WindowTitleFormat = MpvqcWindowTitleFormat.WindowTitleFormat

--- a/mpvqc/services/platform/linux/portals.py
+++ b/mpvqc/services/platform/linux/portals.py
@@ -111,7 +111,7 @@ class SettingsPortal:
             return None
 
     def _read_setting(self, interface: QDBusInterface, namespace: str, key: str, portal_version: int) -> str | None:
-        if portal_version >= 2:  # noqa: PLR2004
+        if portal_version >= 2:  # ruff: ignore[magic-value-comparison]
             method_name = "ReadOne"
         else:
             method_name = "Read"
@@ -125,7 +125,7 @@ class SettingsPortal:
 
         dbus_variant = reply.arguments()[0]
 
-        if portal_version >= 2:  # noqa: SIM108,PLR2004
+        if portal_version >= 2:  # ruff: ignore[if-else-block-instead-of-if-exp, magic-value-comparison]
             value = dbus_variant.variant()
         else:
             value = dbus_variant.variant().variant()

--- a/mpvqc/services/platform/surface.py
+++ b/mpvqc/services/platform/surface.py
@@ -23,7 +23,7 @@ class SurfaceHandler(Protocol):
 class NoSurfaceHandler:
     """For platforms where the app draws no drop shadow."""
 
-    def drop_shadow_margin(self, window: QWindow) -> int:  # noqa: ARG002
+    def drop_shadow_margin(self, window: QWindow) -> int:  # ruff: ignore[unused-method-argument]
         return 0
 
     def on_drop_shadow_margin_changed(self, callback: Callable[[int], None]) -> None:

--- a/mpvqc/services/version_checker.py
+++ b/mpvqc/services/version_checker.py
@@ -48,7 +48,7 @@ class VersionCheckerService:
 
     def _get_latest_version(self) -> str:
         if (version := self._cached_version) is None:
-            with urllib.request.urlopen(_UPDATE_URL, timeout=5) as connection:  # noqa: S310
+            with urllib.request.urlopen(_UPDATE_URL, timeout=5) as connection:  # ruff: ignore[suspicious-url-open-usage]
                 text = connection.read().decode("utf-8").strip()
                 version = f"{json.loads(text)['latest']}".strip()
             self._cached_version = version

--- a/mpvqc/startup.py
+++ b/mpvqc/startup.py
@@ -67,11 +67,11 @@ def configure_environment_variables() -> None:
 
 
 def import_mpvqc_bindings() -> None:
-    import mpvqc.dialogs  # noqa: F401
-    import mpvqc.enums  # noqa: F401
-    import mpvqc.models  # noqa: F401
-    import mpvqc.viewmodels  # noqa: F401
-    import mpvqc.views  # noqa: F401
+    import mpvqc.dialogs  # ruff: ignore[unused-import]
+    import mpvqc.enums  # ruff: ignore[unused-import]
+    import mpvqc.models  # ruff: ignore[unused-import]
+    import mpvqc.viewmodels  # ruff: ignore[unused-import]
+    import mpvqc.views  # ruff: ignore[unused-import]
 
 
 def start_application(process_started_at: float) -> Never:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "Jinja2>=3.1.6",
     "PySide6-Essentials==6.11.1",
-    "inject>=5.4.1",
+    "inject>=5.5.0",
     "mpv>=1.0.8",
 ]
 
@@ -29,13 +29,16 @@ Repository = "https://github.com/mpvqc/mpvQC"
 [dependency-groups]
 dev = [
     "jsonschema>=4.26.0",
-    "materialyoucolor>=3.0.2",
-    "prek>=0.4.5",
+    "materialyoucolor>=3.0.3",
+    "prek>=0.4.11",
     "pyrefly>=1.1.1",
     "pytest>=9.1.1",
-    "ruff>=0.15.20",
+    "ruff>=0.16.0",
     "types-jsonschema>=4.26.0.20260518",
 ]
+
+[tool.uv]
+required-version = ">=0.12.0"
 
 [tool.pyside6-project]
 files = [

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutListItem.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutListItem.qml
@@ -5,7 +5,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
 import QtTest
 
 TestCase {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcAboutTab.qml
@@ -5,7 +5,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
 import QtTest
 
 import io.github.mpvqc.mpvQC.Python

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcCreditsTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcCreditsTab.qml
@@ -5,7 +5,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
 import QtTest
 
 TestCase {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcLicensesTab.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/About/tst_MpvqcLicensesTab.qml
@@ -5,7 +5,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
 import QtTest
 
 import io.github.mpvqc.mpvQC.Python

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardErrorsStep.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardErrorsStep.qml
@@ -5,7 +5,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Controls // qmllint disable unused-imports
 import QtTest
 
 TestCase {

--- a/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardVideoStepDelegate.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Dialogs/ImportWizard/tst_MpvqcWizardVideoStepDelegate.qml
@@ -5,7 +5,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Controls // qmllint disable unused-imports
 import QtTest
 
 TestCase {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,7 @@ class PlayerMock(QObject):
         self.time_remaining = 0
         self.percent_pos = 0
 
-    def update(self, **kwargs):  # noqa: C901
+    def update(self, **kwargs):  # ruff: ignore[complex-structure]
         for key, value in kwargs.items():
             if hasattr(self, key):
                 old_value = getattr(self, key)

--- a/testqml/main.py
+++ b/testqml/main.py
@@ -11,7 +11,7 @@ from PySide6.QtCore import QCoreApplication, QObject, QResource, Qt, Slot
 from PySide6.QtQml import QQmlEngine
 from PySide6.QtQuickTest import QUICK_TEST_MAIN_WITH_SETUP
 
-import testqml.bridge  # noqa: F401, registers MpvqcTestBridge
+import testqml.bridge  # ruff: ignore[unused-import], registers MpvqcTestBridge
 from mpvqc import startup
 from testqml.injections import TEMP_ROOT, configure_injections
 

--- a/uv.lock
+++ b/uv.lock
@@ -109,19 +109,18 @@ wheels = [
 
 [[package]]
 name = "materialyoucolor"
-version = "3.0.2"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/47/2db3504a71e6e7bdad8e4dfdcf4b62a575cb4229c32a3a612062b39cf6cc/materialyoucolor-3.0.2.tar.gz", hash = "sha256:e2c892ae23dc0732c32307682002884616a282de5a350088aacc23cdf885e822", size = 127051, upload-time = "2026-02-22T07:19:30.297Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/94/da86904173a5af7c6af33cefb47365f68e2769f740442d5aaa676fce52ed/materialyoucolor-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:311c1484832c00b8be7ef7781e3fc9e6f17b311f899f6657f4523a1ae067d168", size = 214334, upload-time = "2026-02-22T07:09:34.328Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/42/a12606b88d0d991276bfcd8084e66e06c302d3713db3f8929a0be99e9244/materialyoucolor-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fe03cf51df6e21acf1986810052cf35fed3fbc759c1ab0d7c5a9730ee2890029", size = 203527, upload-time = "2026-02-22T07:09:35.587Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/58/a030f46147f3847c7cd3dcda2bc2c362f7275b771ff61e622c547c29f63a/materialyoucolor-3.0.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c4d302e0b309d9b45548074c8a348903733df8bc4101283dc969f0ff157afde5", size = 233604, upload-time = "2026-02-22T07:09:37.061Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/e6/8d83bd8366300a79b7d529ad65cb523f904481a45c9a7720705174f81352/materialyoucolor-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:92c56bf78cd7008a925b9a928c2784e30266b3c6a56e5a481f627d51c82ed2f8", size = 1265500, upload-time = "2026-02-22T07:09:38.549Z" },
-    { url = "https://files.pythonhosted.org/packages/07/cc/5b3252893277c03ee231d147ce877e5a348b60c628b185433f9e75c40b9d/materialyoucolor-3.0.2-cp313-cp313-win32.whl", hash = "sha256:8fa0ae5ea849b0d120e998b157605aa098b1388a035ecd019c8424fd14fc23b9", size = 161307, upload-time = "2026-02-22T07:09:39.874Z" },
-    { url = "https://files.pythonhosted.org/packages/55/02/f7c7a953b33f64979b97c02bccb0b23226a433d55e5696193e27cdb923c7/materialyoucolor-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:32048938b7735fdb8496fcc6561a5a0c04f74160f8f41674f08304b0942740e7", size = 177237, upload-time = "2026-02-22T07:09:41.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/24/3ebafa4f8bad7b6c69efec59363615f8b2fd3a9abd1460c76bc87a7e35a1/materialyoucolor-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:90bf1d5cc7ac49dbfdd6f88a4639e6bfff5841a9e6ef805a5abf4c78c184eae5", size = 216668, upload-time = "2026-07-15T19:05:02.922Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b5/38e9f3dd9c5002faeb8c7db9c1bcf8f9aebf9d6f3fedb3270d11c56c897b/materialyoucolor-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f449eed1c57b87f6bc572ee3f2f137d53629941f2884457e17fa7857d58f304c", size = 207217, upload-time = "2026-07-15T19:05:04.344Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fc/60eb9e142d916a7f2c23ae0d1a20aa17a631b626ef71a3a8a440ab94158e/materialyoucolor-3.0.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4cd85d01f56f7e201907571126125864f71180872c1ae2ddac866333cf77866", size = 235259, upload-time = "2026-07-15T19:05:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ef/b4379797c7a910ef16c72ec55c306e6bee15b4ebe72c2e2dd4a96b03b2fb/materialyoucolor-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:faf65e7ff8885b0bd6cb13f5d0f9b8333222402c9c14530da53031e18ecaf582", size = 1267725, upload-time = "2026-07-15T19:05:07.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/79/cd4616cc801b450949cf6ad1e0ab03b4e11390e13f0c32950200a5af4121/materialyoucolor-3.0.3-cp313-cp313-win32.whl", hash = "sha256:09f26b67e03183a05deda4390e8166e62565cf09ae6116a6d4738f70a4cf8442", size = 354876, upload-time = "2026-07-15T19:05:09.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/b222e7ad801bfe9a2fd60d863c63f22ffee287b5d4a698279fee22bea3ee/materialyoucolor-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:91dc5eb16bb289fcf19d65d4784baad53cd06192ebafb3967b1b827ad7cb7bc9", size = 376269, upload-time = "2026-07-15T19:05:10.529Z" },
 ]
 
 [[package]]
@@ -157,7 +156,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "inject", specifier = ">=5.4.1" },
+    { name = "inject", specifier = ">=5.5.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "mpv", specifier = ">=1.0.8" },
     { name = "pyside6-essentials", specifier = "==6.11.1" },
@@ -166,11 +165,11 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "materialyoucolor", specifier = ">=3.0.2" },
-    { name = "prek", specifier = ">=0.4.5" },
+    { name = "materialyoucolor", specifier = ">=3.0.3" },
+    { name = "prek", specifier = ">=0.4.11" },
     { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=9.1.1" },
-    { name = "ruff", specifier = ">=0.15.20" },
+    { name = "ruff", specifier = ">=0.16.0" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
 ]
 
@@ -214,26 +213,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.4.9"
+version = "0.4.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/df/94ed29398576e03494c5aacda8bfed9536edf348bed29cd09f382f2b9b23/prek-0.4.9.tar.gz", hash = "sha256:f8b86441484a5756f3fdb6f3b201d3d448f8845902a84653d78cbf6f875c424f", size = 492711, upload-time = "2026-07-11T11:04:04.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1a/73b6dae5ce7e997cb35a69bfe1d25a798e85fa3d2eabf95324563f461b30/prek-0.4.11.tar.gz", hash = "sha256:4a14cb9bbae850605ae3904fbdbb12f0e00c12455efaa2266da8fb8e5c0350d7", size = 516254, upload-time = "2026-07-24T17:05:35.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/02/632446b72103daf92526203bf83cb76043ebce70588632aa2aea3741da07/prek-0.4.9-py3-none-linux_armv6l.whl", hash = "sha256:7b240ad6f679104309a944c4dd427ccc46d9aaf4f53ee07379c02bf7578c2750", size = 5637604, upload-time = "2026-07-11T11:03:38.985Z" },
-    { url = "https://files.pythonhosted.org/packages/57/bf/89daefc85a1db9b8c525731c77121de0a8f57731e81c99d823e919e1f6a5/prek-0.4.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5cbb220d6d77cb047747dcabf421375fdfdd958e01a998a854758698d38fb239", size = 5960396, upload-time = "2026-07-11T11:03:40.953Z" },
-    { url = "https://files.pythonhosted.org/packages/42/39/0e448da00671e77740be32cca96530ef64bcdbed178acce7f155b87f6057/prek-0.4.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fd85df4c186becdc47b2e6155de8cace99133c7517387e30f08ca15b93ead11f", size = 5524982, upload-time = "2026-07-11T11:03:42.605Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e5/1beceff9cfcf02817c06f38e726c9875cd003f62cbfa516f282fb3c3109b/prek-0.4.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:ba40511145e948d461d6641b556b6ff671b186b0c90743600b9dcb788dd5eb5c", size = 5793691, upload-time = "2026-07-11T11:03:44.106Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/17/99e4884c45c46be90e81e220d2bdd5020716963707ef6702361cc398dd91/prek-0.4.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0cc5c06ae448568d076bb5e7ce4d630879d6467b2a89fd79061c349a47826efa", size = 5544549, upload-time = "2026-07-11T11:03:45.564Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/4b/63f5fe22d867a6e07b12e8a7887a0f3b193c2ef0fa9ed80649f2d257f4ac/prek-0.4.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:31af616c216ec7e47913802b082ca816d707d24738fa58eae0463ae296cbe71e", size = 5948798, upload-time = "2026-07-11T11:03:47.424Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/89/90d5005436afb6ab99d3ba6599820fe0f0fcb776f5e9e362b5a19e10cbea/prek-0.4.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a1ef842d7f19879fac2135c42ba15508f2677346ba800bc8bb82e5f43fe6a6ec", size = 6696938, upload-time = "2026-07-11T11:03:49Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/62/068dd25e1106e262b0ce69ffcdc594cf52d85aa13f64628f851e458980d4/prek-0.4.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:442ecf6a454c692bc8a2d5a16936a0fe8e3419727ff208e15818932acca9923a", size = 6170870, upload-time = "2026-07-11T11:03:50.407Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/42/bb1f3f3d84af4d12bb675ff071305fa776d3525c10626465d9960ad93c21/prek-0.4.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:5b3c590252e3d5724ebed3774695712ff7cb554743b25184808aa5f42b06bd4c", size = 5800355, upload-time = "2026-07-11T11:03:51.882Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ca/dfc8312b4a7ce8fa100ce37a843279d108eec7e7fe2ddbe069448acd1642/prek-0.4.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1dd283b15dec4da29caa3910bd72c8c9d7df93209770503465ad109d6370cb8e", size = 5655126, upload-time = "2026-07-11T11:03:53.388Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8a/b19413cb64b81c18502ea7bbef32897f9126b8e53b58cd656996573dc53c/prek-0.4.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:cc25e30e1700a5c7dd9bad665c321e5589b51502bb1bbc6ada45e326d08b428b", size = 5517839, upload-time = "2026-07-11T11:03:54.884Z" },
-    { url = "https://files.pythonhosted.org/packages/94/af/900df3f7535e87045df331646c6a01bef6e77dba7f2bdb53483f30cbb988/prek-0.4.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:4ff5947deeb9a92e6508dfba8b27962dfb927bf60fd36472c9ae862df96fb38c", size = 5802556, upload-time = "2026-07-11T11:03:56.787Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/7b/80e560cbe396d0f8687012769cb2d7d7f3428dd019549225ebf205dea806/prek-0.4.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:8320ca167d41855d9c4fed66df599f31f96307cbb0da1311a9fe465152e20bd5", size = 6285747, upload-time = "2026-07-11T11:03:58.099Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/d4/01ae3b99d09559a69befd128859d0036c604608dd9c6c99986592dde3c21/prek-0.4.9-py3-none-win32.whl", hash = "sha256:b1e8d3bc88ddce6414853468ed8126f45d4ae20f2f4677801ade20ad67a826fa", size = 5320862, upload-time = "2026-07-11T11:03:59.803Z" },
-    { url = "https://files.pythonhosted.org/packages/28/68/d038b14f0220fed197be8bc93229e6ea7ad460803ff8a26e4b14a8c81f66/prek-0.4.9-py3-none-win_amd64.whl", hash = "sha256:ed1b4f87a13d1565e8731c60db7fa058966049cbb4d8872d160add510a286558", size = 5706850, upload-time = "2026-07-11T11:04:01.207Z" },
-    { url = "https://files.pythonhosted.org/packages/02/4a/57d04de49f591088901794cc22f36563a102681e3512ae17ee6085cd2f30/prek-0.4.9-py3-none-win_arm64.whl", hash = "sha256:7eab3900d9ea614c8ea0d0d55a8b708f0c88e43c966dc8b13a4e36c1e398dd16", size = 5540477, upload-time = "2026-07-11T11:04:02.815Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/a00b2de492a80e99b1698e72c1d196ac3ed544dc7ee0ada261ac066e78e0/prek-0.4.11-py3-none-linux_armv6l.whl", hash = "sha256:3830cb7cc47e837888b8b464ecb21355a69235cfacef0fd89101e17f09345d63", size = 5770511, upload-time = "2026-07-24T17:05:12.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1e/f97c74defcd5d5645888cb99fcdd9b8b48cc7247cf31e64414d106d56d66/prek-0.4.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:45facadf9c2332b28e6ab2744312ae0275a93ab5a437da8bcc53a8c7260cb4b0", size = 6118049, upload-time = "2026-07-24T17:05:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/92/8367d26421ee6fe6019a63928fb0ed31179cd0d6199879c524f89ef4c95c/prek-0.4.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2f8a194b1d00d24dff8baff691c99e2668339da2da3482b4ee99c1a0f2409378", size = 5601478, upload-time = "2026-07-24T17:05:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6f/7617c9b87afaadede4167720aae7ef12d7e51167db903bc8fbac0cadef7b/prek-0.4.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:21d93e6d76bf3d7a9bb70c6ac86ef372adaee50068c45749e6b9e1c2ac4ec939", size = 5932071, upload-time = "2026-07-24T17:05:17.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/41/6796a4011b04212333259064aa885a71d03d9581ba9bff52db3ce58d1f06/prek-0.4.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7fb07cde2d2156efa6980122b3f13dc88f20c84b933c6205675d0f1e7be2cde8", size = 5677617, upload-time = "2026-07-24T17:05:18.658Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5f/3e339901f8460b6073313619b4fd9bf4135e48430695c53640b83ace88ea/prek-0.4.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b7f5e446d2aca739bd18b380578e9c78bb4c086299abc3e167d51c47840c56f", size = 6106370, upload-time = "2026-07-24T17:05:20.219Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4e/94e24b5c1910ec15692ecaf33d0d8ef0d02a02a8b5e40d3c976396880cba/prek-0.4.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7059d640e595d098600e2d97af961f46292b4112670edbe632de84f6828389e", size = 6884342, upload-time = "2026-07-24T17:05:21.587Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7c/fc0daa033dcafe74990c00af2da1e16922790b9c1b8da7e8eebf1123838b/prek-0.4.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85a4df33998fcac878bce3b2c624e1caeb9609f3d562c640702c1234ed815daf", size = 6331365, upload-time = "2026-07-24T17:05:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/36/49f152b8f539930e9685cff0509695ce4054abcecc22f4c16c4e1e5c23d0/prek-0.4.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:866991f387527c5f880ce2cc3ddea9b33cc5b986881f8c7f92524cf0969c1350", size = 5939075, upload-time = "2026-07-24T17:05:24.249Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fe/7b097af9161edae7ddedcc9f5cda4a5f31346a492ce3f92583d96c46f628/prek-0.4.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:247e5d8740e137ebdf24fa96f01a95b2d2f1892e956a1ab00c7b1474a59ebcc0", size = 5799029, upload-time = "2026-07-24T17:05:25.652Z" },
+    { url = "https://files.pythonhosted.org/packages/49/63/dc955ff99e1002d3cd375b21467c87046bc41deddfce86d898240757b151/prek-0.4.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:603ba9f2fd9d666dddb3ae190a25a5c55091b843cde90ed52e0a1116f50d4062", size = 5651211, upload-time = "2026-07-24T17:05:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b8/bf2139ec25eefb5afef43afac7620c5181f2c2661f220598beacb1771207/prek-0.4.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f2682ece3c5fc7201106c4fdd84b0587ccea4b8a2ecefa3e94d3074d2841f1df", size = 5954784, upload-time = "2026-07-24T17:05:28.391Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/29/3fe5990aee1bd7c4d50a03358ad867c5e912d9510aafb83a359c7347e5fa/prek-0.4.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:22721d30394192931fecc80d6fc6dd47e8ddf8db8b9693805aba8ec0f50087ec", size = 6448916, upload-time = "2026-07-24T17:05:29.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fb/abddacf43738302242ecd237236c7c80cd7c1d27545e16e803770aee76e9/prek-0.4.11-py3-none-win32.whl", hash = "sha256:8b093e7624522146049e994d5cf283d01d71632b638620b79ae0f96afeaa2624", size = 5483539, upload-time = "2026-07-24T17:05:31.228Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1e/c293f7a15cb93963c4be36a02e144b93f43906bc02644a3f04e5708e7453/prek-0.4.11-py3-none-win_amd64.whl", hash = "sha256:5a3d7c80b970b456e5f1bcec8382008ee1ae6a3f324a6b9bb4ff7e666ab0f3c4", size = 5861119, upload-time = "2026-07-24T17:05:32.479Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0c/05fe6eb9d6a54d0e02dfa8cc5ad6f86869bf953419ec15909a32466a28ee/prek-0.4.11-py3-none-win_arm64.whl", hash = "sha256:e7b0df37ce05e45a14a9da39ab104691474d72f139bf4f6c860f754763a322cb", size = 5626386, upload-time = "2026-07-24T17:05:33.813Z" },
 ]
 
 [[package]]
@@ -333,27 +332,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Routine dependency bump. `inject` goes 5.4.1 to 5.5.0, the dev tools move up with it, and PySide6 stays pinned at 6.11.1.

Ruff 0.16 ships its own suppression syntax, so the old `# noqa: CODE` comments are now `# ruff: ignore[rule-name]`, and the ignore lists name rules instead of codes. I trimmed the rule selection while I was in there.
