### PR TITLE
fix: table columns, the drop shadow margin, and two crashes

### DIFF
--- a/.agents/skills/manual-checks/SKILL.md
+++ b/.agents/skills/manual-checks/SKILL.md
@@ -52,17 +52,19 @@ cannot be seen in the app.
 
 ### 4. Build the section
 
-Group by arrangement, then by area. Skip an arrangement no subagent reached: a Linux-only branch gets no Windows
-heading.
+The fork call places every item: an item stays shared when one run on any arrangement vouches for every arrangement
+it reaches, and it forks when arrangements owe the user different behaviour, or when a pass on one machine says
+nothing about another because the failure is platform-flavoured: fonts, compositors, native modules.
 
-Every heading is one arrangement. There is no shared bucket, no `Any arrangement`, no `All platforms`, no item parked
-outside an arrangement. The boxes are how the user records which machine they sat at, so a box that spans arrangements
-records nothing and they have to start over.
+- A shared item is written once, under the `### 🌐 Anywhere` heading: the user checks it on whichever machine they
+  sit at, and that one tick vouches for the rest. When its reach is narrower than every arrangement, the item names
+  it: `On Linux, …`.
+- A forked item is written once per arrangement it reaches, under that arrangement's heading, each copy stating what
+  its arrangement owes — never one shared line with parentheticals bolted on.
 
-Repetition is the point, not waste. Write the same check under every arrangement it reaches, and where an arrangement
-changes what the user should see, say that in its copy rather than bolting a parenthetical onto a shared line.
+Group each heading by area, and skip an arrangement no subagent reached: a Linux-only branch gets no Windows heading.
 
-Lead every arrangement heading with its emoji, so the user finds their machine by shape before they read a word:
+Lead every heading with its emoji, so the user finds their machine by shape before they read a word: 🌐 Anywhere,
 🪟 Windows, 🐧 Linux desktop, 🧱 Linux tiling. An arrangement the catalogue grows later picks up its own emoji and
 keeps it from then on.
 
@@ -73,31 +75,35 @@ Write each item as the state that should hold, present tense, one observable per
 ```markdown
 ## Manual checks before merging
 
+### 🌐 Anywhere
+
+#### Overlays
+
+- [ ] The search overlay opens above the table
+
 ### 🪟 Windows
 
 #### Window controls
 
 - [ ] Loading a video resizes the window to fit it
-- [ ] Escape leaves fullscreen
 
 ### 🧱 Linux tiling
 
 #### Window controls
 
-- [ ] Escape leaves fullscreen
 - [ ] Known and accepted: loading a video leaves the window alone, the compositor decides the size
 ```
 
-Escape repeats because it reaches both arrangements. Resize is written twice, differently, because the two
-arrangements owe the user different behaviour.
+The overlay is written once: its layout owes nothing to the platform, so one run on any machine vouches for all.
+Resize forks, written twice and differently, because the two arrangements owe different behaviour.
 
 Every line under a heading is a checkbox. Setup a check needs rides inside the item. A quirk the branch knowingly
 leaves behind is still an item, marked `Known and accepted:`.
 
 Boxes ship unchecked. The user ticks them.
 
-Done when every item passes the blast radius filter, and every item sits under exactly one emoji-led arrangement
-heading.
+Done when every item passes the blast radius filter and sits where the fork call puts it: shared items once under
+🌐, forked items once per arrangement, and no behaviour written both shared and forked.
 
 ### 5. Place it
 

--- a/.config/pyrefly.toml
+++ b/.config/pyrefly.toml
@@ -5,6 +5,7 @@
 python-version = "3.13"
 project-includes = ["../**/*.py*"]
 search-path = [".."]
+min-severity = "warn"
 
 [errors]
 missing-override-decorator = "error"

--- a/.gitignore
+++ b/.gitignore
@@ -550,6 +550,7 @@ $RECYCLE.BIN/
 
 rc_project.py
 project.rcc
+project.rcc.tmp
 
 # Share the PyCharm inspection profiles
 !.idea/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,6 +17,15 @@ Terms the code uses. Keep entries short. Add a term when you name a module after
 - **Close-only mode**: wizard state when errors are the only step and nothing importable remains. The user can only
   close the wizard. `WizardDialogPolicy` decides this once for both title and footer.
 
+## Comments
+
+- **Unknown comment type**: a type a comment carries that is not in the configured list. Imported documents introduce
+  them; removing a configured type leaves them behind. They render and export verbatim, since they have no translation
+  catalog entry.
+- **Displayable comment types**: the types the comment table may show: every configured type plus every type present in
+  the document. The table reserves label space for all of them. The new-comment menu (configured types only) and the
+  edit-type menu (configured types plus the row's own type) show different sets by design.
+
 ## UI
 
 - **Overlay**: a dialog, file dialog, or message box that floats above the app, is loaded on demand, and returns focus

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,8 @@ Terms the code uses. Keep entries short. Add a term when you name a module after
   beneath them, an inline editor does not.
 - **Modal overlay**: anything that owns the window's input while open: a dialog, message box, modal menu, modal row
   popup, or native file dialog.
+- **Long time format**: a time rendered with hours, `HH:MM:SS`; the short format is `MM:SS`. A surface uses the long
+  format when any time it may display can reach one hour. Exported documents always use the long format.
 
 ## Platform
 

--- a/Justfile
+++ b/Justfile
@@ -86,7 +86,9 @@ set-build-info:
 @build-develop: _generate-qrc-file _update_pyproject_file
     # Fast replacement for: uv run pyside6-project build
     uv run python build-aux/pyside_project_build.py
-    uv run pyside6-rcc --binary project.qrc -o project.rcc
+    # Replace by rename: a running app has the old bundle mmapped
+    uv run pyside6-rcc --binary project.qrc -o project.rcc.tmp
+    mv project.rcc.tmp project.rcc
     grep -qxF 'depends QtQml.Models' io/github/mpvqc/mpvQC/Python/qmldir || echo 'depends QtQml.Models' >> io/github/mpvqc/mpvQC/Python/qmldir
 
 # Remove ALL generated files
@@ -121,8 +123,8 @@ build-release:
 [group('test')]
 prepare-tests: build-develop
     rm -f test/rc_project.py testqml/rc_project.py
-    cp project.rcc test/project.rcc
-    cp project.rcc testqml/project.rcc
+    cp project.rcc test/project.rcc.tmp && mv test/project.rcc.tmp test/project.rcc
+    cp project.rcc testqml/project.rcc.tmp && mv testqml/project.rcc.tmp testqml/project.rcc
 
 # Run Python and QML tests
 [group('test')]

--- a/mpvqc/injections.py
+++ b/mpvqc/injections.py
@@ -30,6 +30,7 @@ def bindings(binder: inject.Binder) -> None:
     binder.bind_to_constructor(s.SettingsService, s.SettingsService)
     binder.bind_to_constructor(s.StateService, s.StateService)
     binder.bind_to_constructor(s.ThemeService, s.ThemeService)
+    binder.bind_to_constructor(s.TimeFormatPolicyService, s.TimeFormatPolicyService)
     binder.bind_to_constructor(s.TimeFormatterService, s.TimeFormatterService)
     binder.bind_to_constructor(s.TypeMapperService, s.TypeMapperService)
     binder.bind_to_constructor(s.VersionCheckerService, s.VersionCheckerService)

--- a/mpvqc/injections.py
+++ b/mpvqc/injections.py
@@ -11,6 +11,7 @@ def bindings(binder: inject.Binder) -> None:
     binder.bind_to_constructor(s.ApplicationPathsService, s.ApplicationPathsService)
     binder.bind_to_constructor(s.BuildInfoService, s.BuildInfoService)
     binder.bind_to_constructor(s.CommentsService, s.CommentsService)
+    binder.bind_to_constructor(s.CommentTypesPolicyService, s.CommentTypesPolicyService)
     binder.bind_to_constructor(s.CommentTypeValidatorService, s.CommentTypeValidatorService)
     binder.bind_to_constructor(s.DesktopService, s.DesktopService)
     binder.bind_to_constructor(s.ExportService, s.ExportService)

--- a/mpvqc/services/__init__.py
+++ b/mpvqc/services/__init__.py
@@ -5,6 +5,7 @@
 from .application_paths import ApplicationPathsService as ApplicationPathsService
 from .build_info import BuildInfoService as BuildInfoService
 from .comment_type_validator import CommentTypeValidatorService as CommentTypeValidatorService
+from .comment_types_policy import CommentTypesPolicyService as CommentTypesPolicyService
 from .comments import CommentsService as CommentsService
 from .desktop import DesktopService as DesktopService
 from .exporter import ExportService as ExportService

--- a/mpvqc/services/__init__.py
+++ b/mpvqc/services/__init__.py
@@ -28,6 +28,7 @@ from .settings import SettingsService as SettingsService
 from .state import StateService as StateService
 from .theme import ThemePalette as ThemePalette
 from .theme import ThemeService as ThemeService
+from .time_format_policy import TimeFormatPolicyService as TimeFormatPolicyService
 from .type_mapper import TypeMapperService as TypeMapperService
 from .version_checker import VersionCheckerService as VersionCheckerService
 from .video_resize import VideoResizeService as VideoResizeService

--- a/mpvqc/services/comment_types_policy.py
+++ b/mpvqc/services/comment_types_policy.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inject
+from PySide6.QtCore import QObject, Signal, Slot
+
+from .comments import CommentsService
+from .settings import SettingsService
+
+
+class CommentTypesPolicyService(QObject):
+    _comments = inject.attr(CommentsService)
+    _settings = inject.attr(SettingsService)
+
+    displayable_comment_types_changed = Signal(frozenset)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._displayable_comment_types = self._compute_displayable_comment_types()
+        self._comments.comments_changed.connect(self._recompute)
+        self._settings.comment_types_changed.connect(self._recompute)
+
+    @property
+    def displayable_comment_types(self) -> frozenset[str]:
+        return self._displayable_comment_types
+
+    @Slot()
+    def _recompute(self) -> None:
+        value = self._compute_displayable_comment_types()
+        if value != self._displayable_comment_types:
+            self._displayable_comment_types = value
+            self.displayable_comment_types_changed.emit(value)
+
+    def _compute_displayable_comment_types(self) -> frozenset[str]:
+        return frozenset(self._settings.comment_types) | self._comments.distinct_comment_types

--- a/mpvqc/services/comments/service.py
+++ b/mpvqc/services/comments/service.py
@@ -64,6 +64,10 @@ class CommentsService(QObject):
     def count(self) -> int:
         return self._store.rowCount()
 
+    @property
+    def distinct_comment_types(self) -> frozenset[str]:
+        return self._store.distinct_comment_types()
+
     def comments(self) -> tuple[Comment, ...]:
         return self._store.comments()
 

--- a/mpvqc/services/comments/service.py
+++ b/mpvqc/services/comments/service.py
@@ -40,6 +40,7 @@ class CommentsService(QObject):
 
     view_action = Signal(object)  # ViewAction union; Qt sigs can't carry type aliases
     dirty = Signal()
+    comments_changed = Signal()
     about_to_import = Signal()
 
     def __init__(self, parent: QObject | None = None) -> None:
@@ -119,6 +120,7 @@ class CommentsService(QObject):
         self._store.reset(())
         # pyrefly: ignore [bad-assignment]
         self._selection.selectedRow = -1
+        self.comments_changed.emit()
 
     def undo(self) -> None:
         self._history.disarm_merge()
@@ -147,6 +149,7 @@ class CommentsService(QObject):
         if cmd.invalidates_search:
             self._search.invalidate()
         self.dirty.emit()
+        self.comments_changed.emit()
         self._emit_view_action(action)
 
     def _emit_view_action(self, action: ViewAction) -> None:

--- a/mpvqc/services/comments/store.py
+++ b/mpvqc/services/comments/store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import bisect
 import itertools
+from collections import Counter
 from dataclasses import dataclass
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Protocol, override
@@ -15,13 +16,40 @@ from PySide6.QtCore import QAbstractListModel, QModelIndex, QPersistentModelInde
 from .roles import ROLE_NAMES, Role
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from PySide6.QtCore import QByteArray, QObject
 
     from mpvqc.datamodels import Comment
 
 _seq_counter = itertools.count()
+
+
+class TypeTally:
+    def __init__(self) -> None:
+        self._counts: Counter[str] = Counter()
+
+    def add(self, comment_type: str) -> None:
+        self._counts[comment_type] += 1
+
+    def remove(self, comment_type: str) -> None:
+        remaining = self._counts[comment_type] - 1
+        if remaining > 0:
+            self._counts[comment_type] = remaining
+        else:
+            del self._counts[comment_type]
+
+    def swap(self, old: str, new: str) -> None:
+        if old == new:
+            return
+        self.remove(old)
+        self.add(new)
+
+    def rebuild(self, comment_types: Iterable[str]) -> None:
+        self._counts = Counter(comment_types)
+
+    def distinct(self) -> frozenset[str]:
+        return frozenset(self._counts)
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,6 +87,10 @@ class CommentStore(QAbstractListModel):
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
         self._rows: list[StoreItem] = []
+        self._types = TypeTally()
+
+    def distinct_comment_types(self) -> frozenset[str]:
+        return self._types.distinct()
 
     @override
     def rowCount(self, parent: QModelIndex | QPersistentModelIndex | None = None) -> int:
@@ -121,20 +153,24 @@ class CommentStore(QAbstractListModel):
         self.aboutToInsertRow.emit(row)
         self.beginInsertRows(QModelIndex(), row, row)
         self._rows.insert(row, item)
+        self._types.add(item.comment.comment_type)
         self.endInsertRows()
 
     def remove(self, row: int) -> None:
         self.aboutToRemoveRow.emit(row)
         self.beginRemoveRows(QModelIndex(), row, row)
+        self._types.remove(self._rows[row].comment.comment_type)
         del self._rows[row]
         self.endRemoveRows()
 
     def replace(self, row: int, new_comment: Comment, role: Role) -> None:
+        self._types.swap(self._rows[row].comment.comment_type, new_comment.comment_type)
         self._rows[row] = StoreItem(new_comment, self._rows[row].seq)
         idx = self.index(row)
         self.dataChanged.emit(idx, idx, [role])
 
     def move_replace(self, src: int, dst: int, new_comment: Comment, role: Role) -> None:
+        self._types.swap(self._rows[src].comment.comment_type, new_comment.comment_type)
         seq = self._rows[src].seq
         if src == dst:
             self._rows[src] = StoreItem(new_comment, seq)
@@ -152,4 +188,5 @@ class CommentStore(QAbstractListModel):
     def reset(self, items: Sequence[StoreItem]) -> None:
         self.beginResetModel()
         self._rows = list(items)
+        self._types.rebuild(r.comment.comment_type for r in self._rows)
         self.endResetModel()

--- a/mpvqc/services/label_width_calculator.py
+++ b/mpvqc/services/label_width_calculator.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from collections.abc import Collection
+from collections.abc import Iterable
 from functools import cached_property
 from math import ceil
 
@@ -19,7 +19,5 @@ class LabelWidthCalculatorService:
     def _font_metrics(self) -> QFontMetricsF:
         return QFontMetricsF(self._font_loader.application_font())
 
-    def calculate_width_for(self, texts: Collection[str]) -> int:
-        if not texts:
-            return 0
-        return ceil(max(self._font_metrics.horizontalAdvance(text) for text in texts))
+    def calculate_width_for(self, texts: Iterable[str]) -> int:
+        return ceil(max((self._font_metrics.horizontalAdvance(text) for text in texts), default=0))

--- a/mpvqc/services/label_width_calculator.py
+++ b/mpvqc/services/label_width_calculator.py
@@ -4,9 +4,9 @@
 
 from collections.abc import Collection
 from functools import cached_property
+from math import ceil
 
 import inject
-from PySide6.QtCore import QCoreApplication
 from PySide6.QtGui import QFontMetricsF
 
 from .font_loader import FontLoaderService
@@ -22,20 +22,4 @@ class LabelWidthCalculatorService:
     def calculate_width_for(self, texts: Collection[str]) -> int:
         if not texts:
             return 0
-
-        max_width = 0.0
-        for text in texts:
-            bounding_rect = self._font_metrics.tightBoundingRect(text)
-            max_width = max(max_width, bounding_rect.width())
-
-        return int(max_width)
-
-    def calculate_comment_types_width(self, comment_types: list[str]) -> int:
-        labels = [QCoreApplication.translate("CommentTypes", ct) for ct in comment_types]
-        return self.calculate_width_for(labels)
-
-    def calculate_time_width(self, duration: float) -> int:
-        hour_format = duration > 60 * 60
-        pattern = "{0}{0}:" * (3 if hour_format else 2)
-        labels = [pattern.format(i)[:-1] for i in range(10)]
-        return self.calculate_width_for(labels)
+        return ceil(max(self._font_metrics.horizontalAdvance(text) for text in texts))

--- a/mpvqc/services/time_format_policy.py
+++ b/mpvqc/services/time_format_policy.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Final
+
+import inject
+from PySide6.QtCore import QObject, Signal, Slot
+
+from .comments import CommentsService
+from .player import PlayerService
+
+SECONDS_PER_HOUR: Final = 3600
+MILLISECONDS_PER_SECOND: Final = 1000
+
+
+class TimeFormatPolicyService(QObject):
+    _comments = inject.attr(CommentsService)
+    _player = inject.attr(PlayerService)
+
+    table_long_format_changed = Signal(bool)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._table_long_format = self._compute_table_long_format()
+        self._player.duration_changed.connect(self._recompute)
+        self._comments.comments_changed.connect(self._recompute)
+
+    @staticmethod
+    def uses_long_format(seconds: float) -> bool:
+        return seconds >= SECONDS_PER_HOUR
+
+    @property
+    def table_long_format(self) -> bool:
+        return self._table_long_format
+
+    @Slot()
+    def _recompute(self) -> None:
+        value = self._compute_table_long_format()
+        if value != self._table_long_format:
+            self._table_long_format = value
+            self.table_long_format_changed.emit(value)
+
+    def _compute_table_long_format(self) -> bool:
+        if self.uses_long_format(self._player.duration):
+            return True
+        count = self._comments.count
+        if count == 0:
+            return False
+        # Comments are sorted by time, so the last one carries the maximum
+        last_comment = self._comments.comment_at(count - 1)
+        return self.uses_long_format(last_comment.time / MILLISECONDS_PER_SECOND)

--- a/mpvqc/startup.py
+++ b/mpvqc/startup.py
@@ -13,6 +13,7 @@ def perform_startup(process_started_at: float) -> Never:
     configure_logging()
     configure_dependency_injection()
     configure_environment_variables()
+    pin_windows_ui_library()
 
     import_mpvqc_bindings()
 
@@ -64,6 +65,21 @@ def configure_environment_variables() -> None:
 
     # Requirement for mpv
     os.environ["LC_NUMERIC"] = "C"
+
+
+def pin_windows_ui_library() -> None:
+    import sys
+
+    if sys.platform != "win32":
+        return
+
+    import ctypes
+
+    # mpv's and Qt's shutdown do not go well together: Windows may unload this
+    # library while Qt still holds pointers into it, crashing on exit. An extra
+    # reference keeps it loaded until the process ends.
+    # pyrefly: ignore [missing-attribute]
+    ctypes.WinDLL("Windows.UI.dll")
 
 
 def import_mpvqc_bindings() -> None:

--- a/mpvqc/startup.py
+++ b/mpvqc/startup.py
@@ -77,6 +77,8 @@ def import_mpvqc_bindings() -> None:
 def start_application(process_started_at: float) -> Never:
     import sys
 
+    from PySide6.QtCore import QThreadPool
+
     from mpvqc.application import MpvqcApplication
 
     app = MpvqcApplication(sys.argv)
@@ -87,7 +89,10 @@ def start_application(process_started_at: float) -> Never:
 
     app.start()
 
-    sys.exit(app.exec())
+    exit_code = app.exec()
+    # A pool worker still calling into Python during interpreter teardown segfaults
+    QThreadPool.globalInstance().waitForDone()
+    sys.exit(exit_code)
 
 
 def log_startup_time(process_started_at: float) -> None:

--- a/mpvqc/viewmodels/utility/label_width_calculator.py
+++ b/mpvqc/viewmodels/utility/label_width_calculator.py
@@ -8,9 +8,9 @@ from PySide6.QtCore import Property, QCoreApplication, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
 
 from mpvqc.services import (
+    CommentTypesPolicyService,
     InternationalizationService,
     LabelWidthCalculatorService,
-    SettingsService,
     TimeFormatPolicyService,
 )
 
@@ -25,9 +25,9 @@ def _time_candidates(*, long_format: bool) -> list[str]:
 
 @QmlElement
 class MpvqcLabelWidthCalculatorViewModel(QObject):
-    _settings = inject.attr(SettingsService)
     _i18n = inject.attr(InternationalizationService)
-    _policy = inject.attr(TimeFormatPolicyService)
+    _comment_types_policy = inject.attr(CommentTypesPolicyService)
+    _time_format_policy = inject.attr(TimeFormatPolicyService)
     _width_service = inject.attr(LabelWidthCalculatorService)
 
     commentTypesLabelWidthChanged = Signal(int)
@@ -40,8 +40,8 @@ class MpvqcLabelWidthCalculatorViewModel(QObject):
         self._time_label_width = self._compute_time_label_width()
 
         self._i18n.retranslated.connect(self._update_comment_types_label_width)
-        self._settings.comment_types_changed.connect(self._update_comment_types_label_width)
-        self._policy.table_long_format_changed.connect(self._update_time_label_width)
+        self._comment_types_policy.displayable_comment_types_changed.connect(self._update_comment_types_label_width)
+        self._time_format_policy.table_long_format_changed.connect(self._update_time_label_width)
 
     @Property(int, notify=commentTypesLabelWidthChanged)
     def commentTypesLabelWidth(self) -> int:
@@ -66,9 +66,10 @@ class MpvqcLabelWidthCalculatorViewModel(QObject):
             self.timeLabelWidthChanged.emit(value)
 
     def _compute_comment_types_label_width(self) -> int:
-        labels = [QCoreApplication.translate("CommentTypes", ct) for ct in self._settings.comment_types]
+        types = self._comment_types_policy.displayable_comment_types
+        labels = [QCoreApplication.translate("CommentTypes", ct) for ct in types]
         return self._width_service.calculate_width_for(labels)
 
     def _compute_time_label_width(self) -> int:
-        candidates = _time_candidates(long_format=self._policy.table_long_format)
+        candidates = _time_candidates(long_format=self._time_format_policy.table_long_format)
         return self._width_service.calculate_width_for(candidates)

--- a/mpvqc/viewmodels/utility/label_width_calculator.py
+++ b/mpvqc/viewmodels/utility/label_width_calculator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Iterator
 
 import inject
 from PySide6.QtCore import Property, QCoreApplication, QObject, Signal, Slot
@@ -18,9 +19,9 @@ QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
 
 
-def _time_candidates(*, long_format: bool) -> list[str]:
+def _time_candidates(*, long_format: bool) -> Iterator[str]:
     pattern = "{0}{0}:" * (3 if long_format else 2)
-    return [pattern.format(digit)[:-1] for digit in range(10)]
+    return (pattern.format(digit)[:-1] for digit in range(10))
 
 
 @QmlElement
@@ -67,7 +68,7 @@ class MpvqcLabelWidthCalculatorViewModel(QObject):
 
     def _compute_comment_types_label_width(self) -> int:
         types = self._comment_types_policy.displayable_comment_types
-        labels = [QCoreApplication.translate("CommentTypes", ct) for ct in types]
+        labels = (QCoreApplication.translate("CommentTypes", ct) for ct in types)
         return self._width_service.calculate_width_for(labels)
 
     def _compute_time_label_width(self) -> int:

--- a/mpvqc/viewmodels/utility/label_width_calculator.py
+++ b/mpvqc/viewmodels/utility/label_width_calculator.py
@@ -4,19 +4,30 @@
 
 
 import inject
-from PySide6.QtCore import Property, QObject, QTimer, Signal, Slot
+from PySide6.QtCore import Property, QCoreApplication, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
 
-from mpvqc.services import LabelWidthCalculatorService, PlayerService, SettingsService
+from mpvqc.services import (
+    InternationalizationService,
+    LabelWidthCalculatorService,
+    SettingsService,
+    TimeFormatPolicyService,
+)
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
 
 
+def _time_candidates(*, long_format: bool) -> list[str]:
+    pattern = "{0}{0}:" * (3 if long_format else 2)
+    return [pattern.format(digit)[:-1] for digit in range(10)]
+
+
 @QmlElement
 class MpvqcLabelWidthCalculatorViewModel(QObject):
     _settings = inject.attr(SettingsService)
-    _player = inject.attr(PlayerService)
+    _i18n = inject.attr(InternationalizationService)
+    _policy = inject.attr(TimeFormatPolicyService)
     _width_service = inject.attr(LabelWidthCalculatorService)
 
     commentTypesLabelWidthChanged = Signal(int)
@@ -25,38 +36,39 @@ class MpvqcLabelWidthCalculatorViewModel(QObject):
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
 
-        self._comment_type_label_width = 0
-        self._time_label_width = 0
+        self._comment_types_label_width = self._compute_comment_types_label_width()
+        self._time_label_width = self._compute_time_label_width()
 
-        self._update_comment_types_label_width()
-        self._update_time_label_width()
-
-        self._settings.language_changed.connect(self._schedule_comment_types_label_width_update)
-        self._settings.comment_types_changed.connect(self._schedule_comment_types_label_width_update)
-        self._player.duration_changed.connect(self._schedule_update_time_label_width_update)
+        self._i18n.retranslated.connect(self._update_comment_types_label_width)
+        self._settings.comment_types_changed.connect(self._update_comment_types_label_width)
+        self._policy.table_long_format_changed.connect(self._update_time_label_width)
 
     @Property(int, notify=commentTypesLabelWidthChanged)
     def commentTypesLabelWidth(self) -> int:
-        return self._comment_type_label_width
-
-    @Slot()
-    def _schedule_comment_types_label_width_update(self) -> None:
-        QTimer.singleShot(0, self._update_comment_types_label_width)
-
-    def _update_comment_types_label_width(self) -> None:
-        new_width = self._width_service.calculate_comment_types_width(self._settings.comment_types)
-        self._comment_type_label_width = new_width
-        self.commentTypesLabelWidthChanged.emit(new_width)
+        return self._comment_types_label_width
 
     @Property(int, notify=timeLabelWidthChanged)
     def timeLabelWidth(self) -> int:
         return self._time_label_width
 
     @Slot()
-    def _schedule_update_time_label_width_update(self) -> None:
-        QTimer.singleShot(0, self._update_time_label_width)
+    def _update_comment_types_label_width(self) -> None:
+        value = self._compute_comment_types_label_width()
+        if value != self._comment_types_label_width:
+            self._comment_types_label_width = value
+            self.commentTypesLabelWidthChanged.emit(value)
 
+    @Slot()
     def _update_time_label_width(self) -> None:
-        new_width = self._width_service.calculate_time_width(self._player.duration)
-        self._time_label_width = new_width
-        self.timeLabelWidthChanged.emit(new_width)
+        value = self._compute_time_label_width()
+        if value != self._time_label_width:
+            self._time_label_width = value
+            self.timeLabelWidthChanged.emit(value)
+
+    def _compute_comment_types_label_width(self) -> int:
+        labels = [QCoreApplication.translate("CommentTypes", ct) for ct in self._settings.comment_types]
+        return self._width_service.calculate_width_for(labels)
+
+    def _compute_time_label_width(self) -> int:
+        candidates = _time_candidates(long_format=self._policy.table_long_format)
+        return self._width_service.calculate_width_for(candidates)

--- a/mpvqc/viewmodels/views/footer.py
+++ b/mpvqc/viewmodels/views/footer.py
@@ -206,4 +206,4 @@ class MpvqcFooterViewModel(QObject):
     def _derive_time_width(self) -> int:
         if not self._time_text:
             return 0
-        return self._label_calculator.calculate_width_for([self._time_text])
+        return self._label_calculator.calculate_width_for((self._time_text,))

--- a/mpvqc/viewmodels/views/footer.py
+++ b/mpvqc/viewmodels/views/footer.py
@@ -7,12 +7,16 @@ from PySide6.QtCore import Property, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
 
 from mpvqc.enums import TimeFormat
-from mpvqc.services import LabelWidthCalculatorService, PlayerService, SettingsService, TimeFormatterService
+from mpvqc.services import (
+    LabelWidthCalculatorService,
+    PlayerService,
+    SettingsService,
+    TimeFormatPolicyService,
+    TimeFormatterService,
+)
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
-
-SECONDS_PER_HOUR = 3600
 
 
 @QmlElement
@@ -186,7 +190,7 @@ class MpvqcFooterViewModel(QObject):
     def _derive_time_text(self) -> str:
         if not self._video_loaded:
             return ""
-        long_format = self._duration >= SECONDS_PER_HOUR
+        long_format = TimeFormatPolicyService.uses_long_format(self._duration)
         match self._time_format:
             case TimeFormat.CURRENT_TIME:
                 return self._formatter.format_time_to_string(self._time_pos, long_format=long_format)

--- a/mpvqc/viewmodels/views/table/table_utility.py
+++ b/mpvqc/viewmodels/views/table/table_utility.py
@@ -6,7 +6,7 @@ import inject
 from PySide6.QtCore import Property, QObject, Signal
 from PySide6.QtQml import QmlElement
 
-from mpvqc.services import PlayerService
+from mpvqc.services import TimeFormatPolicyService
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
@@ -14,14 +14,14 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 @QmlElement
 class MpvqcTableUtilityViewModel(QObject):
-    _player = inject.attr(PlayerService)
+    _policy = inject.attr(TimeFormatPolicyService)
 
-    durationChanged = Signal(float)
+    tableLongFormatChanged = Signal(bool)
 
     def __init__(self, /) -> None:
         super().__init__()
-        self._player.duration_changed.connect(self.durationChanged)
+        self._policy.table_long_format_changed.connect(self.tableLongFormatChanged)
 
-    @Property(float, notify=durationChanged)
-    def duration(self) -> float:
-        return self._player.duration
+    @Property(bool, notify=tableLongFormatChanged)
+    def tableLongFormat(self) -> bool:
+        return self._policy.table_long_format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -474,6 +474,7 @@ files = [
     "qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBoxPosition.qml",
     "qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBoxStacking.qml",
     "qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Selection.qml",
+    "qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_TypeLabelClamp.qml",
     "qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_Undo.qml",
     "qt/qml/MpvqcApplication.qml",
     "qt/qml/MpvqcStyle/Button.qml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ files = [
     "mpvqc/services/settings.py",
     "mpvqc/services/state.py",
     "mpvqc/services/theme.py",
+    "mpvqc/services/time_format_policy.py",
     "mpvqc/services/type_mapper.py",
     "mpvqc/services/version_checker.py",
     "mpvqc/services/video_resize.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ files = [
     "mpvqc/services/application_paths.py",
     "mpvqc/services/build_info.py",
     "mpvqc/services/comment_type_validator.py",
+    "mpvqc/services/comment_types_policy.py",
     "mpvqc/services/comments/__init__.py",
     "mpvqc/services/comments/commands.py",
     "mpvqc/services/comments/history.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,6 +484,7 @@ files = [
     "qt/qml/MpvqcStyle/ToolButton.qml",
     "qt/qml/MpvqcStyle/ToolSeparator.qml",
     "qt/qml/MpvqcStyle/ToolTip.qml",
+    "qt/qml/tst_MpvqcApplication.qml",
     "testqml/__init__.py",
     "testqml/bridge.py",
     "testqml/fixtures/portable-root/appdata/backups/.keep",

--- a/qt/qml/MpvqcApplication.qml
+++ b/qt/qml/MpvqcApplication.qml
@@ -17,8 +17,9 @@ ApplicationWindow {
     width: 1280
     height: 720
 
-    minimumWidth: 960
-    minimumHeight: 540
+    // The minimum is meant for the window geometry; the surface adds the drop shadow margin on both sides.
+    minimumWidth: 960 + 2 * MpvqcWindowUtility.dropShadowMargin
+    minimumHeight: 540 + 2 * MpvqcWindowUtility.dropShadowMargin
 
     visible: false
     color: MpvqcWindowUtility.drawsDropShadow ? "transparent" : M.Material.background
@@ -47,11 +48,15 @@ ApplicationWindow {
 
     Rectangle {
         id: _frame
+        objectName: "windowFrame"
 
         anchors.fill: parent
         anchors.margins: MpvqcWindowUtility.dropShadowMargin
         radius: MpvqcWindowUtility.windowRadius
         color: M.Material.background
+
+        // Overflowing content must not paint into the drop shadow margin.
+        clip: MpvqcWindowUtility.dropShadowMargin > 0
 
         MpvqcApplicationContent {
             id: _content

--- a/qt/qml/io/github/mpvqc/mpvQC/Utility/MpvqcWindowUtility.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Utility/MpvqcWindowUtility.qml
@@ -11,7 +11,7 @@ import io.github.mpvqc.mpvQC.Python
 QtObject {
 
     // Mutable, not readonly: the QML test harness swaps in a fresh view model per test.
-    property MpvqcWindowViewModel _viewModel: MpvqcWindowViewModel {}
+    property var _viewModel: MpvqcWindowViewModel {}
 
     readonly property int windowGeometryWidth: _viewModel.windowGeometryWidth
     readonly property int windowGeometryHeight: _viewModel.windowGeometryHeight

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListDelegate.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListDelegate.qml
@@ -142,8 +142,10 @@ Item {
 
             text: qsTranslate("CommentTypes", root.commentType)
             horizontalAlignment: Text.AlignLeft
+            elide: Text.ElideRight
 
-            width: MpvqcLabelWidthCalculator.commentTypesLabelWidth + leftPadding + rightPadding
+            // Capped so a pathological type name cannot squeeze the comment column out.
+            width: Math.min(MpvqcLabelWidthCalculator.commentTypesLabelWidth + leftPadding + rightPadding, root.width / 3)
             height: root.height
 
             leftPadding: root.horizontalItemPadding

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcTableUtility.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcTableUtility.qml
@@ -10,9 +10,9 @@ import io.github.mpvqc.mpvQC.Python
 
 QtObject {
     // Mutable, not readonly: the QML test harness swaps in a fresh view model per test.
-    property MpvqcTableUtilityViewModel viewModel: MpvqcTableUtilityViewModel {}
+    property var viewModel: MpvqcTableUtilityViewModel {}
 
-    readonly property bool useLongFormat: viewModel.duration >= 3600
+    readonly property bool useLongFormat: viewModel.tableLongFormat
     readonly property var _reForbidden: /[\u00AD\r\n]/gi
 
     readonly property var _highlightCache: ({

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableUtility.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableUtility.qml
@@ -16,8 +16,14 @@ TestCase {
 
     property Component utilityComponent: Qt.createComponent("MpvqcTableUtility.qml")
 
-    function makeUtility(properties: var): var {
-        const utility = createTemporaryObject(utilityComponent, testCase, properties ?? {});
+    function makeUtility(useLongFormat = false): var {
+        const viewModel = createTemporaryObject(viewModelMockComponent, testCase, {
+            tableLongFormat: useLongFormat
+        });
+        verify(viewModel);
+        const utility = createTemporaryObject(utilityComponent, testCase, {
+            viewModel
+        });
         verify(utility);
         return utility;
     }
@@ -100,9 +106,7 @@ TestCase {
     }
 
     function test_formatTime(data): void {
-        const utility = makeUtility({
-            useLongFormat: data.useLongFormat
-        });
+        const utility = makeUtility(data.useLongFormat);
         compare(utility.formatTime(data.milliseconds), data.expected);
     }
 
@@ -162,7 +166,7 @@ TestCase {
     }
 
     function test_sanitizeText(data): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
 
         // Call twice with the same fresh input to guard against accidental
         // statefulness in the shared `_reForbidden` regex (e.g. lastIndex
@@ -225,40 +229,48 @@ TestCase {
     }
 
     function test_highlightComment(data): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
         compare(utility.highlightComment(data.comment, data.highlight), data.expected);
     }
 
     function test_highlightComment_isStableAcrossRepeatedQueries(): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
         compare(utility.highlightComment("Hello world", "world"), "Hello <b><u>world</u></b>");
         compare(utility.highlightComment("another world here", "world"), "another <b><u>world</u></b> here");
         compare(utility.highlightComment("no match here", "world"), "no match here");
     }
 
     function test_highlightComment_recompilesWhenQueryChanges(): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
         compare(utility.highlightComment("foo bar", "foo"), "<b><u>foo</u></b> bar");
         compare(utility.highlightComment("foo bar", "bar"), "foo <b><u>bar</u></b>");
         compare(utility.highlightComment("foo bar", "foo"), "<b><u>foo</u></b> bar");
     }
 
     function test_highlightComment_returnsCommentUnchangedForEmptyQuery(): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
         compare(utility.highlightComment("Hello world", ""), "Hello world");
     }
 
     function test_highlightComment_emptyQueryBetweenSameQueryStillHighlights(): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
         compare(utility.highlightComment("Hello world", "world"), "Hello <b><u>world</u></b>");
         compare(utility.highlightComment("Hello world", ""), "Hello world");
         compare(utility.highlightComment("Hello world", "world"), "Hello <b><u>world</u></b>");
     }
 
     function test_highlightComment_emptyQueryBetweenDifferentQueriesStillHighlights(): void {
-        const utility = makeUtility({});
+        const utility = makeUtility();
         compare(utility.highlightComment("foo bar", "foo"), "<b><u>foo</u></b> bar");
         compare(utility.highlightComment("foo bar", ""), "foo bar");
         compare(utility.highlightComment("foo bar", "bar"), "foo <b><u>bar</u></b>");
+    }
+
+    Component {
+        id: viewModelMockComponent
+
+        QtObject {
+            property bool tableLongFormat: false
+        }
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_TypeLabelClamp.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_TypeLabelClamp.qml
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: mpvQC developers
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+import io.github.mpvqc.mpvQC.Utility
+
+TestCase {
+    id: testCase
+
+    width: 600
+    height: 400
+    visible: true
+    when: windowShown
+    name: "MpvqcTableView::TypeLabelClamp"
+
+    readonly property int timeout: 2000
+
+    readonly property Component objectUnderTest: Component {
+        MpvqcTableView {
+            backupEnabled: false
+
+            height: testCase.height
+            width: testCase.width
+        }
+    }
+
+    readonly property Component mirroredObjectUnderTest: Component {
+        MpvqcTableView {
+            backupEnabled: false
+
+            height: testCase.height
+            width: testCase.width
+
+            LayoutMirroring.enabled: true
+            LayoutMirroring.childrenInherit: true
+        }
+    }
+
+    readonly property string _pathologicalTypeName: "A".repeat(400)
+
+    function initTestCase(): void {
+        _helpers.initTestCase();
+    }
+
+    function init(): void {
+        MpvqcLabelWidthCalculator.commentTypesLabelWidth = 150;
+    }
+
+    function makeControl(component: Component, commentType: string): var {
+        _helpers.bridge.resetComments();
+        const control = createTemporaryObject(component, testCase);
+        verify(control);
+        _helpers.bridge.importComments([
+            {
+                "time": 1000,
+                "commentType": commentType,
+                "comment": "Comment 1"
+            }
+        ]);
+        waitForRendering(control);
+        return control;
+    }
+
+    function _typeLabel(control: MpvqcTableView): Label {
+        const delegate = control.commentList.itemAtIndex(0);
+        return findChild(delegate, "commentTypeLabel") as Label;
+    }
+
+    function _commentLabel(control: MpvqcTableView): Label {
+        const delegate = control.commentList.itemAtIndex(0);
+        return findChild(delegate, "commentLabel") as Label;
+    }
+
+    function test_hugeMeasuredWidthClampsToTableFraction_data(): var {
+        return [
+            {
+                tag: "ltr",
+                component: objectUnderTest
+            },
+            {
+                tag: "rtl",
+                component: mirroredObjectUnderTest
+            },
+        ];
+    }
+
+    function test_hugeMeasuredWidthClampsToTableFraction(data: var): void {
+        const control = makeControl(data.component, _pathologicalTypeName);
+
+        MpvqcLabelWidthCalculator.commentTypesLabelWidth = 100000;
+
+        const typeLabel = _typeLabel(control);
+        tryCompare(typeLabel, "width", control.width / 3);
+        tryVerify(() => typeLabel.truncated);
+
+        const commentLabel = _commentLabel(control);
+        verify(commentLabel.width > 100);
+    }
+
+    function test_normalMeasuredWidthRendersUnclamped(): void {
+        const control = makeControl(objectUnderTest, "Comment Type 1");
+
+        const typeLabel = _typeLabel(control);
+        compare(typeLabel.width, 150 + typeLabel.leftPadding + typeLabel.rightPadding);
+        verify(!typeLabel.truncated);
+    }
+
+    TestHelpers {
+        id: _helpers
+
+        testCase: testCase
+    }
+}

--- a/qt/qml/tst_MpvqcApplication.qml
+++ b/qt/qml/tst_MpvqcApplication.qml
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: mpvQC developers
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtTest
+
+import io.github.mpvqc.mpvQC.Utility
+
+TestCase {
+    id: testCase
+
+    name: "MpvqcApplication"
+
+    property Component appComponent: Qt.createComponent("MpvqcApplication.qml")
+
+    property var _originalWindowViewModel: null
+
+    function makeWindow(margin: int): var {
+        windowViewModelMock.dropShadowMargin = margin;
+        MpvqcWindowUtility._viewModel = windowViewModelMock;
+
+        const window = createTemporaryObject(appComponent, testCase);
+        verify(window);
+        return window;
+    }
+
+    function init(): void {
+        if (!_originalWindowViewModel) {
+            _originalWindowViewModel = MpvqcWindowUtility._viewModel;
+        }
+    }
+
+    function cleanup(): void {
+        MpvqcWindowUtility._viewModel = _originalWindowViewModel;
+        MpvqcWindowUtility.contentFrame = null;
+    }
+
+    function test_minimumSizeCoversDropShadowMargin_data(): var {
+        return [
+            {
+                tag: "no-margin",
+                margin: 0,
+                expectedMinimumWidth: 960,
+                expectedMinimumHeight: 540
+            },
+            {
+                tag: "drop-shadow-margin",
+                margin: 88,
+                expectedMinimumWidth: 1136,
+                expectedMinimumHeight: 716
+            }
+        ];
+    }
+
+    function test_minimumSizeCoversDropShadowMargin(data): void {
+        const window = makeWindow(data.margin);
+
+        compare(window.minimumWidth, data.expectedMinimumWidth);
+        compare(window.minimumHeight, data.expectedMinimumHeight);
+    }
+
+    function test_frameClipsOverflowingContent(): void {
+        const window = makeWindow(88);
+
+        const frame = findChild(window, "windowFrame");
+        verify(frame, "windowFrame not found");
+        verify(frame.clip, "the frame must clip, otherwise content paints into the drop shadow margin");
+    }
+
+    QtObject {
+        id: windowViewModelMock
+
+        readonly property int windowGeometryWidth: 1280
+        readonly property int windowGeometryHeight: 720
+        readonly property bool isFullscreen: false
+        readonly property bool isMaximized: false
+        readonly property int radius: 0
+        readonly property bool keepsNativeFrame: false
+        readonly property bool drawsDropShadow: true
+        readonly property bool isMainWindowFocused: true
+
+        property int dropShadowMargin: 0
+    }
+}

--- a/test/services/comments/test_comments_changed.py
+++ b/test/services/comments/test_comments_changed.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+
+from mpvqc.datamodels import Comment
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda c: c.add_row(25, "commentType"), id="add"),
+        pytest.param(lambda c: c.update_comment(0, "edited text"), id="update-text"),
+        pytest.param(lambda c: c.update_comment_type(0, "other type"), id="update-type"),
+        pytest.param(lambda c: c.update_time(0, 99), id="update-time"),
+        pytest.param(lambda c: c.remove_row(0), id="remove"),
+        pytest.param(
+            lambda c: c.import_comments((Comment(time=99, comment_type="commentType", comment="Word 6"),)),
+            id="import",
+        ),
+    ],
+)
+def test_mutation_fires_comments_changed(comments, make_spy, mutate):
+    spy = make_spy(comments.comments_changed)
+
+    mutate(comments)
+
+    assert spy.count() == 1
+
+
+def test_undo_redo_fire_comments_changed(comments, make_spy):
+    comments.add_row(99, "commentType")
+    spy = make_spy(comments.comments_changed)
+
+    comments.undo()
+    assert spy.count() == 1
+
+    spy.reset()
+    comments.redo()
+    assert spy.count() == 1
+
+
+def test_reset_fires_comments_changed_but_not_dirty(comments, make_spy):
+    changed_spy = make_spy(comments.comments_changed)
+    dirty_spy = make_spy(comments.dirty)
+
+    comments.reset()
+
+    assert changed_spy.count() == 1
+    assert dirty_spy.count() == 0

--- a/test/services/comments/test_distinct_comment_types.py
+++ b/test/services/comments/test_distinct_comment_types.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+
+from mpvqc.datamodels import Comment
+
+
+def test_reports_distinct_types_of_document(make_comments):
+    comments = make_comments(
+        set_comments=(
+            Comment(time=0, comment_type="Phrasing", comment=""),
+            Comment(time=5, comment_type="Spelling", comment=""),
+            Comment(time=10, comment_type="Phrasing", comment=""),
+        )
+    )
+
+    assert comments.distinct_comment_types == {"Phrasing", "Spelling"}
+
+
+def test_add_introduces_the_new_type(comments):
+    comments.add_row(30, "Translation")
+
+    assert comments.distinct_comment_types == {"commentType", "Translation"}
+
+
+def test_removing_the_last_carrier_drops_the_type(comments):
+    comments.add_row(30, "Translation")
+
+    comments.remove_row(5)
+
+    assert comments.distinct_comment_types == {"commentType"}
+
+
+def test_type_carried_by_several_comments_survives_removing_one(comments):
+    comments.remove_row(0)
+
+    assert comments.distinct_comment_types == {"commentType"}
+
+
+def test_type_edit_away_from_single_carrier_drops_old_type_and_undo_restores_it(comments):
+    comments.add_row(30, "Translation")
+
+    comments.update_comment_type(5, "Phrasing")
+    assert comments.distinct_comment_types == {"commentType", "Phrasing"}
+
+    comments.undo()
+    assert comments.distinct_comment_types == {"commentType", "Translation"}
+
+
+def test_import_undo_redo_track_the_imported_types(comments):
+    comments.import_comments((Comment(time=99, comment_type="Translation", comment=""),))
+    assert comments.distinct_comment_types == {"commentType", "Translation"}
+
+    comments.undo()
+    assert comments.distinct_comment_types == {"commentType"}
+
+    comments.redo()
+    assert comments.distinct_comment_types == {"commentType", "Translation"}
+
+
+def test_reset_empties_the_set(comments):
+    comments.reset()
+
+    assert comments.distinct_comment_types == frozenset()
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda c: c.add_row(25, "added type"), id="add"),
+        pytest.param(lambda c: c.update_comment(0, "edited text"), id="update-text"),
+        pytest.param(lambda c: c.update_comment_type(0, "other type"), id="update-type"),
+        pytest.param(lambda c: c.update_time(0, 99), id="update-time"),
+        pytest.param(lambda c: c.remove_row(0), id="remove"),
+        pytest.param(
+            lambda c: c.import_comments((Comment(time=99, comment_type="imported type", comment=""),)),
+            id="import",
+        ),
+        pytest.param(lambda c: c.reset(), id="reset"),
+    ],
+)
+def test_property_equals_fresh_scan_after_every_mutation_kind(make_comments, mutate):
+    comments = make_comments(
+        set_comments=(
+            Comment(time=0, comment_type="Spelling", comment="Word 1"),
+            Comment(time=5, comment_type="Phrasing", comment="Word 2"),
+            Comment(time=10, comment_type="Phrasing", comment="Word 3"),
+        )
+    )
+
+    def fresh_scan():
+        return frozenset(c.comment_type for c in comments.comments())
+
+    mutate(comments)
+    assert comments.distinct_comment_types == fresh_scan()
+
+    comments.undo()
+    assert comments.distinct_comment_types == fresh_scan()
+
+    comments.redo()
+    assert comments.distinct_comment_types == fresh_scan()

--- a/test/services/test_comment_types_policy.py
+++ b/test/services/test_comment_types_policy.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inject
+import pytest
+from PySide6.QtCore import QObject, Signal
+
+from mpvqc.services import CommentsService, CommentTypesPolicyService, SettingsService
+
+
+class CommentsServiceMock(QObject):
+    """Doubles the comments service surface the policy consumes: a real signal, a stubbed accessor."""
+
+    comments_changed = Signal()
+
+    def __init__(self):
+        super().__init__()
+        assert isinstance(CommentsService.comments_changed, Signal), "mocked surface drifted: not a signal anymore"
+        assert isinstance(CommentsService.distinct_comment_types, property), (
+            "mocked surface drifted: not a property anymore"
+        )
+        self._types: frozenset[str] = frozenset()
+
+    @property
+    def distinct_comment_types(self) -> frozenset[str]:
+        return self._types
+
+    def mutate_comments(self, *types: str) -> None:
+        """Simulates any committed document mutation, leaving these types present."""
+        self._types = frozenset(types)
+        self.comments_changed.emit()
+
+
+@pytest.fixture
+def comments_service_mock() -> CommentsServiceMock:
+    return CommentsServiceMock()
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with, settings_service, comments_service_mock):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind(SettingsService, settings_service)
+        binder.bind(CommentsService, comments_service_mock)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture(autouse=True)
+def configured_types(settings_service):
+    settings_service.comment_types = ["Translation", "Spelling"]
+
+
+@pytest.fixture
+def policy() -> CommentTypesPolicyService:
+    return CommentTypesPolicyService()
+
+
+def test_displayable_types_union_configured_and_document_types(settings_service, comments_service_mock):
+    comments_service_mock.mutate_comments("Spelling", "CustomType")
+
+    policy = CommentTypesPolicyService()
+
+    assert policy.displayable_comment_types == frozenset({"Translation", "Spelling", "CustomType"})
+
+
+def test_unknown_type_entering_and_leaving_document_emits(policy, comments_service_mock, make_spy):
+    spy = make_spy(policy.displayable_comment_types_changed)
+
+    comments_service_mock.mutate_comments("CustomType")
+
+    assert policy.displayable_comment_types == frozenset({"Translation", "Spelling", "CustomType"})
+    assert spy.count() == 1
+    assert spy.at(invocation=0, argument=0) == frozenset({"Translation", "Spelling", "CustomType"})
+
+    comments_service_mock.mutate_comments()
+
+    assert policy.displayable_comment_types == frozenset({"Translation", "Spelling"})
+    assert spy.count() == 2
+    assert spy.at(invocation=1, argument=0) == frozenset({"Translation", "Spelling"})
+
+
+def test_configured_type_list_change_emits(policy, settings_service, make_spy):
+    spy = make_spy(policy.displayable_comment_types_changed)
+
+    settings_service.comment_types = ["Translation", "Spelling", "Timing"]
+
+    assert policy.displayable_comment_types == frozenset({"Translation", "Spelling", "Timing"})
+    assert spy.count() == 1
+
+    settings_service.comment_types = ["Translation"]
+
+    assert policy.displayable_comment_types == frozenset({"Translation"})
+    assert spy.count() == 2
+
+
+def test_mutation_keeping_types_does_not_emit(policy, comments_service_mock, make_spy):
+    comments_service_mock.mutate_comments("CustomType")
+    spy = make_spy(policy.displayable_comment_types_changed)
+
+    comments_service_mock.mutate_comments("CustomType")
+
+    assert spy.count() == 0
+
+
+def test_adding_comment_with_configured_type_does_not_emit(policy, comments_service_mock, make_spy):
+    spy = make_spy(policy.displayable_comment_types_changed)
+
+    comments_service_mock.mutate_comments("Spelling")
+
+    assert spy.count() == 0
+
+
+def test_reordering_configured_types_does_not_emit(policy, settings_service, make_spy):
+    spy = make_spy(policy.displayable_comment_types_changed)
+
+    settings_service.comment_types = ["Spelling", "Translation"]
+
+    assert spy.count() == 0
+
+
+def test_removing_configured_type_still_in_document_does_not_emit(
+    policy, settings_service, comments_service_mock, make_spy
+):
+    comments_service_mock.mutate_comments("Spelling")
+    spy = make_spy(policy.displayable_comment_types_changed)
+
+    settings_service.comment_types = ["Translation"]
+
+    assert policy.displayable_comment_types == frozenset({"Translation", "Spelling"})
+    assert spy.count() == 0

--- a/test/services/test_label_width_calculator.py
+++ b/test/services/test_label_width_calculator.py
@@ -31,6 +31,17 @@ def test_empty_input_yields_zero(calculator):
     assert calculator.calculate_width_for([]) == 0
 
 
+def test_empty_generator_yields_zero(calculator):
+    empty: list[str] = []
+    assert calculator.calculate_width_for(text for text in empty) == 0
+
+
+def test_one_shot_generator_measures_like_a_list(calculator):
+    expected = calculator.calculate_width_for(["i", "Wwwwwwwwww"])
+
+    assert calculator.calculate_width_for(text for text in ["i", "Wwwwwwwwww"]) == expected
+
+
 def test_width_is_the_advance_width_rounded_up(calculator):
     advance = QFontMetricsF(inject.instance(FontLoaderService).application_font()).horizontalAdvance("Translation")
 

--- a/test/services/test_label_width_calculator.py
+++ b/test/services/test_label_width_calculator.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inject
+import pytest
+from PySide6.QtGui import QFontMetricsF
+
+from mpvqc.services import FontLoaderService, LabelWidthCalculatorService
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind_to_constructor(FontLoaderService, FontLoaderService)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture(autouse=True)
+def qt_app_must_be_running(qt_app):
+    pass
+
+
+@pytest.fixture
+def calculator() -> LabelWidthCalculatorService:
+    return LabelWidthCalculatorService()
+
+
+def test_empty_input_yields_zero(calculator):
+    assert calculator.calculate_width_for([]) == 0
+
+
+def test_width_is_the_advance_width_rounded_up(calculator):
+    advance = QFontMetricsF(inject.instance(FontLoaderService).application_font()).horizontalAdvance("Translation")
+
+    width = calculator.calculate_width_for(["Translation"])
+
+    assert advance <= width < advance + 1
+
+
+def test_widest_text_wins(calculator):
+    widest = calculator.calculate_width_for(["Wwwwwwwwww"])
+
+    assert calculator.calculate_width_for(["i", "Wwwwwwwwww"]) == widest

--- a/test/services/test_time_format_policy.py
+++ b/test/services/test_time_format_policy.py
@@ -70,53 +70,53 @@ def test_uses_long_format_is_inclusive_at_one_hour(duration_seconds, expected):
 
 def test_duration_crossing_one_hour_flips_flag(policy, player_service_mock, make_spy):
     spy = make_spy(policy.table_long_format_changed)
-    assert policy.table_long_format is False
+    assert not policy.table_long_format
 
     player_service_mock.update(duration=3600.0)
-    assert policy.table_long_format is True
+    assert policy.table_long_format
     assert spy.count() == 1
     assert spy.at(invocation=0, argument=0) is True
 
     player_service_mock.update(duration=3599.0)
-    assert policy.table_long_format is False
+    assert not policy.table_long_format
     assert spy.count() == 2
     assert spy.at(invocation=1, argument=0) is False
 
 
 def test_long_comment_appearing_and_disappearing_flips_flag(policy, comments_service_mock):
     comments_service_mock.set_comments(0, ONE_HOUR_MS)
-    assert policy.table_long_format is True
+    assert policy.table_long_format
 
     comments_service_mock.set_comments(0)
-    assert policy.table_long_format is False
+    assert not policy.table_long_format
 
 
 def test_comment_times_normalize_from_milliseconds(policy, comments_service_mock):
     comments_service_mock.set_comments(ONE_HOUR_MS - 1)
-    assert policy.table_long_format is False
+    assert not policy.table_long_format
 
     comments_service_mock.set_comments(ONE_HOUR_MS)
-    assert policy.table_long_format is True
+    assert policy.table_long_format
 
 
 def test_duration_and_comment_times_combine(policy, player_service_mock, comments_service_mock):
     player_service_mock.update(duration=3600.0)
     comments_service_mock.set_comments(1_000)
-    assert policy.table_long_format is True
+    assert policy.table_long_format
 
     player_service_mock.update(duration=10.0)
-    assert policy.table_long_format is False
+    assert not policy.table_long_format
 
     comments_service_mock.set_comments(1_000, ONE_HOUR_MS)
-    assert policy.table_long_format is True
+    assert policy.table_long_format
 
 
 def test_reset_returns_flag_to_short(policy, comments_service_mock):
     comments_service_mock.set_comments(ONE_HOUR_MS)
-    assert policy.table_long_format is True
+    assert policy.table_long_format
 
     comments_service_mock.set_comments()
-    assert policy.table_long_format is False
+    assert not policy.table_long_format
 
 
 def test_unchanged_flag_does_not_emit(policy, player_service_mock, comments_service_mock, make_spy):
@@ -137,4 +137,4 @@ def test_flag_computes_at_construction(player_service_mock):
 
     policy = TimeFormatPolicyService()
 
-    assert policy.table_long_format is True
+    assert policy.table_long_format

--- a/test/services/test_time_format_policy.py
+++ b/test/services/test_time_format_policy.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inject
+import pytest
+from PySide6.QtCore import QObject, Signal
+
+from mpvqc.datamodels import Comment
+from mpvqc.services import CommentsService, PlayerService, TimeFormatPolicyService
+
+ONE_HOUR_MS = 3_600_000
+
+
+class CommentsServiceMock(QObject):
+    """Doubles the comments service surface the policy consumes: a real signal, a stubbed accessor."""
+
+    comments_changed = Signal()
+
+    def __init__(self):
+        super().__init__()
+        assert isinstance(CommentsService.comments_changed, Signal), "mocked surface drifted: not a signal anymore"
+        assert isinstance(CommentsService.count, property), "mocked surface drifted: not a property anymore"
+        assert callable(CommentsService.comment_at), "mocked surface drifted: not a plain method anymore"
+        self._comments: tuple[Comment, ...] = ()
+
+    @property
+    def count(self) -> int:
+        return len(self._comments)
+
+    def comment_at(self, row: int) -> Comment:
+        return self._comments[row]
+
+    def set_comments(self, *times: int) -> None:
+        self._comments = tuple(Comment(time=time, comment_type="commentType", comment="") for time in sorted(times))
+        self.comments_changed.emit()
+
+
+@pytest.fixture
+def comments_service_mock() -> CommentsServiceMock:
+    return CommentsServiceMock()
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with, player_service_mock, comments_service_mock):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind(PlayerService, player_service_mock)
+        binder.bind(CommentsService, comments_service_mock)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture
+def policy() -> TimeFormatPolicyService:
+    return TimeFormatPolicyService()
+
+
+@pytest.mark.parametrize(
+    ("duration_seconds", "expected"),
+    [
+        (0, False),
+        (3599, False),
+        (3600, True),
+        (3601, True),
+    ],
+)
+def test_uses_long_format_is_inclusive_at_one_hour(duration_seconds, expected):
+    assert TimeFormatPolicyService.uses_long_format(duration_seconds) is expected
+
+
+def test_duration_crossing_one_hour_flips_flag(policy, player_service_mock, make_spy):
+    spy = make_spy(policy.table_long_format_changed)
+    assert policy.table_long_format is False
+
+    player_service_mock.update(duration=3600.0)
+    assert policy.table_long_format is True
+    assert spy.count() == 1
+    assert spy.at(invocation=0, argument=0) is True
+
+    player_service_mock.update(duration=3599.0)
+    assert policy.table_long_format is False
+    assert spy.count() == 2
+    assert spy.at(invocation=1, argument=0) is False
+
+
+def test_long_comment_appearing_and_disappearing_flips_flag(policy, comments_service_mock):
+    comments_service_mock.set_comments(0, ONE_HOUR_MS)
+    assert policy.table_long_format is True
+
+    comments_service_mock.set_comments(0)
+    assert policy.table_long_format is False
+
+
+def test_comment_times_normalize_from_milliseconds(policy, comments_service_mock):
+    comments_service_mock.set_comments(ONE_HOUR_MS - 1)
+    assert policy.table_long_format is False
+
+    comments_service_mock.set_comments(ONE_HOUR_MS)
+    assert policy.table_long_format is True
+
+
+def test_duration_and_comment_times_combine(policy, player_service_mock, comments_service_mock):
+    player_service_mock.update(duration=3600.0)
+    comments_service_mock.set_comments(1_000)
+    assert policy.table_long_format is True
+
+    player_service_mock.update(duration=10.0)
+    assert policy.table_long_format is False
+
+    comments_service_mock.set_comments(1_000, ONE_HOUR_MS)
+    assert policy.table_long_format is True
+
+
+def test_reset_returns_flag_to_short(policy, comments_service_mock):
+    comments_service_mock.set_comments(ONE_HOUR_MS)
+    assert policy.table_long_format is True
+
+    comments_service_mock.set_comments()
+    assert policy.table_long_format is False
+
+
+def test_unchanged_flag_does_not_emit(policy, player_service_mock, comments_service_mock, make_spy):
+    spy = make_spy(policy.table_long_format_changed)
+
+    player_service_mock.update(duration=10.0)
+    player_service_mock.update(duration=20.0)
+    comments_service_mock.set_comments(1_000)
+    assert spy.count() == 0
+
+    player_service_mock.update(duration=3600.0)
+    comments_service_mock.set_comments(1_000, ONE_HOUR_MS)
+    assert spy.count() == 1
+
+
+def test_flag_computes_at_construction(player_service_mock):
+    player_service_mock.update(duration=7200.0)
+
+    policy = TimeFormatPolicyService()
+
+    assert policy.table_long_format is True

--- a/test/viewmodels/test_footer.py
+++ b/test/viewmodels/test_footer.py
@@ -82,6 +82,9 @@ def test_percentText(view_model):
         (True, TimeFormat.REMAINING_TIME.value, 7200.0, 3661, 3539, "-00:58:59"),
         (True, TimeFormat.CURRENT_TOTAL_TIME.value, 125.0, 65, 60, "01:05/02:05"),
         (True, TimeFormat.CURRENT_TOTAL_TIME.value, 7200.0, 3661, 3539, "01:01:01/02:00:00"),
+        (True, TimeFormat.CURRENT_TIME.value, 3599.0, 65, 3534, "01:05"),
+        (True, TimeFormat.CURRENT_TIME.value, 3600.0, 65, 3535, "00:01:05"),
+        (True, TimeFormat.CURRENT_TOTAL_TIME.value, 3600.0, 3600, 0, "01:00:00/01:00:00"),
     ],
 )
 def test_timeText(view_model, video_loaded, time_format, duration, time_pos, time_remaining, expected):

--- a/test/viewmodels/test_label_width_calculator.py
+++ b/test/viewmodels/test_label_width_calculator.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inject
+import pytest
+
+from mpvqc.services import (
+    FontLoaderService,
+    InternationalizationService,
+    LabelWidthCalculatorService,
+    PlayerService,
+    SettingsService,
+    TimeFormatPolicyService,
+)
+from mpvqc.viewmodels import MpvqcLabelWidthCalculatorViewModel
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with, player_service_mock, settings_service):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind(PlayerService, player_service_mock)
+        binder.bind(SettingsService, settings_service)
+        binder.bind_to_constructor(FontLoaderService, FontLoaderService)
+        binder.bind_to_constructor(InternationalizationService, InternationalizationService)
+        binder.bind_to_constructor(LabelWidthCalculatorService, LabelWidthCalculatorService)
+        binder.bind_to_constructor(TimeFormatPolicyService, TimeFormatPolicyService)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture(autouse=True)
+def qt_app_must_be_running(qt_app):
+    pass
+
+
+@pytest.fixture
+def view_model() -> MpvqcLabelWidthCalculatorViewModel:
+    # noinspection PyCallingNonCallable
+    return MpvqcLabelWidthCalculatorViewModel()
+
+
+def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, make_spy):
+    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+    english_width = view_model.commentTypesLabelWidth
+    assert english_width > 0
+
+    inject.instance(InternationalizationService).retranslate(qt_app, "de-DE")
+
+    assert view_model.commentTypesLabelWidth != english_width
+    assert spy.count() == 1
+    assert spy.at(invocation=0, argument=0) == view_model.commentTypesLabelWidth
+
+
+def test_comment_types_width_recomputes_on_comment_types_change(view_model, settings_service, make_spy):
+    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+
+    settings_service.comment_types = ["i"]
+    narrow_width = view_model.commentTypesLabelWidth
+    assert spy.count() == 1
+
+    settings_service.comment_types = ["Wwwwwwwwwwwwwwwwwwww"]
+
+    assert view_model.commentTypesLabelWidth > narrow_width
+    assert spy.count() == 2
+
+
+def test_comment_types_width_of_same_value_does_not_emit(view_model, settings_service, make_spy):
+    settings_service.comment_types = ["Wwwwwwwwww"]
+    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+
+    settings_service.comment_types = ["Wwwwwwwwww", "i"]
+
+    assert spy.count() == 0
+
+
+def test_time_width_flips_with_format(view_model, player_service_mock, make_spy):
+    spy = make_spy(view_model.timeLabelWidthChanged)
+    short_width = view_model.timeLabelWidth
+    assert short_width > 0
+
+    player_service_mock.update(duration=3600.0)
+
+    long_width = view_model.timeLabelWidth
+    assert long_width > short_width
+    assert spy.count() == 1
+    assert spy.at(invocation=0, argument=0) == long_width
+
+    player_service_mock.update(duration=3599.0)
+
+    assert view_model.timeLabelWidth == short_width
+    assert spy.count() == 2

--- a/test/viewmodels/test_label_width_calculator.py
+++ b/test/viewmodels/test_label_width_calculator.py
@@ -90,14 +90,15 @@ def test_comment_types_width_follows_displayable_types(view_model, comment_types
 
 
 def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, comment_types_policy_mock, make_spy):
-    comment_types_policy_mock.change_displayable_types("Translation")
+    # "Spelling" -> "Rechtschreibung" grows on every font engine; near-equal pairs tie on Windows.
+    comment_types_policy_mock.change_displayable_types("Spelling")
     spy = make_spy(view_model.commentTypesLabelWidthChanged)
     english_width = view_model.commentTypesLabelWidth
     assert english_width > 0
 
     inject.instance(InternationalizationService).retranslate(qt_app, "de-DE")
 
-    assert view_model.commentTypesLabelWidth != english_width
+    assert view_model.commentTypesLabelWidth > english_width
     assert spy.count() == 1
     assert spy.at(invocation=0, argument=0) == view_model.commentTypesLabelWidth
 

--- a/test/viewmodels/test_label_width_calculator.py
+++ b/test/viewmodels/test_label_width_calculator.py
@@ -4,23 +4,53 @@
 
 import inject
 import pytest
+from PySide6.QtCore import QObject, Signal
 
 from mpvqc.services import (
+    CommentTypesPolicyService,
     FontLoaderService,
     InternationalizationService,
     LabelWidthCalculatorService,
     PlayerService,
-    SettingsService,
     TimeFormatPolicyService,
 )
 from mpvqc.viewmodels import MpvqcLabelWidthCalculatorViewModel
 
 
+class CommentTypesPolicyServiceMock(QObject):
+    """Doubles the policy surface the view model consumes: a real signal, a stubbed accessor."""
+
+    displayable_comment_types_changed = Signal(frozenset)
+
+    def __init__(self):
+        super().__init__()
+        assert isinstance(CommentTypesPolicyService.displayable_comment_types_changed, Signal), (
+            "mocked surface drifted: not a signal anymore"
+        )
+        assert isinstance(CommentTypesPolicyService.displayable_comment_types, property), (
+            "mocked surface drifted: not a property anymore"
+        )
+        self._types: frozenset[str] = frozenset()
+
+    @property
+    def displayable_comment_types(self) -> frozenset[str]:
+        return self._types
+
+    def change_displayable_types(self, *types: str) -> None:
+        self._types = frozenset(types)
+        self.displayable_comment_types_changed.emit(self._types)
+
+
+@pytest.fixture
+def comment_types_policy_mock() -> CommentTypesPolicyServiceMock:
+    return CommentTypesPolicyServiceMock()
+
+
 @pytest.fixture(autouse=True)
-def configure_inject(common_bindings_with, player_service_mock, settings_service):
+def configure_inject(common_bindings_with, player_service_mock, comment_types_policy_mock):
     def custom_bindings(binder: inject.Binder):
         binder.bind(PlayerService, player_service_mock)
-        binder.bind(SettingsService, settings_service)
+        binder.bind(CommentTypesPolicyService, comment_types_policy_mock)
         binder.bind_to_constructor(FontLoaderService, FontLoaderService)
         binder.bind_to_constructor(InternationalizationService, InternationalizationService)
         binder.bind_to_constructor(LabelWidthCalculatorService, LabelWidthCalculatorService)
@@ -40,7 +70,27 @@ def view_model() -> MpvqcLabelWidthCalculatorViewModel:
     return MpvqcLabelWidthCalculatorViewModel()
 
 
-def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, make_spy):
+def test_comment_types_width_follows_displayable_types(view_model, comment_types_policy_mock, make_spy):
+    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+
+    comment_types_policy_mock.change_displayable_types("i")
+    narrow_width = view_model.commentTypesLabelWidth
+    assert narrow_width > 0
+    assert spy.count() == 1
+
+    comment_types_policy_mock.change_displayable_types("i", "Wwwwwwwwwwwwwwwwwwww")
+    wide_width = view_model.commentTypesLabelWidth
+    assert wide_width > narrow_width
+    assert spy.count() == 2
+    assert spy.at(invocation=1, argument=0) == wide_width
+
+    comment_types_policy_mock.change_displayable_types("i")
+    assert view_model.commentTypesLabelWidth == narrow_width
+    assert spy.count() == 3
+
+
+def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, comment_types_policy_mock, make_spy):
+    comment_types_policy_mock.change_displayable_types("Translation")
     spy = make_spy(view_model.commentTypesLabelWidthChanged)
     english_width = view_model.commentTypesLabelWidth
     assert english_width > 0
@@ -52,24 +102,21 @@ def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, mak
     assert spy.at(invocation=0, argument=0) == view_model.commentTypesLabelWidth
 
 
-def test_comment_types_width_recomputes_on_comment_types_change(view_model, settings_service, make_spy):
+def test_unknown_type_measures_verbatim_after_retranslation(qt_app, view_model, comment_types_policy_mock):
+    comment_types_policy_mock.change_displayable_types("CustomTypeXyz")
+    english_width = view_model.commentTypesLabelWidth
+    assert english_width > 0
+
+    inject.instance(InternationalizationService).retranslate(qt_app, "de-DE")
+
+    assert view_model.commentTypesLabelWidth == english_width
+
+
+def test_comment_types_width_of_same_value_does_not_emit(view_model, comment_types_policy_mock, make_spy):
+    comment_types_policy_mock.change_displayable_types("Wwwwwwwwww")
     spy = make_spy(view_model.commentTypesLabelWidthChanged)
 
-    settings_service.comment_types = ["i"]
-    narrow_width = view_model.commentTypesLabelWidth
-    assert spy.count() == 1
-
-    settings_service.comment_types = ["Wwwwwwwwwwwwwwwwwwww"]
-
-    assert view_model.commentTypesLabelWidth > narrow_width
-    assert spy.count() == 2
-
-
-def test_comment_types_width_of_same_value_does_not_emit(view_model, settings_service, make_spy):
-    settings_service.comment_types = ["Wwwwwwwwww"]
-    spy = make_spy(view_model.commentTypesLabelWidthChanged)
-
-    settings_service.comment_types = ["Wwwwwwwwww", "i"]
+    comment_types_policy_mock.change_displayable_types("Wwwwwwwwww", "i")
 
     assert spy.count() == 0
 

--- a/test/viewmodels/test_table_utility.py
+++ b/test/viewmodels/test_table_utility.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inject
+import pytest
+
+from mpvqc.datamodels import Comment
+from mpvqc.services import CommentsService, PlayerService, TimeFormatPolicyService
+from mpvqc.viewmodels import MpvqcTableUtilityViewModel
+
+ONE_HOUR_MS = 3_600_000
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with, player_service_mock):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind(PlayerService, player_service_mock)
+        binder.bind_to_constructor(TimeFormatPolicyService, TimeFormatPolicyService)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture
+def comments() -> CommentsService:
+    return inject.instance(CommentsService)
+
+
+@pytest.fixture
+def view_model() -> MpvqcTableUtilityViewModel:
+    # noinspection PyCallingNonCallable
+    return MpvqcTableUtilityViewModel()
+
+
+def _comment_at(time: int) -> Comment:
+    return Comment(time=time, comment_type="commentType", comment="")
+
+
+def test_long_comment_flips_to_long_format_without_video(view_model, comments, make_spy):
+    spy = make_spy(view_model.tableLongFormatChanged)
+    assert view_model.tableLongFormat is False
+
+    comments.import_comments([_comment_at(ONE_HOUR_MS)])
+
+    assert view_model.tableLongFormat is True
+    assert spy.count() == 1
+    assert spy.at(invocation=0, argument=0) is True
+
+
+def test_long_comment_with_shorter_video_uses_long_format(view_model, comments, player_service_mock):
+    player_service_mock.update(video_loaded=True, duration=125.0)
+    assert view_model.tableLongFormat is False
+
+    comments.import_comments([_comment_at(5_400_000)])
+
+    assert view_model.tableLongFormat is True
+
+
+def test_undo_returns_to_short_format(view_model, comments):
+    comments.import_comments([_comment_at(ONE_HOUR_MS)])
+    assert view_model.tableLongFormat is True
+
+    comments.undo()
+
+    assert view_model.tableLongFormat is False
+
+
+def test_reset_returns_to_short_format(view_model, comments):
+    comments.import_comments([_comment_at(ONE_HOUR_MS)])
+    assert view_model.tableLongFormat is True
+
+    comments.reset()
+
+    assert view_model.tableLongFormat is False
+
+
+def test_duration_of_exactly_one_hour_uses_long_format(view_model, player_service_mock):
+    player_service_mock.update(duration=3600.0)
+    assert view_model.tableLongFormat is True
+
+    player_service_mock.update(duration=3599.0)
+    assert view_model.tableLongFormat is False

--- a/test/viewmodels/test_table_utility.py
+++ b/test/viewmodels/test_table_utility.py
@@ -38,45 +38,45 @@ def _comment_at(time: int) -> Comment:
 
 def test_long_comment_flips_to_long_format_without_video(view_model, comments, make_spy):
     spy = make_spy(view_model.tableLongFormatChanged)
-    assert view_model.tableLongFormat is False
+    assert not view_model.tableLongFormat
 
     comments.import_comments([_comment_at(ONE_HOUR_MS)])
 
-    assert view_model.tableLongFormat is True
+    assert view_model.tableLongFormat
     assert spy.count() == 1
     assert spy.at(invocation=0, argument=0) is True
 
 
 def test_long_comment_with_shorter_video_uses_long_format(view_model, comments, player_service_mock):
     player_service_mock.update(video_loaded=True, duration=125.0)
-    assert view_model.tableLongFormat is False
+    assert not view_model.tableLongFormat
 
     comments.import_comments([_comment_at(5_400_000)])
 
-    assert view_model.tableLongFormat is True
+    assert view_model.tableLongFormat
 
 
 def test_undo_returns_to_short_format(view_model, comments):
     comments.import_comments([_comment_at(ONE_HOUR_MS)])
-    assert view_model.tableLongFormat is True
+    assert view_model.tableLongFormat
 
     comments.undo()
 
-    assert view_model.tableLongFormat is False
+    assert not view_model.tableLongFormat
 
 
 def test_reset_returns_to_short_format(view_model, comments):
     comments.import_comments([_comment_at(ONE_HOUR_MS)])
-    assert view_model.tableLongFormat is True
+    assert view_model.tableLongFormat
 
     comments.reset()
 
-    assert view_model.tableLongFormat is False
+    assert not view_model.tableLongFormat
 
 
 def test_duration_of_exactly_one_hour_uses_long_format(view_model, player_service_mock):
     player_service_mock.update(duration=3600.0)
-    assert view_model.tableLongFormat is True
+    assert view_model.tableLongFormat
 
     player_service_mock.update(duration=3599.0)
-    assert view_model.tableLongFormat is False
+    assert not view_model.tableLongFormat

--- a/testqml/bridge.py
+++ b/testqml/bridge.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 
 import inject
 from PySide6.QtCore import Property, QObject, QThreadPool, QUrl, Slot
-from PySide6.QtQml import QmlElement, QQmlEngine, QQmlProperty
+from PySide6.QtQml import QmlElement, QQmlContext, QQmlEngine, QQmlExpression
 
 from mpvqc.datamodels import Comment
 from mpvqc.dialogs.import_wizard import MpvqcImportWizardViewModel
@@ -150,8 +150,16 @@ class MpvqcTestBridge(QObject):
             previous = [child for child in singleton.children() if isinstance(child, entry.view_model_class)]
             view_model = entry.view_model_class()
             view_model.setParent(singleton)
-            if not QQmlProperty.write(singleton, entry.property_name, view_model):
-                msg = f"Cannot swap {entry.property_name} on {entry.singleton_name}"
+            # Assign through a JS expression, not QQmlProperty.write: only a JS
+            # assignment removes the property's declarative initializer. Left in
+            # place, it re-fires when the previous view model is destroyed and
+            # stomps the fresh one with null.
+            swap_context = QQmlContext(engine.rootContext())
+            swap_context.setContextProperty("__freshViewModel", view_model)
+            expression = QQmlExpression(swap_context, singleton, f"{entry.property_name} = __freshViewModel")
+            expression.evaluate()
+            if expression.hasError():
+                msg = f"Cannot swap {entry.property_name} on {entry.singleton_name}: {expression.error()}"
                 raise RuntimeError(msg)
             for old in previous:
                 old.deleteLater()


### PR DESCRIPTION
## Manual checks before merging

### 🌐 Anywhere

#### Comment table times

- [x] Importing a document with a comment past one hour into a session with no or a shorter video flips the visible rows to HH:MM:SS at once
- [x] Undoing that import returns the visible rows to MM:SS
- [x] The edit-time popup shows the row's time in the same format as the table
- [x] The delete confirmation names the comment's time in the same format as the table

#### Table columns

- [x] The time column widens and narrows together with the format flip
- [x] Switching the language resizes the comment type column in one step, no flicker
- [x] Adding a wider comment type in the settings widens the column immediately
- [x] Importing a document with a comment type wider than any configured one widens the type column at once
- [x] Undoing that import narrows the type column back
- [x] An absurdly long comment type from an imported document caps at a third of the table, the comment text stays readable
- [x] On Linux, the time column shows no clipped digits in either format
- [x] On Linux, the widest comment type label keeps clear air to the column edge

#### Footer

- [x] On Linux, with a video of an hour or more, every footer time format fits without eliding or per-second jitter
- [x] Known and accepted: a long imported comment flips the table but not the footer, which follows the video duration alone

#### Quitting

- [x] Quitting right after triggering a save, export, or backup exits cleanly, repeated a few times, never a segfault in the terminal

#### Dev rebuild

- [x] `just build-develop` while a dev instance runs leaves the running app intact, icons and dialogs still load

### 🪟 Windows

#### Table columns

- [x] The time column shows no clipped digits in either format
- [x] The widest comment type label keeps clear air to the column edge

#### Footer

- [x] With a video of an hour or more, every footer time format fits without eliding or per-second jitter

### 🐧 Linux desktop

#### Window resize

- [x] Dragging a window edge stops while 960x540 of content stays visible
- [x] At the smallest window with video and table side by side, the comment rows end at the window border, nothing paints into the drop shadow
- [x] Maximizing and restoring lands back at the previous size with border, shadow and resize band intact
