### PR TITLE
refactor: view model snapshot pattern

### DIFF
--- a/.agents/skills/committing/SKILL.md
+++ b/.agents/skills/committing/SKILL.md
@@ -43,8 +43,15 @@ Agent-facing rules live in `CLAUDE.md` and the skills beside this one. A rule th
 
 The body says why, not what. The diff already shows what. No bullet list of individual changes.
 
-Plain, everyday English, the casual register of an open source log. When the work came from a plan, the message stands
-without it: a reader who never saw the plan still understands it.
+Plain, everyday English, the casual register of an open source log: common words and short sentences a non-native
+reader follows on the first pass. When the work came from a plan, the message stands without it: a reader who never
+saw the plan still understands it.
+
+Modest claims: the message promises only what you verified. A change that narrows a symptom narrows it; "fixes" is
+for behaviour you watched fail and then pass.
+
+Faults are behaviour, not blame: say what the code did and stop there. No author, no culprit commit, no project at
+fault, no talk of reporting anything upstream.
 
 ## After
 
@@ -55,3 +62,4 @@ When a larger chunk of work is done, offer to push, and to write the manual chec
 - The new files this change brings are added, and nothing else is.
 - `just fmt` came back clean, and whatever it rewrote outside this change stayed out of the commit.
 - Each doc in the table that the change reaches now describes what the code does.
+- The message claims only what was verified, in everyday words, and names no culprit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@
 ### Issue tracker
 
 User reports and triage live on GitHub Issues; larger chunks of work are planned as local markdown under
-`.scratch/<feature>/`. See `docs/agents/issue-tracker.md`.
+`.scratch/<feature>/`, and internally found bugs go to `.scratch/bugs/` — never to the public tracker. See
+`docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,8 @@ Terms the code uses. Keep entries short. Add a term when you name a module after
   popup, or native file dialog.
 - **Long time format**: a time rendered with hours, `HH:MM:SS`; the short format is `MM:SS`. A surface uses the long
   format when any time it may display can reach one hour. Exported documents always use the long format.
+- **Time display mode**: which time the footer shows: current, remaining, current over total, or none. Independent of
+  the long and short time format, which only decides whether hours render.
 
 ## Platform
 

--- a/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
+++ b/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
@@ -29,6 +29,13 @@ element, not part of the base pattern. While every upstream dedupes at its sourc
 untestable through the seam. It is added only when an upstream can refire an unchanged payload; the first expected
 case is a payload-free trigger like retranslation.
 
+**Burst coalescing** — a trailing debounce between fold and cycle — is likewise a conditional element, added only
+when a consumer needs one settled emission per upstream burst. Folds still apply every payload immediately; the
+timer defers only derive-and-emit, so the cycle runs once against settled inputs and emits only the deltas that
+survive the burst. The toolbar view model is the first case: its button cascade animation is designed to settle once
+per change, and the player reports a transient no-path on every video switch — the debounce absorbs that
+video-loaded flip before it can reach QML.
+
 ## Consequences
 
 - The interface holds only what the view binds: the properties, their notifies, and real slots. Service wiring is

--- a/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
+++ b/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
@@ -26,8 +26,16 @@ Sourcing is per-field by default: the view model subscribes to the per-field sig
 
 The unchanged-inputs guard — returning early when the folded inputs equal the previous snapshot — is a conditional
 element, not part of the base pattern. While every upstream dedupes at its source, the guard is unreachable and
-untestable through the seam. It is added only when an upstream can refire an unchanged payload; the first expected
-case is a payload-free trigger like retranslation.
+untestable through the seam. It is added only when an upstream can refire an unchanged payload. Retranslation is not
+that case: under the trigger fold it is an ordinary fold of a real value.
+
+**Trigger fold** — the fold for a payload-free trigger signal — is how ambient state enters the snapshot. The
+handler re-reads exactly the ambient values the signal announces, nothing else, and folds them into dedicated inputs
+fields, so the derivation stays pure over the inputs snapshot alone — no injected callables for ambient state.
+Constants read once at construction may sit in the inputs snapshot without a fold. The first case is retranslation:
+the header view model folds the translated unsaved-title template on the internationalization service's retranslated
+signal, which fires only after the translators are installed — the read-at-trigger is as trustworthy as a payload,
+and ordering is structural instead of connection-order luck.
 
 **Burst coalescing** — a trailing debounce between fold and cycle — is likewise a conditional element, added only
 when a consumer needs one settled emission per upstream burst. Folds still apply every payload immediately; the

--- a/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
+++ b/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
@@ -1,0 +1,58 @@
+# Run dataflow view models on the snapshot pattern
+
+A dataflow view model consumes service state and exposes derived values to QML. Written slot by slot, every consumed
+signal gets a public setter, every derived value its own update method, and each hand-maintains its own dedupe and
+its own list of dependents. The derivation smears across the file, the interface fills with members that are wiring
+rather than interface, and tests push state through that wiring past the seam production uses. The footer view model
+was the worst case and is the first migration.
+
+The pattern runs on two frozen structs private to the view model. The **inputs snapshot** holds exactly the scalars
+the view model derives from, one field per consumed upstream signal — a projection whose field list names the exact
+dependency set, never an embedded service state. The **props snapshot** holds the value of every QML-facing
+property. The cycle between them is three motions:
+
+- **Fold**: one private handler per consumed signal replaces that one field in the inputs snapshot and runs the
+  cycle. Services are read exactly once, at construction, to build the initial inputs snapshot; afterwards only
+  signal payloads arrive. Payloads are trustworthy because every upstream emits from stored state, coerced and
+  deduped at its own boundary — so initial-read and update semantics cannot diverge.
+- **Derive**: one pure function takes the inputs snapshot and returns the props snapshot. Pure static helpers are
+  called directly inside it; a stateful dependency crosses as an injected callable, so the signature names the
+  derivation's real dependencies.
+- **Emit**: the new props snapshot is swapped in before the first emission, then each per-field notify emits exactly
+  when its value changed, carrying the new value. The swap completing first makes settled-state reads structural: an
+  observer of any notify sees fully consistent state, independent of connection order.
+
+Sourcing is per-field by default: the view model subscribes to the per-field signals the services already emit.
+
+The unchanged-inputs guard — returning early when the folded inputs equal the previous snapshot — is a conditional
+element, not part of the base pattern. While every upstream dedupes at its source, the guard is unreachable and
+untestable through the seam. It is added only when an upstream can refire an unchanged payload; the first expected
+case is a payload-free trigger like retranslation.
+
+## Consequences
+
+- The interface holds only what the view binds: the properties, their notifies, and real slots. Service wiring is
+  private, so neither callers nor tests can push state past the production seam.
+- Every derived value is verifiable by calling the derivation directly — one table row per case, no view model
+  construction.
+- Wiring tests drive real service signals in and assert exact emission sets out: the fields whose derived value
+  changed, nothing else.
+- An unrelated update never makes QML re-read the other properties, and an unrelated service field never wakes the
+  view model at all.
+- Roughly thirteen dataflow view models are expected to migrate onto the pattern; the rest of the layer — dialog
+  drivers, one-shot commands — coexists unchanged.
+
+## Dropped alternatives
+
+- **A shared single notify** for all properties: one signal on any change makes QML re-read every property and
+  loses per-property change granularity.
+- **Per-value selector objects**, one per derived value with its own recompute and signal: more objects and
+  connection order back in play, for the same observable behavior.
+- **Descriptor or dependency-graph primitives** that declare fields once and generate the wiring: speculative
+  machinery — the cycle is a dozen plain lines per view model.
+- **Read-everything refresh**, re-reading all services on any signal and diffing: reintroduces the initial-read
+  versus update divergence and hides the dependency set the inputs snapshot exists to name.
+- **A player state-snapshot publication**, the player service emitting its whole reduced state as one payload: no
+  two consumed fields co-change in one reduce today, per-field payloads are equally trustworthy, and per-field
+  sourcing wakes consumers strictly less often. Revisit when a consumer must read co-changing fields in one
+  observation — a path load's video-loaded flag together with its dimensions, or both track counts.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,8 +6,10 @@ This repo uses two trackers:
 - **Local markdown** under `.scratch/` — the working tracker for a larger chunk of work: the spec and the implementation
   tickets derived from it.
 
-Routing rule: anything public-facing (user reports, triage, discussion with reporters) lives on GitHub. Internal working
-state for a feature effort (specs, implementation tickets, wayfinder maps) lives in `.scratch/`.
+Routing rule: anything public-facing (user reports, triage, discussion with reporters) lives on GitHub. Everything that
+starts inside the project lives in `.scratch/`: working state for a feature effort (specs, implementation tickets,
+wayfinder maps) and bugs we find ourselves. Only reports from users open GitHub issues — a bug found by the maintainer
+or an agent goes to `.scratch/bugs/`, never to the public tracker.
 
 ## GitHub Issues (public tracker)
 
@@ -29,6 +31,8 @@ _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` r
 ## Local markdown (working tracker)
 
 - One feature per directory: `.scratch/<feature-slug>/`
+- Bugs found internally that belong to no feature effort: one file per bug at `.scratch/bugs/<NN>-<slug>.md`, numbered
+  from `01`, with a `Status:` line near the top
 - The spec is `.scratch/<feature-slug>/spec.md`
 - Implementation issues are one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` —
   never a single combined tickets file
@@ -42,6 +46,7 @@ _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` r
 - Triage outcomes, or comments and labels on a user report → GitHub, via `gh`.
 - A spec or implementation tickets for a feature effort → files under `.scratch/<feature-slug>/` (creating the directory
   if needed).
+- A bug found while working, unrelated to the current effort → a file under `.scratch/bugs/`.
 
 ## When a skill says "fetch the relevant ticket"
 

--- a/mpvqc/enums/__init__.py
+++ b/mpvqc/enums/__init__.py
@@ -12,7 +12,7 @@ from .import_wizard_step_kind import MpvqcImportWizardStepKind as MpvqcImportWiz
 from .import_wizard_step_kind import StepKind as StepKind
 from .message_box_kind import MessageBoxKind as MessageBoxKind
 from .message_box_kind import MpvqcMessageBoxKind as MpvqcMessageBoxKind
-from .time_format import MpvqcTimeFormat as MpvqcTimeFormat
-from .time_format import TimeFormat as TimeFormat
+from .time_display_mode import MpvqcTimeDisplayMode as MpvqcTimeDisplayMode
+from .time_display_mode import TimeDisplayMode as TimeDisplayMode
 from .window_title_format import MpvqcWindowTitleFormat as MpvqcWindowTitleFormat
 from .window_title_format import WindowTitleFormat as WindowTitleFormat

--- a/mpvqc/enums/time_display_mode.py
+++ b/mpvqc/enums/time_display_mode.py
@@ -12,13 +12,13 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 
 @QmlElement
-class MpvqcTimeFormat(QObject):
+class MpvqcTimeDisplayMode(QObject):
     @QEnum
-    class TimeFormat(IntEnum):
-        EMPTY = 0
+    class TimeDisplayMode(IntEnum):
+        NONE = 0
         CURRENT_TIME = 1
         REMAINING_TIME = 2
         CURRENT_TOTAL_TIME = 3
 
 
-TimeFormat = MpvqcTimeFormat.TimeFormat
+TimeDisplayMode = MpvqcTimeDisplayMode.TimeDisplayMode

--- a/mpvqc/services/player/service.py
+++ b/mpvqc/services/player/service.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import inject
-from PySide6.QtCore import Property, QObject, Signal, Slot
+from PySide6.QtCore import QObject, Signal, Slot
 
 from mpvqc.services.application_paths import ApplicationPathsService
 from mpvqc.services.build_info import BuildInfoService
@@ -215,11 +215,11 @@ class PlayerService(QObject):
     def external_subtitles(self) -> tuple[str, ...]:
         return self._state.external_subtitles
 
-    @Property(int, notify=audio_track_count_changed)
+    @property
     def audio_track_count(self) -> int:
         return self._state.audio_track_count
 
-    @Property(int, notify=subtitle_track_count_changed)
+    @property
     def subtitle_track_count(self) -> int:
         return self._state.subtitle_track_count
 

--- a/mpvqc/services/settings.py
+++ b/mpvqc/services/settings.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import (
 )
 
 from mpvqc.datamodels import LANGUAGES, ImportFoundVideo
-from mpvqc.enums import TimeFormat, WindowTitleFormat
+from mpvqc.enums import TimeDisplayMode, WindowTitleFormat
 
 from .application_paths import ApplicationPathsService
 from .type_mapper import TypeMapperService
@@ -193,12 +193,12 @@ class SettingsService(QObject):
         signal=lambda s: s.statusbar_percentage_changed,
     )
 
-    time_format_changed = Signal(int)
-    time_format = _Setting(
+    time_display_mode_changed = Signal(int)
+    time_display_mode = _Setting(
         "StatusBar/timeFormat",
-        default=TimeFormat.CURRENT_TOTAL_TIME.value,
+        default=TimeDisplayMode.CURRENT_TOTAL_TIME.value,
         type_=int,
-        signal=lambda s: s.time_format_changed,
+        signal=lambda s: s.time_display_mode_changed,
     )
 
     last_directory_video_changed = Signal(QUrl)

--- a/mpvqc/viewmodels/views/footer.py
+++ b/mpvqc/viewmodels/views/footer.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
 import inject
 from PySide6.QtCore import Property, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
@@ -19,11 +22,63 @@ QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
 
 
+@dataclass(frozen=True)
+class FooterInputs:
+    video_loaded: bool
+    percent_pos: int
+    time_pos: int
+    time_remaining: int
+    duration: float
+    statusbar_percentage: bool
+    time_display_mode: int
+
+
+@dataclass(frozen=True)
+class FooterProps:
+    statusbar_percentage: bool
+    time_display_mode: int
+    is_percent_visible: bool
+    percent_text: str
+    is_time_visible: bool
+    time_text: str
+    time_width: int
+
+
+def derive_footer_props(inputs: FooterInputs, measure_width: Callable[[str], int]) -> FooterProps:
+    time_text = _derive_time_text(inputs)
+    return FooterProps(
+        statusbar_percentage=inputs.statusbar_percentage,
+        time_display_mode=inputs.time_display_mode,
+        is_percent_visible=inputs.video_loaded and inputs.statusbar_percentage,
+        percent_text=f"{inputs.percent_pos}%",
+        is_time_visible=inputs.video_loaded and inputs.time_display_mode != TimeFormat.EMPTY,
+        time_text=time_text,
+        time_width=measure_width(time_text) if time_text else 0,
+    )
+
+
+def _derive_time_text(inputs: FooterInputs) -> str:
+    if not inputs.video_loaded:
+        return ""
+    long_format = TimeFormatPolicyService.uses_long_format(inputs.duration)
+    to_string = TimeFormatterService.format_time_to_string
+    match inputs.time_display_mode:
+        case TimeFormat.CURRENT_TIME:
+            return to_string(inputs.time_pos, long_format=long_format)
+        case TimeFormat.REMAINING_TIME:
+            return f"-{to_string(inputs.time_remaining, long_format=long_format)}"
+        case TimeFormat.CURRENT_TOTAL_TIME:
+            current = to_string(inputs.time_pos, long_format=long_format)
+            total = to_string(inputs.duration, long_format=long_format)
+            return f"{current}/{total}"
+        case _:
+            return ""
+
+
 @QmlElement
 class MpvqcFooterViewModel(QObject):
     _player = inject.attr(PlayerService)
     _settings = inject.attr(SettingsService)
-    _formatter = inject.attr(TimeFormatterService)
     _label_calculator = inject.attr(LabelWidthCalculatorService)
 
     statusbarPercentageChanged = Signal(bool)
@@ -37,35 +92,87 @@ class MpvqcFooterViewModel(QObject):
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
 
-        self._statusbar_percentage = self._settings.statusbar_percentage
-        self._time_format = self._settings.time_format
-        self._video_loaded = self._player.video_loaded
-        self._percent_pos = self._player.percent_pos or 0
-        self._time_pos = self._player.time_pos or 0
-        self._time_remaining = self._player.time_remaining or 0
-        self._duration = self._player.duration
+        self._inputs = FooterInputs(
+            video_loaded=self._player.video_loaded,
+            percent_pos=self._player.percent_pos,
+            time_pos=self._player.time_pos,
+            time_remaining=self._player.time_remaining,
+            duration=self._player.duration,
+            statusbar_percentage=self._settings.statusbar_percentage,
+            time_display_mode=self._settings.time_format,
+        )
+        self._props = self._derive()
 
-        self._is_percent_visible = self._video_loaded and self._statusbar_percentage
-        self._percent_text = f"{self._percent_pos}%"
-        self._is_time_visible = self._video_loaded and self._time_format != TimeFormat.EMPTY
-        self._time_text = self._derive_time_text()
-        self._time_width = self._derive_time_width()
+        self._settings.statusbar_percentage_changed.connect(self._fold_statusbar_percentage)
+        self._settings.time_format_changed.connect(self._fold_time_display_mode)
+        self._player.video_loaded_changed.connect(self._fold_video_loaded)
+        self._player.percent_pos_changed.connect(self._fold_percent_pos)
+        self._player.time_pos_changed.connect(self._fold_time_pos)
+        self._player.time_remaining_changed.connect(self._fold_time_remaining)
+        self._player.duration_changed.connect(self._fold_duration)
 
-        self._settings.statusbar_percentage_changed.connect(self.setStatusbarPercentage)
-        self._settings.time_format_changed.connect(self.setTimeFormat)
-        self._player.video_loaded_changed.connect(self.setVideoLoaded)
-        self._player.percent_pos_changed.connect(self.setPercentPos)
-        self._player.time_pos_changed.connect(self.setTimePos)
-        self._player.time_remaining_changed.connect(self.setTimeRemaining)
-        self._player.duration_changed.connect(self.setDuration)
+    def _derive(self) -> FooterProps:
+        return derive_footer_props(self._inputs, self._measure_width)
+
+    def _measure_width(self, text: str) -> int:
+        return self._label_calculator.calculate_width_for((text,))
+
+    @Slot(bool)
+    def _fold_statusbar_percentage(self, value: bool) -> None:
+        self._update(replace(self._inputs, statusbar_percentage=value))
+
+    @Slot(int)
+    def _fold_time_display_mode(self, value: int) -> None:
+        self._update(replace(self._inputs, time_display_mode=value))
+
+    @Slot(bool)
+    def _fold_video_loaded(self, value: bool) -> None:
+        self._update(replace(self._inputs, video_loaded=value))
+
+    @Slot(int)
+    def _fold_percent_pos(self, value: int) -> None:
+        self._update(replace(self._inputs, percent_pos=value))
+
+    @Slot(int)
+    def _fold_time_pos(self, value: int) -> None:
+        self._update(replace(self._inputs, time_pos=value))
+
+    @Slot(int)
+    def _fold_time_remaining(self, value: int) -> None:
+        self._update(replace(self._inputs, time_remaining=value))
+
+    @Slot(float)
+    def _fold_duration(self, value: float) -> None:
+        self._update(replace(self._inputs, duration=value))
+
+    def _update(self, inputs: FooterInputs) -> None:
+        self._inputs = inputs
+        new, old = self._derive(), self._props
+        if new == old:
+            return
+        self._props = new
+        if new.statusbar_percentage != old.statusbar_percentage:
+            self.statusbarPercentageChanged.emit(new.statusbar_percentage)
+        if new.time_display_mode != old.time_display_mode:
+            self.timeFormatChanged.emit(new.time_display_mode)
+        if new.is_percent_visible != old.is_percent_visible:
+            self.isPercentVisibleChanged.emit(new.is_percent_visible)
+        if new.percent_text != old.percent_text:
+            self.percentTextChanged.emit(new.percent_text)
+        if new.is_time_visible != old.is_time_visible:
+            self.isTimeVisibleChanged.emit(new.is_time_visible)
+        if new.time_text != old.time_text:
+            self.timeTextChanged.emit(new.time_text)
+        if new.time_width != old.time_width:
+            self.timeWidthChanged.emit(new.time_width)
 
     @Property(bool, notify=statusbarPercentageChanged)
     def statusbarPercentage(self) -> bool:
-        return self._statusbar_percentage
+        return self._props.statusbar_percentage
 
     @Property(int, notify=timeFormatChanged)
     def timeFormat(self) -> int:
-        return self._time_format
+        return self._props.time_display_mode
 
     @timeFormat.setter
     def timeFormat(self, value: int) -> None:
@@ -73,137 +180,24 @@ class MpvqcFooterViewModel(QObject):
 
     @Property(bool, notify=isPercentVisibleChanged)
     def isPercentVisible(self) -> bool:
-        return self._is_percent_visible
+        return self._props.is_percent_visible
 
     @Property(str, notify=percentTextChanged)
     def percentText(self) -> str:
-        return self._percent_text
+        return self._props.percent_text
 
     @Property(bool, notify=isTimeVisibleChanged)
     def isTimeVisible(self) -> bool:
-        return self._is_time_visible
+        return self._props.is_time_visible
 
     @Property(str, notify=timeTextChanged)
     def timeText(self) -> str:
-        return self._time_text
+        return self._props.time_text
 
     @Property(int, notify=timeWidthChanged)
     def timeWidth(self) -> int:
-        return self._time_width
-
-    @Slot(bool)
-    def setStatusbarPercentage(self, value: bool) -> None:
-        if self._statusbar_percentage == value:
-            return
-        self._statusbar_percentage = value
-        self.statusbarPercentageChanged.emit(value)
-        self._update_is_percent_visible()
-
-    @Slot(int)
-    def setTimeFormat(self, value: int) -> None:
-        if self._time_format == value:
-            return
-        self._time_format = value
-        self.timeFormatChanged.emit(value)
-        self._update_is_time_visible()
-        self._update_time_text()
-        self._update_time_width()
-
-    @Slot(bool)
-    def setVideoLoaded(self, value: bool) -> None:
-        if self._video_loaded == value:
-            return
-        self._video_loaded = value
-        self._update_is_percent_visible()
-        self._update_is_time_visible()
-        self._update_time_text()
-        self._update_time_width()
-
-    @Slot(int)
-    def setPercentPos(self, value: int) -> None:
-        if self._percent_pos == value:
-            return
-        self._percent_pos = value
-        self._update_percent_text()
-
-    @Slot(int)
-    def setTimePos(self, value: int) -> None:
-        if self._time_pos == value:
-            return
-        self._time_pos = value
-        self._update_time_text()
-
-    @Slot(int)
-    def setTimeRemaining(self, value: int) -> None:
-        if self._time_remaining == value:
-            return
-        self._time_remaining = value
-        self._update_time_text()
-
-    @Slot(float)
-    def setDuration(self, value: float) -> None:
-        if self._duration == value:
-            return
-        self._duration = value
-        self._update_time_text()
-        self._update_time_width()
+        return self._props.time_width
 
     @Slot()
     def toggleStatusbarPercentage(self) -> None:
-        self._settings.statusbar_percentage = not self._statusbar_percentage
-
-    def _update_is_percent_visible(self) -> None:
-        new_value = self._video_loaded and self._statusbar_percentage
-        if self._is_percent_visible == new_value:
-            return
-        self._is_percent_visible = new_value
-        self.isPercentVisibleChanged.emit(new_value)
-
-    def _update_percent_text(self) -> None:
-        new_value = f"{self._percent_pos}%"
-        if self._percent_text == new_value:
-            return
-        self._percent_text = new_value
-        self.percentTextChanged.emit(new_value)
-
-    def _update_is_time_visible(self) -> None:
-        new_value = self._video_loaded and self._time_format != TimeFormat.EMPTY
-        if self._is_time_visible == new_value:
-            return
-        self._is_time_visible = new_value
-        self.isTimeVisibleChanged.emit(new_value)
-
-    def _update_time_text(self) -> None:
-        new_value = self._derive_time_text()
-        if self._time_text == new_value:
-            return
-        self._time_text = new_value
-        self.timeTextChanged.emit(new_value)
-
-    def _update_time_width(self) -> None:
-        new_value = self._derive_time_width()
-        if self._time_width == new_value:
-            return
-        self._time_width = new_value
-        self.timeWidthChanged.emit(new_value)
-
-    def _derive_time_text(self) -> str:
-        if not self._video_loaded:
-            return ""
-        long_format = TimeFormatPolicyService.uses_long_format(self._duration)
-        match self._time_format:
-            case TimeFormat.CURRENT_TIME:
-                return self._formatter.format_time_to_string(self._time_pos, long_format=long_format)
-            case TimeFormat.REMAINING_TIME:
-                return f"-{self._formatter.format_time_to_string(self._time_remaining, long_format=long_format)}"
-            case TimeFormat.CURRENT_TOTAL_TIME:
-                current = self._formatter.format_time_to_string(self._time_pos, long_format=long_format)
-                total = self._formatter.format_time_to_string(self._duration, long_format=long_format)
-                return f"{current}/{total}"
-            case _:
-                return ""
-
-    def _derive_time_width(self) -> int:
-        if not self._time_text:
-            return 0
-        return self._label_calculator.calculate_width_for((self._time_text,))
+        self._settings.statusbar_percentage = not self._props.statusbar_percentage

--- a/mpvqc/viewmodels/views/footer.py
+++ b/mpvqc/viewmodels/views/footer.py
@@ -9,7 +9,7 @@ import inject
 from PySide6.QtCore import Property, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
 
-from mpvqc.enums import TimeFormat
+from mpvqc.enums import TimeDisplayMode
 from mpvqc.services import (
     LabelWidthCalculatorService,
     PlayerService,
@@ -51,7 +51,7 @@ def derive_footer_props(inputs: FooterInputs, measure_width: Callable[[str], int
         time_display_mode=inputs.time_display_mode,
         is_percent_visible=inputs.video_loaded and inputs.statusbar_percentage,
         percent_text=f"{inputs.percent_pos}%",
-        is_time_visible=inputs.video_loaded and inputs.time_display_mode != TimeFormat.EMPTY,
+        is_time_visible=inputs.video_loaded and inputs.time_display_mode != TimeDisplayMode.NONE,
         time_text=time_text,
         time_width=measure_width(time_text) if time_text else 0,
     )
@@ -63,11 +63,11 @@ def _derive_time_text(inputs: FooterInputs) -> str:
     long_format = TimeFormatPolicyService.uses_long_format(inputs.duration)
     to_string = TimeFormatterService.format_time_to_string
     match inputs.time_display_mode:
-        case TimeFormat.CURRENT_TIME:
+        case TimeDisplayMode.CURRENT_TIME:
             return to_string(inputs.time_pos, long_format=long_format)
-        case TimeFormat.REMAINING_TIME:
+        case TimeDisplayMode.REMAINING_TIME:
             return f"-{to_string(inputs.time_remaining, long_format=long_format)}"
-        case TimeFormat.CURRENT_TOTAL_TIME:
+        case TimeDisplayMode.CURRENT_TOTAL_TIME:
             current = to_string(inputs.time_pos, long_format=long_format)
             total = to_string(inputs.duration, long_format=long_format)
             return f"{current}/{total}"
@@ -82,7 +82,7 @@ class MpvqcFooterViewModel(QObject):
     _label_calculator = inject.attr(LabelWidthCalculatorService)
 
     statusbarPercentageChanged = Signal(bool)
-    timeFormatChanged = Signal(int)
+    timeDisplayModeChanged = Signal(int)
     isPercentVisibleChanged = Signal(bool)
     percentTextChanged = Signal(str)
     isTimeVisibleChanged = Signal(bool)
@@ -99,12 +99,12 @@ class MpvqcFooterViewModel(QObject):
             time_remaining=self._player.time_remaining,
             duration=self._player.duration,
             statusbar_percentage=self._settings.statusbar_percentage,
-            time_display_mode=self._settings.time_format,
+            time_display_mode=self._settings.time_display_mode,
         )
         self._props = self._derive()
 
         self._settings.statusbar_percentage_changed.connect(self._fold_statusbar_percentage)
-        self._settings.time_format_changed.connect(self._fold_time_display_mode)
+        self._settings.time_display_mode_changed.connect(self._fold_time_display_mode)
         self._player.video_loaded_changed.connect(self._fold_video_loaded)
         self._player.percent_pos_changed.connect(self._fold_percent_pos)
         self._player.time_pos_changed.connect(self._fold_time_pos)
@@ -154,7 +154,7 @@ class MpvqcFooterViewModel(QObject):
         if new.statusbar_percentage != old.statusbar_percentage:
             self.statusbarPercentageChanged.emit(new.statusbar_percentage)
         if new.time_display_mode != old.time_display_mode:
-            self.timeFormatChanged.emit(new.time_display_mode)
+            self.timeDisplayModeChanged.emit(new.time_display_mode)
         if new.is_percent_visible != old.is_percent_visible:
             self.isPercentVisibleChanged.emit(new.is_percent_visible)
         if new.percent_text != old.percent_text:
@@ -170,13 +170,13 @@ class MpvqcFooterViewModel(QObject):
     def statusbarPercentage(self) -> bool:
         return self._props.statusbar_percentage
 
-    @Property(int, notify=timeFormatChanged)
-    def timeFormat(self) -> int:
+    @Property(int, notify=timeDisplayModeChanged)
+    def timeDisplayMode(self) -> int:
         return self._props.time_display_mode
 
-    @timeFormat.setter
-    def timeFormat(self, value: int) -> None:
-        self._settings.time_format = value
+    @timeDisplayMode.setter
+    def timeDisplayMode(self, value: int) -> None:
+        self._settings.time_display_mode = value
 
     @Property(bool, notify=isPercentVisibleChanged)
     def isPercentVisible(self) -> bool:

--- a/mpvqc/viewmodels/views/header/header.py
+++ b/mpvqc/viewmodels/views/header/header.py
@@ -2,15 +2,49 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from dataclasses import dataclass, replace
+
 import inject
 from PySide6.QtCore import Property, QCoreApplication, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
 
 from mpvqc.enums import WindowTitleFormat
-from mpvqc.services import PlayerService, SettingsService, StateService
+from mpvqc.services import InternationalizationService, PlayerService, SettingsService, StateService
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
+
+
+@dataclass(frozen=True)
+class HeaderInputs:
+    video_loaded: bool
+    filename: str
+    path: str
+    window_title_format: int
+    has_unsaved_document: bool
+    app_name: str
+    unsaved_template: str
+
+
+@dataclass(frozen=True)
+class HeaderProps:
+    window_title: str
+
+
+def derive_header_props(inputs: HeaderInputs) -> HeaderProps:
+    if not inputs.video_loaded or inputs.window_title_format == WindowTitleFormat.DEFAULT:
+        title = inputs.app_name
+    elif inputs.window_title_format == WindowTitleFormat.FILE_NAME:
+        title = inputs.filename
+    elif inputs.window_title_format == WindowTitleFormat.FILE_PATH:
+        title = inputs.path
+    else:
+        msg = "Cannot determine window title: configuration not known"
+        raise ValueError(msg)
+
+    if not inputs.has_unsaved_document:
+        return HeaderProps(window_title=title)
+    return HeaderProps(window_title=inputs.unsaved_template.replace("%1", title))
 
 
 @QmlElement
@@ -18,46 +52,67 @@ class MpvqcHeaderViewModel(QObject):
     _player = inject.attr(PlayerService)
     _settings = inject.attr(SettingsService)
     _state = inject.attr(StateService)
+    _i18n = inject.attr(InternationalizationService)
 
     windowTitleChanged = Signal(str)
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._window_title = self._derive_window_title()
-        self._player.video_loaded_changed.connect(self._update_window_title)
-        self._player.path_changed.connect(self._update_window_title)
-        self._player.filename_changed.connect(self._update_window_title)
-        self._settings.window_title_format_changed.connect(self._update_window_title)
-        self._settings.language_changed.connect(self._update_window_title)
-        self._state.has_unsaved_document_changed.connect(self._update_window_title)
+        self._inputs = HeaderInputs(
+            video_loaded=self._player.video_loaded,
+            filename=self._player.filename,
+            path=self._player.path,
+            window_title_format=self._settings.window_title_format,
+            has_unsaved_document=self._state.has_unsaved_document,
+            app_name=QCoreApplication.applicationName(),
+            unsaved_template=self._read_unsaved_template(),
+        )
+        self._props = derive_header_props(self._inputs)
+
+        self._player.video_loaded_changed.connect(self._fold_video_loaded)
+        self._player.filename_changed.connect(self._fold_filename)
+        self._player.path_changed.connect(self._fold_path)
+        self._settings.window_title_format_changed.connect(self._fold_window_title_format)
+        self._state.has_unsaved_document_changed.connect(self._fold_has_unsaved_document)
+        self._i18n.retranslated.connect(self._fold_retranslated)
+
+    @staticmethod
+    def _read_unsaved_template() -> str:
+        #: %1 will be the title of the application (one of: mpvQC, file name, file path)
+        return QCoreApplication.translate("MainWindow", "%1 (unsaved)")
+
+    @Slot(bool)
+    def _fold_video_loaded(self, value: bool) -> None:
+        self._update(replace(self._inputs, video_loaded=value))
+
+    @Slot(str)
+    def _fold_filename(self, value: str) -> None:
+        self._update(replace(self._inputs, filename=value))
+
+    @Slot(str)
+    def _fold_path(self, value: str) -> None:
+        self._update(replace(self._inputs, path=value))
+
+    @Slot(int)
+    def _fold_window_title_format(self, value: int) -> None:
+        self._update(replace(self._inputs, window_title_format=value))
+
+    @Slot(bool)
+    def _fold_has_unsaved_document(self, value: bool) -> None:
+        self._update(replace(self._inputs, has_unsaved_document=value))
+
+    @Slot()
+    def _fold_retranslated(self) -> None:
+        self._update(replace(self._inputs, unsaved_template=self._read_unsaved_template()))
+
+    def _update(self, inputs: HeaderInputs) -> None:
+        self._inputs = inputs
+        new, old = derive_header_props(self._inputs), self._props
+        if new == old:
+            return
+        self._props = new
+        self.windowTitleChanged.emit(new.window_title)
 
     @Property(str, notify=windowTitleChanged)
     def windowTitle(self) -> str:
-        return self._window_title
-
-    @Slot()
-    def _update_window_title(self) -> None:
-        new_value = self._derive_window_title()
-        if new_value == self._window_title:
-            return
-        self._window_title = new_value
-        self.windowTitleChanged.emit(new_value)
-
-    def _derive_window_title(self) -> str:
-        window_title_format = self._settings.window_title_format
-
-        if not self._player.video_loaded or window_title_format == WindowTitleFormat.DEFAULT:
-            title = QCoreApplication.applicationName()
-        elif window_title_format == WindowTitleFormat.FILE_NAME:
-            title = self._player.filename or ""
-        elif window_title_format == WindowTitleFormat.FILE_PATH:
-            title = self._player.path or ""
-        else:
-            msg = "Cannot determine window title: configuration not known"
-            raise ValueError(msg)
-
-        if not self._state.has_unsaved_document:
-            return title
-
-        #: %1 will be the title of the application (one of: mpvQC, file name, file path)
-        return QCoreApplication.translate("MainWindow", "%1 (unsaved)").replace("%1", title)
+        return self._props.window_title

--- a/mpvqc/viewmodels/views/header/toolbar.py
+++ b/mpvqc/viewmodels/views/header/toolbar.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import annotations
+from dataclasses import dataclass, replace
 
 import inject
 from PySide6.QtCore import Property, QObject, QTimer, Signal, Slot
@@ -12,6 +12,28 @@ from mpvqc.services import PlayerService
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ToolbarInputs:
+    video_loaded: bool
+    audio_track_count: int
+    subtitle_track_count: int
+
+
+@dataclass(frozen=True)
+class ToolbarProps:
+    frame_step_active: bool
+    subtitle_active: bool
+    audio_active: bool
+
+
+def derive_toolbar_props(inputs: ToolbarInputs) -> ToolbarProps:
+    return ToolbarProps(
+        frame_step_active=inputs.video_loaded,
+        subtitle_active=inputs.video_loaded and inputs.subtitle_track_count > 0,
+        audio_active=inputs.video_loaded and inputs.audio_track_count > 0,
+    )
 
 
 @QmlElement
@@ -24,67 +46,64 @@ class MpvqcToolBarViewModel(QObject):
 
     _BURST_WINDOW_MS = 300
 
-    def __init__(self, parent: QObject | None = None) -> None:
+    def __init__(self, parent: QObject | None = None, *, burst_window_ms: int = _BURST_WINDOW_MS) -> None:
         super().__init__(parent)
-        self._frame_step_active = False
-        self._subtitle_active = False
-        self._audio_active = False
+        self._inputs = ToolbarInputs(
+            video_loaded=self._player.video_loaded,
+            audio_track_count=self._player.audio_track_count,
+            subtitle_track_count=self._player.subtitle_track_count,
+        )
+        self._props = derive_toolbar_props(self._inputs)
 
-        self._refresh_timer = QTimer(self)
-        self._refresh_timer.setSingleShot(True)
-        self._refresh_timer.setInterval(self._BURST_WINDOW_MS)
-        self._refresh_timer.timeout.connect(self._refresh)
+        self._settle_timer = QTimer(self)
+        self._settle_timer.setSingleShot(True)
+        self._settle_timer.setInterval(burst_window_ms)
+        self._settle_timer.timeout.connect(self._derive_and_emit)
 
-        self._player.video_loaded_changed.connect(self._schedule_refresh)
-        self._player.audio_track_count_changed.connect(self._schedule_refresh)
-        self._player.subtitle_track_count_changed.connect(self._schedule_refresh)
-        self._player.file_loaded.connect(self._schedule_refresh)
+        self._player.video_loaded_changed.connect(self._fold_video_loaded)
+        self._player.audio_track_count_changed.connect(self._fold_audio_track_count)
+        self._player.subtitle_track_count_changed.connect(self._fold_subtitle_track_count)
+
+    @Slot(bool)
+    def _fold_video_loaded(self, value: bool) -> None:
+        self._apply(replace(self._inputs, video_loaded=value))
+
+    @Slot(int)
+    def _fold_audio_track_count(self, value: int) -> None:
+        self._apply(replace(self._inputs, audio_track_count=value))
+
+    @Slot(int)
+    def _fold_subtitle_track_count(self, value: int) -> None:
+        self._apply(replace(self._inputs, subtitle_track_count=value))
+
+    def _apply(self, inputs: ToolbarInputs) -> None:
+        self._inputs = inputs
+        self._settle_timer.start()
 
     @Slot()
-    def _schedule_refresh(self) -> None:
-        self._refresh_timer.start()
-
-    @Slot()
-    def _refresh(self) -> None:
-        video_loaded = self._player.video_loaded
-        if video_loaded:
-            # pyrefly: ignore [bad-assignment]
-            self.frameStepActive = True
-
-        # pyrefly: ignore [bad-assignment, unsupported-operation]
-        self.subtitleActive = video_loaded and self._player.subtitle_track_count > 0
-        # pyrefly: ignore [bad-assignment, unsupported-operation]
-        self.audioActive = video_loaded and self._player.audio_track_count > 0
+    def _derive_and_emit(self) -> None:
+        new, old = derive_toolbar_props(self._inputs), self._props
+        if new == old:
+            return
+        self._props = new
+        if new.frame_step_active != old.frame_step_active:
+            self.frameStepActiveChanged.emit(new.frame_step_active)
+        if new.subtitle_active != old.subtitle_active:
+            self.subtitleActiveChanged.emit(new.subtitle_active)
+        if new.audio_active != old.audio_active:
+            self.audioActiveChanged.emit(new.audio_active)
 
     @Property(bool, notify=frameStepActiveChanged)
     def frameStepActive(self) -> bool:
-        return self._frame_step_active
-
-    @frameStepActive.setter
-    def frameStepActive(self, value: bool) -> None:
-        if self._frame_step_active != value:
-            self._frame_step_active = value
-            self.frameStepActiveChanged.emit(value)
+        return self._props.frame_step_active
 
     @Property(bool, notify=subtitleActiveChanged)
     def subtitleActive(self) -> bool:
-        return self._subtitle_active
-
-    @subtitleActive.setter
-    def subtitleActive(self, value: bool) -> None:
-        if self._subtitle_active != value:
-            self._subtitle_active = value
-            self.subtitleActiveChanged.emit(value)
+        return self._props.subtitle_active
 
     @Property(bool, notify=audioActiveChanged)
     def audioActive(self) -> bool:
-        return self._audio_active
-
-    @audioActive.setter
-    def audioActive(self, value: bool) -> None:
-        if self._audio_active != value:
-            self._audio_active = value
-            self.audioActiveChanged.emit(value)
+        return self._props.audio_active
 
     @Slot()
     def requestFrameStepBackward(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ files = [
     "mpvqc/enums/import_wizard_session_mode.py",
     "mpvqc/enums/import_wizard_step_kind.py",
     "mpvqc/enums/message_box_kind.py",
-    "mpvqc/enums/time_format.py",
+    "mpvqc/enums/time_display_mode.py",
     "mpvqc/enums/window_title_format.py",
     "mpvqc/injections.py",
     "mpvqc/jobs.py",

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/MpvqcFooterView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/MpvqcFooterView.qml
@@ -129,16 +129,16 @@ Item {
             y: -height
             transformOrigin: isMirrored ? Popup.BottomLeft : Popup.BottomRight
 
-            isDefaultFormatChecked: root.viewModel.timeFormat === MpvqcTimeFormat.TimeFormat.CURRENT_TOTAL_TIME
-            isCurrentTimeChecked: root.viewModel.timeFormat === MpvqcTimeFormat.TimeFormat.CURRENT_TIME
-            isRemainingTimeChecked: root.viewModel.timeFormat === MpvqcTimeFormat.TimeFormat.REMAINING_TIME
-            isHideTimeChecked: root.viewModel.timeFormat === MpvqcTimeFormat.TimeFormat.EMPTY
+            isDefaultFormatChecked: root.viewModel.timeDisplayMode === MpvqcTimeDisplayMode.TimeDisplayMode.CURRENT_TOTAL_TIME
+            isCurrentTimeChecked: root.viewModel.timeDisplayMode === MpvqcTimeDisplayMode.TimeDisplayMode.CURRENT_TIME
+            isRemainingTimeChecked: root.viewModel.timeDisplayMode === MpvqcTimeDisplayMode.TimeDisplayMode.REMAINING_TIME
+            isHideTimeChecked: root.viewModel.timeDisplayMode === MpvqcTimeDisplayMode.TimeDisplayMode.NONE
             isPercentChecked: root.viewModel.statusbarPercentage
 
-            onDefaultFormatPicked: root.viewModel.timeFormat = MpvqcTimeFormat.TimeFormat.CURRENT_TOTAL_TIME
-            onCurrentTimePicked: root.viewModel.timeFormat = MpvqcTimeFormat.TimeFormat.CURRENT_TIME
-            onRemainingTimePicked: root.viewModel.timeFormat = MpvqcTimeFormat.TimeFormat.REMAINING_TIME
-            onHideTimePicked: root.viewModel.timeFormat = MpvqcTimeFormat.TimeFormat.EMPTY
+            onDefaultFormatPicked: root.viewModel.timeDisplayMode = MpvqcTimeDisplayMode.TimeDisplayMode.CURRENT_TOTAL_TIME
+            onCurrentTimePicked: root.viewModel.timeDisplayMode = MpvqcTimeDisplayMode.TimeDisplayMode.CURRENT_TIME
+            onRemainingTimePicked: root.viewModel.timeDisplayMode = MpvqcTimeDisplayMode.TimeDisplayMode.REMAINING_TIME
+            onHideTimePicked: root.viewModel.timeDisplayMode = MpvqcTimeDisplayMode.TimeDisplayMode.NONE
             onPercentToggled: root.viewModel.toggleStatusbarPercentage()
         }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/tst_MpvqcFooterView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Footer/tst_MpvqcFooterView.qml
@@ -18,23 +18,31 @@ TestCase {
     when: windowShown
     name: "MpvqcFooterView"
 
-    function makeControl(props): var {
-        const control = createTemporaryObject(objectUnderTest, testCase);
+    readonly property MpvqcTestBridge bridge: MpvqcTestBridge {}
+
+    function init(): void {
+        bridge.resetState();
+    }
+
+    function makeControl(properties = {}): MpvqcFooterView {
+        const control = createTemporaryObject(objectUnderTest, testCase, properties);
         verify(control);
-        const footer = findChild(control, "footer");
-        for (const key in (props ?? {})) {
-            footer[key] = props[key];
-        }
         waitForRendering(control);
         return control;
     }
 
-    function configureStatusbar(control: Item, enabled: bool): void {
-        const footer = findChild(control, "footer");
-        if (footer.viewModel.statusbarPercentage !== enabled) {
-            footer.viewModel.toggleStatusbarPercentage();
+    function configureStatusbar(control: MpvqcFooterView, enabled: bool): void {
+        if (control.viewModel.statusbarPercentage !== enabled) {
+            control.viewModel.toggleStatusbarPercentage();
         }
-        compare(footer.viewModel.statusbarPercentage, enabled);
+        compare(control.viewModel.statusbarPercentage, enabled);
+    }
+
+    function openContextMenuItem(control: Item, menuItem: string): var {
+        const button = findChild(control, "contextMenuButton");
+        mouseClick(button, button.width / 2, button.height / 2);
+        tryVerify(() => findChild(control, menuItem) !== null);
+        return findChild(control, menuItem);
     }
 
     function test_commentCountLabel_data(): var {
@@ -125,142 +133,58 @@ TestCase {
         verify(!percentLabel.visible);
         compare(timeLabel.text, "");
 
-        const button = findChild(control, "contextMenuButton");
-        mouseClick(button, button.width / 2, button.height / 2);
-
-        tryVerify(() => findChild(control, data.menuItem) !== null);
-        const menuItem = findChild(control, data.menuItem);
+        const menuItem = openContextMenuItem(control, data.menuItem);
         mouseClick(menuItem, menuItem.width / 2, menuItem.height / 2);
 
         verify(!timeLabel.visible);
         compare(timeLabel.text, "");
         verify(!percentLabel.visible);
 
+        const button = findChild(control, "contextMenuButton");
         mouseClick(button, button.width / 2, button.height / 2);
         tryVerify(() => menuItem.visible);
         verify(menuItem.checked);
     }
 
-    function test_timeLabelWithVideoLoaded_data(): var {
-        return [
-            {
-                tag: "default format",
-                menuItem: "defaultFormatMenuItem",
-                initialTimeFormat: MpvqcTimeFormat.TimeFormat.EMPTY,
-                expectedText: "01:05/02:05"
-            },
-            {
-                tag: "current time",
-                menuItem: "currentTimeMenuItem",
-                initialTimeFormat: MpvqcTimeFormat.TimeFormat.EMPTY,
-                expectedText: "01:05"
-            },
-            {
-                tag: "remaining time",
-                menuItem: "remainingTimeMenuItem",
-                initialTimeFormat: MpvqcTimeFormat.TimeFormat.EMPTY,
-                expectedText: "-01:00"
-            },
-            {
-                tag: "hide time",
-                menuItem: "hideTimeMenuItem",
-                initialTimeFormat: MpvqcTimeFormat.TimeFormat.CURRENT_TIME,
-                expectedText: ""
-            },
-        ];
-    }
-
-    function test_timeLabelWithVideoLoaded(data): void {
+    function test_contextMenuDrivesLabelsOverLoadedVideo(): void {
         const control = makeControl();
-        const footer = findChild(control, "footer");
-
-        footer.viewModel.setVideoLoaded(true);
-        footer.viewModel.setDuration(125.0);
-        footer.viewModel.setTimePos(65);
-        footer.viewModel.setTimeRemaining(60);
-        footer.viewModel.setPercentPos(42);
-        footer.viewModel.timeFormat = data.initialTimeFormat;
-        configureStatusbar(control, true);
+        bridge.loadVideo({
+            duration: 125,
+            timePos: 65,
+            timeRemaining: 60,
+            percentPos: 42
+        });
 
         const timeLabel = findChild(control, "timeLabel");
         const percentLabel = findChild(control, "percentLabel");
-
-        const button = findChild(control, "contextMenuButton");
-        mouseClick(button, button.width / 2, button.height / 2);
-
-        tryVerify(() => findChild(control, data.menuItem) !== null);
-        const menuItem = findChild(control, data.menuItem);
-        mouseClick(menuItem, menuItem.width / 2, menuItem.height / 2);
-
-        compare(timeLabel.visible, data.expectedText !== "");
-        compare(timeLabel.text, data.expectedText);
+        tryVerify(() => timeLabel.visible);
+        compare(timeLabel.text, "01:05/02:05");
         verify(percentLabel.visible);
         compare(percentLabel.text, "42%");
 
-        mouseClick(button, button.width / 2, button.height / 2);
-        tryVerify(() => menuItem.visible);
-        verify(menuItem.checked);
-    }
+        const currentTimeItem = openContextMenuItem(control, "currentTimeMenuItem");
+        mouseClick(currentTimeItem, currentTimeItem.width / 2, currentTimeItem.height / 2);
 
-    function test_percentLabelToggleWithVideoLoaded_data(): var {
-        return [
-            {
-                tag: "off to on",
-                initial: false,
-                expectedVisible: true,
-                expectedChecked: true
-            },
-            {
-                tag: "on to off",
-                initial: true,
-                expectedVisible: false,
-                expectedChecked: false
-            },
-        ];
-    }
+        tryCompare(timeLabel, "text", "01:05");
+        verify(timeLabel.visible);
 
-    function test_percentLabelToggleWithVideoLoaded(data): void {
-        const control = makeControl();
-        const footer = findChild(control, "footer");
+        const percentItem = openContextMenuItem(control, "percentMenuItem");
+        mouseClick(percentItem, percentItem.width / 2, percentItem.height / 2);
 
-        footer.viewModel.setVideoLoaded(true);
-        footer.viewModel.setPercentPos(42);
-        configureStatusbar(control, data.initial);
-
-        const percentLabel = findChild(control, "percentLabel");
-
-        const button = findChild(control, "contextMenuButton");
-        mouseClick(button, button.width / 2, button.height / 2);
-
-        tryVerify(() => findChild(control, "percentMenuItem") !== null);
-        const menuItem = findChild(control, "percentMenuItem");
-        mouseClick(menuItem, menuItem.width / 2, menuItem.height / 2);
-
-        compare(percentLabel.visible, data.expectedVisible);
-        if (data.expectedVisible) {
-            compare(percentLabel.text, "42%");
-        }
-
-        mouseClick(button, button.width / 2, button.height / 2);
-        tryVerify(() => menuItem.visible);
-        compare(menuItem.checked, data.expectedChecked);
+        tryVerify(() => !percentLabel.visible);
+        verify(timeLabel.visible);
+        compare(timeLabel.text, "01:05");
     }
 
     Component {
         id: objectUnderTest
 
-        Item {
-            width: testCase.width
-            height: testCase.height
-
-            MpvqcFooterView {
-                objectName: "footer"
-                selectedCommentIndex: 0
-                totalCommentCount: 0
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-            }
+        MpvqcFooterView {
+            selectedCommentIndex: 0
+            totalCommentCount: 0
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
         }
     }
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,71 +5,86 @@
 from collections import deque
 from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import Any
+from typing import Any, override
 
 import inject
 import pytest
-from PySide6.QtCore import QByteArray, QCoreApplication, QLocale, QObject, QResource, Signal, SignalInstance
+from PySide6.QtCore import QByteArray, QCoreApplication, QLocale, QResource, SignalInstance
 from PySide6.QtTest import QSignalSpy
 
 from mpvqc.application import MpvqcApplication
 from mpvqc.services import (
     BuildInfoService,
     CommentsService,
+    PlayerService,
     ResourceService,
     SettingsService,
     StateService,
     TimeFormatterService,
     TypeMapperService,
 )
+from mpvqc.services.player.state import OBSERVED_PROPERTIES, RawPropertyValue, make_observer
 
 
-class PlayerMock(QObject):
-    video_loaded_changed = Signal(bool)
-    path_changed = Signal(str)
-    filename_changed = Signal(str)
-    duration_changed = Signal(float)
-    percent_pos_changed = Signal(int)
-    time_pos_changed = Signal(int)
-    time_remaining_changed = Signal(int)
+class FakePlayerService(PlayerService):
+    """Stands in for mpv: raw values pass through the production observers,
+    so coercion, dedupe, and signal emission match the real service."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
-        self.video_loaded = False
-        self.path = None
-        self.filename = None
-        self.duration = 0.0
-        self.time_pos = 0
-        self.time_remaining = 0
-        self.percent_pos = 0
+        self._raw_time_pos: float | None = None
+        self._observers = {spec.name: make_observer(spec, self._apply_property_update) for spec in OBSERVED_PROPERTIES}
 
-    def update(self, **kwargs):  # ruff: ignore[complex-structure]
-        for key, value in kwargs.items():
-            if hasattr(self, key):
-                old_value = getattr(self, key)
-                if old_value != value:
-                    setattr(self, key, value)
+    @property
+    @override
+    def exact_time_pos(self) -> float:
+        if self._raw_time_pos is not None:
+            return self._raw_time_pos
+        return super().exact_time_pos
 
-                    match key:
-                        case "video_loaded":
-                            self.video_loaded_changed.emit(value)
-                        case "path":
-                            self.path_changed.emit(value or "")
-                        case "filename":
-                            self.filename_changed.emit(value or "")
-                        case "duration":
-                            self.duration_changed.emit(value)
-                        case "time_pos":
-                            self.time_pos_changed.emit(value)
-                        case "time_remaining":
-                            self.time_remaining_changed.emit(value)
-                        case "percent_pos":
-                            self.percent_pos_changed.emit(value)
+    def load_video(self, path: str) -> None:
+        self._observe("path", path)
+        self._observe("filename", Path(path).name)
+
+    def unload_video(self) -> None:
+        self._raw_time_pos = None
+        self._observe("path", None)
+
+    def update(
+        self,
+        *,
+        duration: float | None = None,
+        percent_pos: float | None = None,
+        time_pos: float | None = None,
+        time_remaining: float | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        track_list: list[dict] | None = None,
+    ) -> None:
+        if duration is not None:
+            # the reducer matches float instances, an int literal would be dropped
+            self._observe("duration", duration + 0.0)
+        if percent_pos is not None:
+            self._observe("percent-pos", percent_pos)
+        if time_pos is not None:
+            self._raw_time_pos = time_pos
+            self._observe("time-pos", time_pos)
+        if time_remaining is not None:
+            self._observe("time-remaining", time_remaining)
+        if height is not None:
+            self._observe("height", height)
+        if width is not None:
+            self._observe("width", width)
+        if track_list is not None:
+            self._observe("track-list", track_list)
+
+    def _observe(self, name: str, raw: RawPropertyValue) -> None:
+        self._observers[name](name, raw)
 
 
 @pytest.fixture
-def player_service_mock() -> PlayerMock:
-    return PlayerMock()
+def fake_player_service() -> FakePlayerService:
+    return FakePlayerService()
 
 
 class MySpy:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,7 @@ from mpvqc.application import MpvqcApplication
 from mpvqc.services import (
     BuildInfoService,
     CommentsService,
+    InternationalizationService,
     PlayerService,
     ResourceService,
     SettingsService,
@@ -186,6 +187,12 @@ def restore_default_locale():
     QLocale.setDefault(locale)
 
 
+@pytest.fixture(autouse=True)
+def clear_injector():
+    yield
+    inject.clear()
+
+
 @pytest.fixture
 def qt_app() -> Generator[MpvqcApplication, Any]:
     QCoreApplication.setApplicationName("TestApp")
@@ -212,6 +219,7 @@ def common_bindings_with():
             # Common & shared services
             binder.bind_to_constructor(BuildInfoService, BuildInfoService)
             binder.bind_to_constructor(CommentsService, CommentsService)
+            binder.bind_to_constructor(InternationalizationService, InternationalizationService)
             binder.bind_to_constructor(ResourceService, ResourceService)
             binder.bind_to_constructor(StateService, StateService)
             binder.bind_to_constructor(TimeFormatterService, TimeFormatterService)

--- a/test/services/test_settings.py
+++ b/test/services/test_settings.py
@@ -98,33 +98,33 @@ def test_backup_interval_signal_emission(settings_service, make_spy):
     assert spy.count() == 1
 
 
-def test_time_format_default(settings_service):
-    assert settings_service.time_format == 3
+def test_time_display_mode_default(settings_service):
+    assert settings_service.time_display_mode == 3
 
 
-def test_time_format_set_and_get(settings_service):
-    test_format = 1
-    settings_service.time_format = test_format
-    assert settings_service.time_format == test_format
+def test_time_display_mode_set_and_get(settings_service):
+    test_mode = 1
+    settings_service.time_display_mode = test_mode
+    assert settings_service.time_display_mode == test_mode
 
 
-def test_time_format_signal_emission(settings_service, make_spy):
-    spy = make_spy(settings_service.time_format_changed)
+def test_time_display_mode_signal_emission(settings_service, make_spy):
+    spy = make_spy(settings_service.time_display_mode_changed)
 
-    test_format = 2
-    settings_service.time_format = test_format
+    test_mode = 2
+    settings_service.time_display_mode = test_mode
     assert spy.count() == 1
-    assert spy.at(0, 0) == test_format
+    assert spy.at(0, 0) == test_mode
 
-    settings_service.time_format = test_format
+    settings_service.time_display_mode = test_mode
     assert spy.count() == 1
 
 
 def test_multiple_property_changes(settings_service):
     settings_service.backup_interval = 30
     settings_service.theme_identifier = "test-theme"
-    settings_service.time_format = 1
+    settings_service.time_display_mode = 1
 
     assert settings_service.backup_interval == 30
     assert settings_service.theme_identifier == "test-theme"
-    assert settings_service.time_format == 1
+    assert settings_service.time_display_mode == 1

--- a/test/services/test_time_format_policy.py
+++ b/test/services/test_time_format_policy.py
@@ -42,9 +42,9 @@ def comments_service_mock() -> CommentsServiceMock:
 
 
 @pytest.fixture(autouse=True)
-def configure_inject(common_bindings_with, player_service_mock, comments_service_mock):
+def configure_inject(common_bindings_with, fake_player_service, comments_service_mock):
     def custom_bindings(binder: inject.Binder):
-        binder.bind(PlayerService, player_service_mock)
+        binder.bind(PlayerService, fake_player_service)
         binder.bind(CommentsService, comments_service_mock)
 
     common_bindings_with(custom_bindings)
@@ -68,16 +68,16 @@ def test_uses_long_format_is_inclusive_at_one_hour(duration_seconds, expected):
     assert TimeFormatPolicyService.uses_long_format(duration_seconds) is expected
 
 
-def test_duration_crossing_one_hour_flips_flag(policy, player_service_mock, make_spy):
+def test_duration_crossing_one_hour_flips_flag(policy, fake_player_service, make_spy):
     spy = make_spy(policy.table_long_format_changed)
     assert not policy.table_long_format
 
-    player_service_mock.update(duration=3600.0)
+    fake_player_service.update(duration=3600.0)
     assert policy.table_long_format
     assert spy.count() == 1
     assert spy.at(invocation=0, argument=0) is True
 
-    player_service_mock.update(duration=3599.0)
+    fake_player_service.update(duration=3599.0)
     assert not policy.table_long_format
     assert spy.count() == 2
     assert spy.at(invocation=1, argument=0) is False
@@ -99,12 +99,12 @@ def test_comment_times_normalize_from_milliseconds(policy, comments_service_mock
     assert policy.table_long_format
 
 
-def test_duration_and_comment_times_combine(policy, player_service_mock, comments_service_mock):
-    player_service_mock.update(duration=3600.0)
+def test_duration_and_comment_times_combine(policy, fake_player_service, comments_service_mock):
+    fake_player_service.update(duration=3600.0)
     comments_service_mock.set_comments(1_000)
     assert policy.table_long_format
 
-    player_service_mock.update(duration=10.0)
+    fake_player_service.update(duration=10.0)
     assert not policy.table_long_format
 
     comments_service_mock.set_comments(1_000, ONE_HOUR_MS)
@@ -119,21 +119,21 @@ def test_reset_returns_flag_to_short(policy, comments_service_mock):
     assert not policy.table_long_format
 
 
-def test_unchanged_flag_does_not_emit(policy, player_service_mock, comments_service_mock, make_spy):
+def test_unchanged_flag_does_not_emit(policy, fake_player_service, comments_service_mock, make_spy):
     spy = make_spy(policy.table_long_format_changed)
 
-    player_service_mock.update(duration=10.0)
-    player_service_mock.update(duration=20.0)
+    fake_player_service.update(duration=10.0)
+    fake_player_service.update(duration=20.0)
     comments_service_mock.set_comments(1_000)
     assert spy.count() == 0
 
-    player_service_mock.update(duration=3600.0)
+    fake_player_service.update(duration=3600.0)
     comments_service_mock.set_comments(1_000, ONE_HOUR_MS)
     assert spy.count() == 1
 
 
-def test_flag_computes_at_construction(player_service_mock):
-    player_service_mock.update(duration=7200.0)
+def test_flag_computes_at_construction(fake_player_service):
+    fake_player_service.update(duration=7200.0)
 
     policy = TimeFormatPolicyService()
 

--- a/test/viewmodels/test_comment_table.py
+++ b/test/viewmodels/test_comment_table.py
@@ -26,13 +26,13 @@ def state_service_mock():
 @pytest.fixture(autouse=True)
 def configure_inject(
     common_bindings_with,
-    player_service_mock,
+    fake_player_service,
     settings_service,
     state_service_mock,
 ):
     def custom_bindings(binder: inject.Binder):
         binder.bind_to_constructor(CommentsService, CommentsService)
-        binder.bind(PlayerService, player_service_mock)
+        binder.bind(PlayerService, fake_player_service)
         binder.bind(StateService, state_service_mock)
         binder.bind(SettingsService, settings_service)
 
@@ -75,8 +75,8 @@ def test_state_changes_on_mutation(make_view_model, state_service_mock):
     assert state_service_mock.record_change.call_count == 2
 
 
-def test_add_row_captures_exact_player_time(make_view_model, player_service_mock):
-    player_service_mock.exact_time_pos = 12.3454
+def test_add_row_captures_exact_player_time(make_view_model, fake_player_service):
+    fake_player_service.update(time_pos=12.3454)
     vm = make_view_model(comments=[])
 
     vm.addRow("Translation")

--- a/test/viewmodels/test_footer.py
+++ b/test/viewmodels/test_footer.py
@@ -8,12 +8,12 @@ from typing import NamedTuple
 import inject
 import pytest
 
-from mpvqc.enums import MpvqcTimeFormat
+from mpvqc.enums import MpvqcTimeDisplayMode
 from mpvqc.services import FontLoaderService, LabelWidthCalculatorService, PlayerService, SettingsService
 from mpvqc.viewmodels import MpvqcFooterViewModel
 from mpvqc.viewmodels.views.footer import FooterInputs, FooterProps, derive_footer_props
 
-TimeFormat = MpvqcTimeFormat.TimeFormat
+TimeDisplayMode = MpvqcTimeDisplayMode.TimeDisplayMode
 
 
 @pytest.fixture(autouse=True)
@@ -46,7 +46,7 @@ def spy_notifies(make_spy):
     def _spy(view_model: MpvqcFooterViewModel) -> dict:
         return {
             "statusbarPercentage": make_spy(view_model.statusbarPercentageChanged),
-            "timeFormat": make_spy(view_model.timeFormatChanged),
+            "timeDisplayMode": make_spy(view_model.timeDisplayModeChanged),
             "isPercentVisible": make_spy(view_model.isPercentVisibleChanged),
             "percentText": make_spy(view_model.percentTextChanged),
             "isTimeVisible": make_spy(view_model.isTimeVisibleChanged),
@@ -72,7 +72,7 @@ BASE_INPUTS = FooterInputs(
     time_remaining=60,
     duration=125.0,
     statusbar_percentage=True,
-    time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+    time_display_mode=TimeDisplayMode.CURRENT_TOTAL_TIME,
 )
 
 
@@ -90,7 +90,7 @@ class DerivationCase(NamedTuple):
             inputs=BASE_INPUTS,
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TOTAL_TIME,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=True,
@@ -100,10 +100,10 @@ class DerivationCase(NamedTuple):
         ),
         DerivationCase(
             name="current time",
-            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.CURRENT_TIME),
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeDisplayMode.CURRENT_TIME),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.CURRENT_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TIME,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=True,
@@ -113,10 +113,10 @@ class DerivationCase(NamedTuple):
         ),
         DerivationCase(
             name="remaining time carries a minus prefix",
-            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.REMAINING_TIME),
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeDisplayMode.REMAINING_TIME),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.REMAINING_TIME,
+                time_display_mode=TimeDisplayMode.REMAINING_TIME,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=True,
@@ -125,11 +125,11 @@ class DerivationCase(NamedTuple):
             ),
         ),
         DerivationCase(
-            name="empty mode hides the time and zeroes the width",
-            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.EMPTY),
+            name="none mode hides the time and zeroes the width",
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeDisplayMode.NONE),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.EMPTY,
+                time_display_mode=TimeDisplayMode.NONE,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=False,
@@ -139,10 +139,10 @@ class DerivationCase(NamedTuple):
         ),
         DerivationCase(
             name="one hour flips to the long format",
-            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.CURRENT_TIME, duration=3600.0),
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeDisplayMode.CURRENT_TIME, duration=3600.0),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.CURRENT_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TIME,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=True,
@@ -152,10 +152,10 @@ class DerivationCase(NamedTuple):
         ),
         DerivationCase(
             name="just under one hour stays short",
-            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.CURRENT_TIME, duration=3599.0),
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeDisplayMode.CURRENT_TIME, duration=3599.0),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.CURRENT_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TIME,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=True,
@@ -168,7 +168,7 @@ class DerivationCase(NamedTuple):
             inputs=replace(BASE_INPUTS, duration=7200.0),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TOTAL_TIME,
                 is_percent_visible=True,
                 percent_text="42%",
                 is_time_visible=True,
@@ -181,7 +181,7 @@ class DerivationCase(NamedTuple):
             inputs=replace(BASE_INPUTS, video_loaded=False),
             expected=FooterProps(
                 statusbar_percentage=True,
-                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TOTAL_TIME,
                 is_percent_visible=False,
                 percent_text="42%",
                 is_time_visible=False,
@@ -194,7 +194,7 @@ class DerivationCase(NamedTuple):
             inputs=replace(BASE_INPUTS, statusbar_percentage=False),
             expected=FooterProps(
                 statusbar_percentage=False,
-                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                time_display_mode=TimeDisplayMode.CURRENT_TOTAL_TIME,
                 is_percent_visible=False,
                 percent_text="42%",
                 is_time_visible=True,
@@ -233,7 +233,7 @@ def test_percent_pos_fold(make_view_model, fake_player_service, spy_notifies):
 def test_time_pos_fold(make_view_model, fake_player_service, settings_service, spy_notifies):
     fake_player_service.load_video("/videos/movie.mkv")
     fake_player_service.update(time_pos=1.0)
-    settings_service.time_format = TimeFormat.CURRENT_TIME.value
+    settings_service.time_display_mode = TimeDisplayMode.CURRENT_TIME.value
     view_model = make_view_model()
     assert view_model.timeText == "00:01"
     spies = spy_notifies(view_model)
@@ -248,7 +248,7 @@ def test_time_pos_fold(make_view_model, fake_player_service, settings_service, s
 def test_time_remaining_fold(make_view_model, fake_player_service, settings_service, spy_notifies):
     fake_player_service.load_video("/videos/movie.mkv")
     fake_player_service.update(time_remaining=1.0)
-    settings_service.time_format = TimeFormat.REMAINING_TIME.value
+    settings_service.time_display_mode = TimeDisplayMode.REMAINING_TIME.value
     view_model = make_view_model()
     assert view_model.timeText == "-00:01"
     spies = spy_notifies(view_model)
@@ -292,21 +292,21 @@ def test_time_display_mode_fold(make_view_model, fake_player_service, settings_s
     assert view_model.timeText == "01:05/02:05"
     spies = spy_notifies(view_model)
 
-    settings_service.time_format = TimeFormat.EMPTY.value
+    settings_service.time_display_mode = TimeDisplayMode.NONE.value
 
-    assert emissions(spies) == {"timeFormat": 1, "isTimeVisible": 1, "timeText": 1, "timeWidth": 1}
+    assert emissions(spies) == {"timeDisplayMode": 1, "isTimeVisible": 1, "timeText": 1, "timeWidth": 1}
     assert not spies["timeText"].at(0, 0)
     assert spies["timeWidth"].at(0, 0) == 0
 
 
-def test_time_format_property_writes_through_to_settings(make_view_model, settings_service, make_spy):
+def test_time_display_mode_property_writes_through_to_settings(make_view_model, settings_service, make_spy):
     view_model = make_view_model()
-    spy = make_spy(view_model.timeFormatChanged)
+    spy = make_spy(view_model.timeDisplayModeChanged)
 
-    view_model.timeFormat = TimeFormat.REMAINING_TIME.value
+    view_model.timeDisplayMode = TimeDisplayMode.REMAINING_TIME.value
 
-    assert settings_service.time_format == TimeFormat.REMAINING_TIME.value
-    assert view_model.timeFormat == TimeFormat.REMAINING_TIME.value
+    assert settings_service.time_display_mode == TimeDisplayMode.REMAINING_TIME.value
+    assert view_model.timeDisplayMode == TimeDisplayMode.REMAINING_TIME.value
     assert spy.count() == 1
 
 

--- a/test/viewmodels/test_footer.py
+++ b/test/viewmodels/test_footer.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from dataclasses import replace
+from typing import NamedTuple
+
 import inject
 import pytest
 
 from mpvqc.enums import MpvqcTimeFormat
 from mpvqc.services import FontLoaderService, LabelWidthCalculatorService, PlayerService, SettingsService
 from mpvqc.viewmodels import MpvqcFooterViewModel
+from mpvqc.viewmodels.views.footer import FooterInputs, FooterProps, derive_footer_props
 
 TimeFormat = MpvqcTimeFormat.TimeFormat
 
@@ -29,105 +33,285 @@ def qt_app_must_be_running(qt_app):
 
 
 @pytest.fixture
-def view_model():
-    # noinspection PyCallingNonCallable
-    return MpvqcFooterViewModel()
+def make_view_model():
+    def _make() -> MpvqcFooterViewModel:
+        # noinspection PyCallingNonCallable
+        return MpvqcFooterViewModel()
+
+    return _make
 
 
-def test_statusbarPercentage(view_model, settings_service):
-    settings_service.statusbar_percentage = False
-    assert not view_model.statusbarPercentage
+@pytest.fixture
+def spy_notifies(make_spy):
+    def _spy(view_model: MpvqcFooterViewModel) -> dict:
+        return {
+            "statusbarPercentage": make_spy(view_model.statusbarPercentageChanged),
+            "timeFormat": make_spy(view_model.timeFormatChanged),
+            "isPercentVisible": make_spy(view_model.isPercentVisibleChanged),
+            "percentText": make_spy(view_model.percentTextChanged),
+            "isTimeVisible": make_spy(view_model.isTimeVisibleChanged),
+            "timeText": make_spy(view_model.timeTextChanged),
+            "timeWidth": make_spy(view_model.timeWidthChanged),
+        }
 
-    settings_service.statusbar_percentage = True
-    assert view_model.statusbarPercentage
+    return _spy
 
 
-def test_timeFormat(view_model, settings_service):
-    settings_service.time_format = TimeFormat.REMAINING_TIME.value
-    assert view_model.timeFormat == TimeFormat.REMAINING_TIME.value
+def emissions(spies: dict) -> dict[str, int]:
+    return {name: spy.count() for name, spy in spies.items() if spy.count()}
 
-    view_model.timeFormat = TimeFormat.CURRENT_TIME.value
-    assert settings_service.time_format == TimeFormat.CURRENT_TIME.value
+
+def measure_stub(text: str) -> int:
+    return 10 + len(text)
+
+
+BASE_INPUTS = FooterInputs(
+    video_loaded=True,
+    percent_pos=42,
+    time_pos=65,
+    time_remaining=60,
+    duration=125.0,
+    statusbar_percentage=True,
+    time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+)
+
+
+class DerivationCase(NamedTuple):
+    name: str
+    inputs: FooterInputs
+    expected: FooterProps
 
 
 @pytest.mark.parametrize(
-    ("setting", "video_loaded", "visible"),
+    "case",
     [
-        (False, False, False),
-        (False, True, False),
-        (True, False, False),
-        (True, True, True),
+        DerivationCase(
+            name="current over total joins both times",
+            inputs=BASE_INPUTS,
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="01:05/02:05",
+                time_width=21,
+            ),
+        ),
+        DerivationCase(
+            name="current time",
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.CURRENT_TIME),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.CURRENT_TIME,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="01:05",
+                time_width=15,
+            ),
+        ),
+        DerivationCase(
+            name="remaining time carries a minus prefix",
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.REMAINING_TIME),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.REMAINING_TIME,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="-01:00",
+                time_width=16,
+            ),
+        ),
+        DerivationCase(
+            name="empty mode hides the time and zeroes the width",
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.EMPTY),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.EMPTY,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=False,
+                time_text="",
+                time_width=0,
+            ),
+        ),
+        DerivationCase(
+            name="one hour flips to the long format",
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.CURRENT_TIME, duration=3600.0),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.CURRENT_TIME,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="00:01:05",
+                time_width=18,
+            ),
+        ),
+        DerivationCase(
+            name="just under one hour stays short",
+            inputs=replace(BASE_INPUTS, time_display_mode=TimeFormat.CURRENT_TIME, duration=3599.0),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.CURRENT_TIME,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="01:05",
+                time_width=15,
+            ),
+        ),
+        DerivationCase(
+            name="long format joins in total mode",
+            inputs=replace(BASE_INPUTS, duration=7200.0),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                is_percent_visible=True,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="00:01:05/02:00:00",
+                time_width=27,
+            ),
+        ),
+        DerivationCase(
+            name="no video blanks the time and hides both labels",
+            inputs=replace(BASE_INPUTS, video_loaded=False),
+            expected=FooterProps(
+                statusbar_percentage=True,
+                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                is_percent_visible=False,
+                percent_text="42%",
+                is_time_visible=False,
+                time_text="",
+                time_width=0,
+            ),
+        ),
+        DerivationCase(
+            name="statusbar setting off hides percent despite video",
+            inputs=replace(BASE_INPUTS, statusbar_percentage=False),
+            expected=FooterProps(
+                statusbar_percentage=False,
+                time_display_mode=TimeFormat.CURRENT_TOTAL_TIME,
+                is_percent_visible=False,
+                percent_text="42%",
+                is_time_visible=True,
+                time_text="01:05/02:05",
+                time_width=21,
+            ),
+        ),
     ],
+    ids=lambda case: case.name,
 )
-def test_isPercentVisible(view_model, setting, video_loaded, visible):
-    view_model.setStatusbarPercentage(setting)
-    view_model.setVideoLoaded(video_loaded)
-
-    assert view_model.isPercentVisible is visible
+def test_derivation(case: DerivationCase):
+    assert derive_footer_props(case.inputs, measure_stub) == case.expected
 
 
-def test_percentText(view_model):
-    view_model.setPercentPos(42)
-    assert view_model.percentText == "42%"
+def test_video_loaded_fold(make_view_model, fake_player_service, spy_notifies):
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
 
+    fake_player_service.load_video("/videos/movie.mkv")
 
-@pytest.mark.parametrize(
-    ("video_loaded", "time_format", "duration", "time_pos", "time_remaining", "expected"),
-    [
-        (False, TimeFormat.CURRENT_TIME.value, 125.0, 65, 60, ""),
-        (True, TimeFormat.EMPTY.value, 125.0, 65, 60, ""),
-        (True, TimeFormat.CURRENT_TIME.value, 125.0, 65, 60, "01:05"),
-        (True, TimeFormat.CURRENT_TIME.value, 7200.0, 3661, 3539, "01:01:01"),
-        (True, TimeFormat.REMAINING_TIME.value, 125.0, 65, 60, "-01:00"),
-        (True, TimeFormat.REMAINING_TIME.value, 7200.0, 3661, 3539, "-00:58:59"),
-        (True, TimeFormat.CURRENT_TOTAL_TIME.value, 125.0, 65, 60, "01:05/02:05"),
-        (True, TimeFormat.CURRENT_TOTAL_TIME.value, 7200.0, 3661, 3539, "01:01:01/02:00:00"),
-        (True, TimeFormat.CURRENT_TIME.value, 3599.0, 65, 3534, "01:05"),
-        (True, TimeFormat.CURRENT_TIME.value, 3600.0, 65, 3535, "00:01:05"),
-        (True, TimeFormat.CURRENT_TOTAL_TIME.value, 3600.0, 3600, 0, "01:00:00/01:00:00"),
-    ],
-)
-def test_timeText(view_model, video_loaded, time_format, duration, time_pos, time_remaining, expected):
-    view_model.setVideoLoaded(video_loaded)
-    view_model.setDuration(duration)
-    view_model.setTimePos(time_pos)
-    view_model.setTimeRemaining(time_remaining)
-    view_model.setTimeFormat(time_format)
-
-    assert view_model.timeText == expected
-    assert view_model.isTimeVisible is bool(expected)
-
-
-def test_timeWidth(view_model):
-    view_model.setTimeFormat(TimeFormat.CURRENT_TIME.value)
-    view_model.setDuration(125.0)
-    assert view_model.timeWidth == 0
-
-    view_model.setVideoLoaded(True)
-    view_model.setTimeFormat(TimeFormat.EMPTY.value)
-    assert view_model.timeWidth == 0
-
-    view_model.setTimeFormat(TimeFormat.CURRENT_TIME.value)
-    short_width = view_model.timeWidth
-    assert short_width > 0
-
-    view_model.setDuration(7200.0)
-    assert view_model.timeWidth > short_width
-
-
-def test_timeWidth_recomputes_when_video_loaded_toggles_after_duration_and_format(view_model):
-    view_model.setTimeFormat(TimeFormat.CURRENT_TIME.value)
-    view_model.setDuration(125.0)
-    assert view_model.timeWidth == 0
-
-    view_model.setVideoLoaded(True)
+    assert emissions(spies) == {"isPercentVisible": 1, "isTimeVisible": 1, "timeText": 1, "timeWidth": 1}
+    assert spies["timeText"].at(0, 0) == "00:00/00:00"
     assert view_model.timeWidth > 0
 
-    view_model.setVideoLoaded(False)
-    assert view_model.timeWidth == 0
+
+def test_percent_pos_fold(make_view_model, fake_player_service, spy_notifies):
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    fake_player_service.update(percent_pos=42.0)
+
+    assert emissions(spies) == {"percentText": 1}
+    assert spies["percentText"].at(0, 0) == "42%"
 
 
-def test_toggleStatusbarPercentage(view_model, settings_service):
+def test_time_pos_fold(make_view_model, fake_player_service, settings_service, spy_notifies):
+    fake_player_service.load_video("/videos/movie.mkv")
+    fake_player_service.update(time_pos=1.0)
+    settings_service.time_format = TimeFormat.CURRENT_TIME.value
+    view_model = make_view_model()
+    assert view_model.timeText == "00:01"
+    spies = spy_notifies(view_model)
+
+    # 1 -> 10 permutes the same glyphs, so the width stays put on every font engine
+    fake_player_service.update(time_pos=10.0)
+
+    assert emissions(spies) == {"timeText": 1}
+    assert spies["timeText"].at(0, 0) == "00:10"
+
+
+def test_time_remaining_fold(make_view_model, fake_player_service, settings_service, spy_notifies):
+    fake_player_service.load_video("/videos/movie.mkv")
+    fake_player_service.update(time_remaining=1.0)
+    settings_service.time_format = TimeFormat.REMAINING_TIME.value
+    view_model = make_view_model()
+    assert view_model.timeText == "-00:01"
+    spies = spy_notifies(view_model)
+
+    # 1 -> 10 permutes the same glyphs, so the width stays put on every font engine
+    fake_player_service.update(time_remaining=10.0)
+
+    assert emissions(spies) == {"timeText": 1}
+    assert spies["timeText"].at(0, 0) == "-00:10"
+
+
+def test_duration_fold(make_view_model, fake_player_service, spy_notifies):
+    fake_player_service.load_video("/videos/movie.mkv")
+    view_model = make_view_model()
+    assert view_model.timeText == "00:00/00:00"
+    spies = spy_notifies(view_model)
+
+    fake_player_service.update(duration=3600.0)
+
+    assert emissions(spies) == {"timeText": 1, "timeWidth": 1}
+    assert spies["timeText"].at(0, 0) == "00:00:00/01:00:00"
+    assert spies["timeWidth"].at(0, 0) == view_model.timeWidth
+
+
+def test_statusbar_percentage_fold(make_view_model, fake_player_service, settings_service, spy_notifies):
+    fake_player_service.load_video("/videos/movie.mkv")
+    view_model = make_view_model()
+    assert view_model.isPercentVisible
+    spies = spy_notifies(view_model)
+
+    settings_service.statusbar_percentage = False
+
+    assert emissions(spies) == {"statusbarPercentage": 1, "isPercentVisible": 1}
+    assert spies["isPercentVisible"].at(0, 0) is False
+
+
+def test_time_display_mode_fold(make_view_model, fake_player_service, settings_service, spy_notifies):
+    fake_player_service.load_video("/videos/movie.mkv")
+    fake_player_service.update(duration=125.0, time_pos=65.0, time_remaining=60.0)
+    view_model = make_view_model()
+    assert view_model.timeText == "01:05/02:05"
+    spies = spy_notifies(view_model)
+
+    settings_service.time_format = TimeFormat.EMPTY.value
+
+    assert emissions(spies) == {"timeFormat": 1, "isTimeVisible": 1, "timeText": 1, "timeWidth": 1}
+    assert not spies["timeText"].at(0, 0)
+    assert spies["timeWidth"].at(0, 0) == 0
+
+
+def test_time_format_property_writes_through_to_settings(make_view_model, settings_service, make_spy):
+    view_model = make_view_model()
+    spy = make_spy(view_model.timeFormatChanged)
+
+    view_model.timeFormat = TimeFormat.REMAINING_TIME.value
+
+    assert settings_service.time_format == TimeFormat.REMAINING_TIME.value
+    assert view_model.timeFormat == TimeFormat.REMAINING_TIME.value
+    assert spy.count() == 1
+
+
+def test_toggle_statusbar_percentage_writes_through_to_settings(make_view_model, settings_service):
+    view_model = make_view_model()
     initial = view_model.statusbarPercentage
 
     view_model.toggleStatusbarPercentage()

--- a/test/viewmodels/test_footer.py
+++ b/test/viewmodels/test_footer.py
@@ -13,9 +13,9 @@ TimeFormat = MpvqcTimeFormat.TimeFormat
 
 
 @pytest.fixture(autouse=True)
-def configure_inject(common_bindings_with, player_service_mock, settings_service):
+def configure_inject(common_bindings_with, fake_player_service, settings_service):
     def custom_bindings(binder: inject.Binder):
-        binder.bind(PlayerService, player_service_mock)
+        binder.bind(PlayerService, fake_player_service)
         binder.bind(SettingsService, settings_service)
         binder.bind_to_constructor(FontLoaderService, FontLoaderService)
         binder.bind(LabelWidthCalculatorService, LabelWidthCalculatorService())

--- a/test/viewmodels/test_header.py
+++ b/test/viewmodels/test_header.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from dataclasses import replace
 from pathlib import Path
 from typing import NamedTuple
 
@@ -9,8 +10,9 @@ import inject
 import pytest
 
 from mpvqc.enums import MpvqcWindowTitleFormat
-from mpvqc.services import PlayerService, SettingsService, StateService
+from mpvqc.services import InternationalizationService, PlayerService, SettingsService, StateService
 from mpvqc.viewmodels import MpvqcHeaderViewModel
+from mpvqc.viewmodels.views.header.header import HeaderInputs, HeaderProps, derive_header_props
 
 WindowTitleFormat = MpvqcWindowTitleFormat.WindowTitleFormat
 
@@ -32,93 +34,91 @@ def configure_inject(
         binder.bind(StateService, state_service)
         binder.bind(PlayerService, fake_player_service)
         binder.bind(SettingsService, settings_service)
+        binder.bind_to_constructor(InternationalizationService, InternationalizationService)
 
     common_bindings_with(custom_bindings)
 
 
-class WindowTitleTestCase(NamedTuple):
-    saved: bool
-    document: Path | None
-    window_title_format: WindowTitleFormat
-    video: str | None
-    expected: str
+@pytest.fixture(autouse=True)
+def qt_app_must_be_running(qt_app):
+    pass
+
+
+BASE_INPUTS = HeaderInputs(
+    video_loaded=True,
+    filename="test_video.mp4",
+    path="/videos/test_video.mp4",
+    window_title_format=WindowTitleFormat.DEFAULT,
+    has_unsaved_document=False,
+    app_name="TestApp",
+    unsaved_template="%1 (unsaved)",
+)
+
+
+class DerivationCase(NamedTuple):
+    name: str
+    inputs: HeaderInputs
+    expected: HeaderProps
 
 
 @pytest.mark.parametrize(
-    "test_case",
+    "case",
     [
-        WindowTitleTestCase(
-            saved=True,
-            document=None,
-            window_title_format=WindowTitleFormat.DEFAULT,
-            video=None,
-            expected="TestApp",
+        DerivationCase(
+            name="no video shows the app name",
+            inputs=replace(BASE_INPUTS, video_loaded=False, filename="", path=""),
+            expected=HeaderProps(window_title="TestApp"),
         ),
-        WindowTitleTestCase(
-            saved=False,
-            document=Path("doc.qc"),
-            window_title_format=WindowTitleFormat.DEFAULT,
-            video=None,
-            expected="TestApp (unsaved)",
+        DerivationCase(
+            name="no video with unsaved document suffixes the app name",
+            inputs=replace(BASE_INPUTS, video_loaded=False, filename="", path="", has_unsaved_document=True),
+            expected=HeaderProps(window_title="TestApp (unsaved)"),
         ),
-        WindowTitleTestCase(
-            saved=True,
-            document=Path("doc.qc"),
-            window_title_format=WindowTitleFormat.FILE_NAME,
-            video=str(Path.home() / "test_video.mp4"),
-            expected="test_video.mp4",
+        DerivationCase(
+            name="no video forces the app name despite file name format",
+            inputs=replace(BASE_INPUTS, video_loaded=False, window_title_format=WindowTitleFormat.FILE_NAME),
+            expected=HeaderProps(window_title="TestApp"),
         ),
-        WindowTitleTestCase(
-            saved=False,
-            document=Path("doc.qc"),
-            window_title_format=WindowTitleFormat.FILE_NAME,
-            video=str(Path.home() / "test_video.mp4"),
-            expected="test_video.mp4 (unsaved)",
+        DerivationCase(
+            name="default format shows the app name despite video",
+            inputs=BASE_INPUTS,
+            expected=HeaderProps(window_title="TestApp"),
         ),
-        WindowTitleTestCase(
-            saved=True,
-            document=Path("doc.qc"),
-            window_title_format=WindowTitleFormat.FILE_PATH,
-            video=str(Path.home() / "test_video.mp4"),
-            expected=str(Path.home() / "test_video.mp4"),
+        DerivationCase(
+            name="file name format shows the file name",
+            inputs=replace(BASE_INPUTS, window_title_format=WindowTitleFormat.FILE_NAME),
+            expected=HeaderProps(window_title="test_video.mp4"),
         ),
-        WindowTitleTestCase(
-            saved=False,
-            document=Path("doc.qc"),
-            window_title_format=WindowTitleFormat.FILE_PATH,
-            video=str(Path.home() / "test_video.mp4"),
-            expected=str(Path.home() / "test_video.mp4") + " (unsaved)",
+        DerivationCase(
+            name="file name format with unsaved document suffixes the file name",
+            inputs=replace(BASE_INPUTS, window_title_format=WindowTitleFormat.FILE_NAME, has_unsaved_document=True),
+            expected=HeaderProps(window_title="test_video.mp4 (unsaved)"),
         ),
-        WindowTitleTestCase(
-            saved=True,
-            document=None,
-            window_title_format=WindowTitleFormat.FILE_NAME,
-            video=None,
-            expected="TestApp",
+        DerivationCase(
+            name="file path format shows the file path",
+            inputs=replace(BASE_INPUTS, window_title_format=WindowTitleFormat.FILE_PATH),
+            expected=HeaderProps(window_title="/videos/test_video.mp4"),
         ),
-        WindowTitleTestCase(
-            saved=False,
-            document=None,
-            window_title_format=WindowTitleFormat.FILE_NAME,
-            video=str(Path.home() / "test_video.mp4"),
-            expected="test_video.mp4",
+        DerivationCase(
+            name="file path format with unsaved document suffixes the file path",
+            inputs=replace(BASE_INPUTS, window_title_format=WindowTitleFormat.FILE_PATH, has_unsaved_document=True),
+            expected=HeaderProps(window_title="/videos/test_video.mp4 (unsaved)"),
+        ),
+        DerivationCase(
+            name="untranslated template is honored",
+            inputs=replace(BASE_INPUTS, has_unsaved_document=True, unsaved_template="%1 (unsaved)"),
+            expected=HeaderProps(window_title="TestApp (unsaved)"),
+        ),
+        DerivationCase(
+            name="german-shaped template is honored",
+            inputs=replace(BASE_INPUTS, has_unsaved_document=True, unsaved_template="%1 (ungespeichert)"),
+            expected=HeaderProps(window_title="TestApp (ungespeichert)"),
         ),
     ],
+    ids=lambda case: case.name,
 )
-def test_window_title(
-    qt_app,
-    view_model,
-    configure_state,
-    fake_player_service,
-    settings_service,
-    test_case: WindowTitleTestCase,
-):
-    configure_state(saved=test_case.saved, document=test_case.document)
-    if test_case.video is not None:
-        fake_player_service.load_video(test_case.video)
-    settings_service.window_title_format = test_case.window_title_format.value
-
-    assert view_model.windowTitle == test_case.expected
+def test_derivation(case: DerivationCase):
+    assert derive_header_props(case.inputs) == case.expected
 
 
 def test_window_title_changed(
@@ -136,3 +136,35 @@ def test_window_title_changed(
 
     settings_service.window_title_format = WindowTitleFormat.FILE_NAME.value
     assert spy.count() == 1
+
+
+def test_initial_snapshot_reads_services_at_construction(
+    configure_state,
+    fake_player_service,
+    settings_service,
+):
+    configure_state(saved=False, document=Path("doc.qc"))
+    fake_player_service.load_video("/videos/test_video.mp4")
+    settings_service.window_title_format = WindowTitleFormat.FILE_NAME.value
+
+    # noinspection PyCallingNonCallable
+    view_model = MpvqcHeaderViewModel()
+
+    assert view_model.windowTitle == "test_video.mp4 (unsaved)"
+
+
+def test_retranslation_folds_german_unsaved_template(
+    qt_app,
+    view_model,
+    configure_state,
+    make_spy,
+):
+    configure_state(saved=False, document=Path("doc.qc"))
+    assert view_model.windowTitle == "TestApp (unsaved)"
+    spy = make_spy(view_model.windowTitleChanged)
+
+    inject.instance(InternationalizationService).retranslate(qt_app, "de-DE")
+
+    assert spy.count() == 1
+    assert spy.at(0, 0) == "TestApp (ungespeichert)"
+    assert view_model.windowTitle == "TestApp (ungespeichert)"

--- a/test/viewmodels/test_header.py
+++ b/test/viewmodels/test_header.py
@@ -25,12 +25,12 @@ def view_model() -> MpvqcHeaderViewModel:
 def configure_inject(
     common_bindings_with,
     state_service,
-    player_service_mock,
+    fake_player_service,
     settings_service,
 ):
     def custom_bindings(binder: inject.Binder):
         binder.bind(StateService, state_service)
-        binder.bind(PlayerService, player_service_mock)
+        binder.bind(PlayerService, fake_player_service)
         binder.bind(SettingsService, settings_service)
 
     common_bindings_with(custom_bindings)
@@ -40,9 +40,7 @@ class WindowTitleTestCase(NamedTuple):
     saved: bool
     document: Path | None
     window_title_format: WindowTitleFormat
-    video_loaded: bool
-    filename: str | None
-    path: str | None
+    video: str | None
     expected: str
 
 
@@ -53,72 +51,56 @@ class WindowTitleTestCase(NamedTuple):
             saved=True,
             document=None,
             window_title_format=WindowTitleFormat.DEFAULT,
-            video_loaded=False,
-            filename=None,
-            path=None,
+            video=None,
             expected="TestApp",
         ),
         WindowTitleTestCase(
             saved=False,
             document=Path("doc.qc"),
             window_title_format=WindowTitleFormat.DEFAULT,
-            video_loaded=False,
-            filename=None,
-            path=None,
+            video=None,
             expected="TestApp (unsaved)",
         ),
         WindowTitleTestCase(
             saved=True,
             document=Path("doc.qc"),
             window_title_format=WindowTitleFormat.FILE_NAME,
-            video_loaded=True,
-            filename="test_video.mp4",
-            path=None,
+            video=str(Path.home() / "test_video.mp4"),
             expected="test_video.mp4",
         ),
         WindowTitleTestCase(
             saved=False,
             document=Path("doc.qc"),
             window_title_format=WindowTitleFormat.FILE_NAME,
-            video_loaded=True,
-            filename="test_video.mp4",
-            path=None,
+            video=str(Path.home() / "test_video.mp4"),
             expected="test_video.mp4 (unsaved)",
         ),
         WindowTitleTestCase(
             saved=True,
             document=Path("doc.qc"),
             window_title_format=WindowTitleFormat.FILE_PATH,
-            video_loaded=True,
-            filename=None,
-            path=str(Path.home() / "test_video.mp4"),
+            video=str(Path.home() / "test_video.mp4"),
             expected=str(Path.home() / "test_video.mp4"),
         ),
         WindowTitleTestCase(
             saved=False,
             document=Path("doc.qc"),
             window_title_format=WindowTitleFormat.FILE_PATH,
-            video_loaded=True,
-            filename=None,
-            path=str(Path.home() / "test_video.mp4"),
+            video=str(Path.home() / "test_video.mp4"),
             expected=str(Path.home() / "test_video.mp4") + " (unsaved)",
         ),
         WindowTitleTestCase(
             saved=True,
             document=None,
             window_title_format=WindowTitleFormat.FILE_NAME,
-            video_loaded=False,
-            filename=None,
-            path=None,
+            video=None,
             expected="TestApp",
         ),
         WindowTitleTestCase(
             saved=False,
             document=None,
             window_title_format=WindowTitleFormat.FILE_NAME,
-            video_loaded=True,
-            filename="test_video.mp4",
-            path=None,
+            video=str(Path.home() / "test_video.mp4"),
             expected="test_video.mp4",
         ),
     ],
@@ -127,16 +109,13 @@ def test_window_title(
     qt_app,
     view_model,
     configure_state,
-    player_service_mock,
+    fake_player_service,
     settings_service,
     test_case: WindowTitleTestCase,
 ):
     configure_state(saved=test_case.saved, document=test_case.document)
-    player_service_mock.update(
-        video_loaded=test_case.video_loaded,
-        filename=test_case.filename,
-        path=test_case.path,
-    )
+    if test_case.video is not None:
+        fake_player_service.load_video(test_case.video)
     settings_service.window_title_format = test_case.window_title_format.value
 
     assert view_model.windowTitle == test_case.expected
@@ -145,35 +124,15 @@ def test_window_title(
 def test_window_title_changed(
     view_model,
     configure_state,
-    player_service_mock,
+    fake_player_service,
     settings_service,
     make_spy,
 ):
     file = Path.home() / "test_video.mp4"
     configure_state(saved=False)
-    player_service_mock.update(
-        video_loaded=True,
-        filename=file.name,
-        path=f"{file.resolve()}",
-    )
+    fake_player_service.load_video(f"{file.resolve()}")
 
     spy = make_spy(view_model.windowTitleChanged)
 
     settings_service.window_title_format = WindowTitleFormat.FILE_NAME.value
     assert spy.count() == 1
-
-
-def test_window_title_reflects_only_notified_changes(
-    view_model,
-    configure_state,
-    player_service_mock,
-    settings_service,
-):
-    configure_state(saved=True)
-    settings_service.window_title_format = WindowTitleFormat.FILE_NAME.value
-    cached = view_model.windowTitle
-
-    player_service_mock.video_loaded = True
-    player_service_mock.filename = "video.mp4"
-
-    assert view_model.windowTitle == cached

--- a/test/viewmodels/test_header.py
+++ b/test/viewmodels/test_header.py
@@ -34,7 +34,6 @@ def configure_inject(
         binder.bind(StateService, state_service)
         binder.bind(PlayerService, fake_player_service)
         binder.bind(SettingsService, settings_service)
-        binder.bind_to_constructor(InternationalizationService, InternationalizationService)
 
     common_bindings_with(custom_bindings)
 

--- a/test/viewmodels/test_label_width_calculator.py
+++ b/test/viewmodels/test_label_width_calculator.py
@@ -52,7 +52,6 @@ def configure_inject(common_bindings_with, fake_player_service, comment_types_po
         binder.bind(PlayerService, fake_player_service)
         binder.bind(CommentTypesPolicyService, comment_types_policy_mock)
         binder.bind_to_constructor(FontLoaderService, FontLoaderService)
-        binder.bind_to_constructor(InternationalizationService, InternationalizationService)
         binder.bind_to_constructor(LabelWidthCalculatorService, LabelWidthCalculatorService)
         binder.bind_to_constructor(TimeFormatPolicyService, TimeFormatPolicyService)
 

--- a/test/viewmodels/test_label_width_calculator.py
+++ b/test/viewmodels/test_label_width_calculator.py
@@ -47,9 +47,9 @@ def comment_types_policy_mock() -> CommentTypesPolicyServiceMock:
 
 
 @pytest.fixture(autouse=True)
-def configure_inject(common_bindings_with, player_service_mock, comment_types_policy_mock):
+def configure_inject(common_bindings_with, fake_player_service, comment_types_policy_mock):
     def custom_bindings(binder: inject.Binder):
-        binder.bind(PlayerService, player_service_mock)
+        binder.bind(PlayerService, fake_player_service)
         binder.bind(CommentTypesPolicyService, comment_types_policy_mock)
         binder.bind_to_constructor(FontLoaderService, FontLoaderService)
         binder.bind_to_constructor(InternationalizationService, InternationalizationService)
@@ -122,19 +122,19 @@ def test_comment_types_width_of_same_value_does_not_emit(view_model, comment_typ
     assert spy.count() == 0
 
 
-def test_time_width_flips_with_format(view_model, player_service_mock, make_spy):
+def test_time_width_flips_with_format(view_model, fake_player_service, make_spy):
     spy = make_spy(view_model.timeLabelWidthChanged)
     short_width = view_model.timeLabelWidth
     assert short_width > 0
 
-    player_service_mock.update(duration=3600.0)
+    fake_player_service.update(duration=3600.0)
 
     long_width = view_model.timeLabelWidth
     assert long_width > short_width
     assert spy.count() == 1
     assert spy.at(invocation=0, argument=0) == long_width
 
-    player_service_mock.update(duration=3599.0)
+    fake_player_service.update(duration=3599.0)
 
     assert view_model.timeLabelWidth == short_width
     assert spy.count() == 2

--- a/test/viewmodels/test_table_utility.py
+++ b/test/viewmodels/test_table_utility.py
@@ -13,9 +13,9 @@ ONE_HOUR_MS = 3_600_000
 
 
 @pytest.fixture(autouse=True)
-def configure_inject(common_bindings_with, player_service_mock):
+def configure_inject(common_bindings_with, fake_player_service):
     def custom_bindings(binder: inject.Binder):
-        binder.bind(PlayerService, player_service_mock)
+        binder.bind(PlayerService, fake_player_service)
         binder.bind_to_constructor(TimeFormatPolicyService, TimeFormatPolicyService)
 
     common_bindings_with(custom_bindings)
@@ -47,8 +47,9 @@ def test_long_comment_flips_to_long_format_without_video(view_model, comments, m
     assert spy.at(invocation=0, argument=0) is True
 
 
-def test_long_comment_with_shorter_video_uses_long_format(view_model, comments, player_service_mock):
-    player_service_mock.update(video_loaded=True, duration=125.0)
+def test_long_comment_with_shorter_video_uses_long_format(view_model, comments, fake_player_service):
+    fake_player_service.load_video("/videos/video.mkv")
+    fake_player_service.update(duration=125.0)
     assert not view_model.tableLongFormat
 
     comments.import_comments([_comment_at(5_400_000)])
@@ -74,9 +75,9 @@ def test_reset_returns_to_short_format(view_model, comments):
     assert not view_model.tableLongFormat
 
 
-def test_duration_of_exactly_one_hour_uses_long_format(view_model, player_service_mock):
-    player_service_mock.update(duration=3600.0)
+def test_duration_of_exactly_one_hour_uses_long_format(view_model, fake_player_service):
+    fake_player_service.update(duration=3600.0)
     assert view_model.tableLongFormat
 
-    player_service_mock.update(duration=3599.0)
+    fake_player_service.update(duration=3599.0)
     assert not view_model.tableLongFormat

--- a/test/viewmodels/test_toolbar.py
+++ b/test/viewmodels/test_toolbar.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import NamedTuple
+
+import inject
+import pytest
+
+from mpvqc.services import PlayerService
+from mpvqc.viewmodels import MpvqcToolBarViewModel
+from mpvqc.viewmodels.views.header.toolbar import ToolbarInputs, ToolbarProps, derive_toolbar_props
+
+BOTH_TRACKS = [{"type": "audio"}, {"type": "sub"}]
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with, fake_player_service):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind(PlayerService, fake_player_service)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture(autouse=True)
+def qt_app_must_be_running(qt_app):
+    pass
+
+
+@pytest.fixture
+def make_view_model():
+    def _make() -> MpvqcToolBarViewModel:
+        # noinspection PyCallingNonCallable
+        return MpvqcToolBarViewModel(burst_window_ms=20)
+
+    return _make
+
+
+@pytest.fixture
+def spy_notifies(make_spy):
+    def _spy(view_model: MpvqcToolBarViewModel) -> dict:
+        return {
+            "frameStepActive": make_spy(view_model.frameStepActiveChanged),
+            "subtitleActive": make_spy(view_model.subtitleActiveChanged),
+            "audioActive": make_spy(view_model.audioActiveChanged),
+        }
+
+    return _spy
+
+
+def emissions(spies: dict) -> dict[str, int]:
+    return {name: spy.count() for name, spy in spies.items() if spy.count()}
+
+
+class DerivationCase(NamedTuple):
+    name: str
+    inputs: ToolbarInputs
+    expected: ToolbarProps
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        DerivationCase(
+            name="no video deactivates everything despite tracks",
+            inputs=ToolbarInputs(video_loaded=False, audio_track_count=2, subtitle_track_count=1),
+            expected=ToolbarProps(frame_step_active=False, subtitle_active=False, audio_active=False),
+        ),
+        DerivationCase(
+            name="video without tracks activates frame step only",
+            inputs=ToolbarInputs(video_loaded=True, audio_track_count=0, subtitle_track_count=0),
+            expected=ToolbarProps(frame_step_active=True, subtitle_active=False, audio_active=False),
+        ),
+        DerivationCase(
+            name="audio alone activates audio",
+            inputs=ToolbarInputs(video_loaded=True, audio_track_count=1, subtitle_track_count=0),
+            expected=ToolbarProps(frame_step_active=True, subtitle_active=False, audio_active=True),
+        ),
+        DerivationCase(
+            name="subtitles alone activate subtitles",
+            inputs=ToolbarInputs(video_loaded=True, audio_track_count=0, subtitle_track_count=1),
+            expected=ToolbarProps(frame_step_active=True, subtitle_active=True, audio_active=False),
+        ),
+        DerivationCase(
+            name="both tracks activate everything",
+            inputs=ToolbarInputs(video_loaded=True, audio_track_count=1, subtitle_track_count=1),
+            expected=ToolbarProps(frame_step_active=True, subtitle_active=True, audio_active=True),
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_derivation(case: DerivationCase):
+    assert derive_toolbar_props(case.inputs) == case.expected
+
+
+def test_initial_snapshot_reads_player_at_construction(make_view_model, fake_player_service):
+    fake_player_service.load_video("/videos/movie.mkv")
+    fake_player_service.update(track_list=BOTH_TRACKS)
+
+    view_model = make_view_model()
+
+    assert view_model.frameStepActive
+    assert view_model.subtitleActive
+    assert view_model.audioActive
+
+
+def test_folds_inside_one_window_settle_to_one_emission_batch(make_view_model, fake_player_service, spy_notifies):
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    fake_player_service.load_video("/videos/movie.mkv")
+    fake_player_service.update(track_list=BOTH_TRACKS)
+
+    assert emissions(spies) == {}
+    assert not view_model.frameStepActive
+
+    assert spies["frameStepActive"].wait(5000)
+    assert emissions(spies) == {"frameStepActive": 1, "subtitleActive": 1, "audioActive": 1}
+    assert spies["frameStepActive"].at(0, 0) is True
+    assert spies["subtitleActive"].at(0, 0) is True
+    assert spies["audioActive"].at(0, 0) is True
+
+
+def test_video_switch_emits_only_settled_deltas(make_view_model, fake_player_service, spy_notifies):
+    fake_player_service.load_video("/videos/a.mkv")
+    fake_player_service.update(track_list=BOTH_TRACKS)
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    fake_player_service.unload_video()
+    fake_player_service.load_video("/videos/b.mkv")
+    fake_player_service.update(track_list=[{"type": "audio"}])
+
+    assert spies["subtitleActive"].wait(5000)
+    assert emissions(spies) == {"subtitleActive": 1}
+    assert spies["subtitleActive"].at(0, 0) is False
+
+
+def test_failed_load_retracts_all_three_buttons(make_view_model, fake_player_service, spy_notifies):
+    fake_player_service.load_video("/videos/movie.mkv")
+    fake_player_service.update(track_list=BOTH_TRACKS)
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    fake_player_service.unload_video()
+
+    assert spies["frameStepActive"].wait(5000)
+    assert emissions(spies) == {"frameStepActive": 1, "subtitleActive": 1, "audioActive": 1}
+    assert spies["frameStepActive"].at(0, 0) is False
+    assert spies["subtitleActive"].at(0, 0) is False
+    assert spies["audioActive"].at(0, 0) is False

--- a/testqml/bridge.py
+++ b/testqml/bridge.py
@@ -30,7 +30,14 @@ from mpvqc.viewmodels import (
     MpvqcWindowViewModel,
 )
 from testqml import import_wizard_fixtures
-from testqml.injections import FIXTURES_DIR, TEMP_ROOT, TEMP_SAVES_DIR, configure_injections, rebind_main_window
+from testqml.injections import (
+    FIXTURES_DIR,
+    TEMP_ROOT,
+    TEMP_SAVES_DIR,
+    PlayerServiceOverride,
+    configure_injections,
+    rebind_main_window,
+)
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
@@ -223,6 +230,20 @@ class MpvqcTestBridge(QObject):
     @Slot(result=list)
     def importMultiVideoDocuments(self) -> list[QUrl]:
         return [QUrl.fromLocalFile(str(p)) for p in _create_multi_video_qc_documents()]
+
+    @Slot(dict)
+    def loadVideo(self, values: dict) -> None:
+        player = inject.instance(PlayerService)
+        if not isinstance(player, PlayerServiceOverride):
+            msg = "loadVideo needs the player service override binding"
+            raise TypeError(msg)
+        player.load_video(
+            values.get("path", "/videos/movie.mkv"),
+            duration=float(values.get("duration", 0.0)),
+            time_pos=float(values.get("timePos", 0.0)),
+            time_remaining=float(values.get("timeRemaining", 0.0)),
+            percent_pos=float(values.get("percentPos", 0.0)),
+        )
 
     @Slot(result=str)
     def openedVideoName(self) -> str:

--- a/testqml/injections.py
+++ b/testqml/injections.py
@@ -33,6 +33,7 @@ from mpvqc.services.platform.window_buttons import StaticWindowButtons
 from mpvqc.services.platform.window_configuration import NoWindowConfigurator
 from mpvqc.services.platform.window_reveal import NoWindowRevealer
 from mpvqc.services.platform.window_state import QtWindowStateHandler
+from mpvqc.services.player.state import OBSERVED_PROPERTIES, make_observer
 from mpvqc.services.version_checker import CheckOutcome, UpToDate
 from mpvqc.services.video_resize import ResizeResult, ViewDimensions
 from mpvqc.viewmodels import MpvqcBackupTimerViewModel
@@ -98,6 +99,25 @@ class PlayerServiceOverride(PlayerService):
         super().__init__()
         self.opened_video: Path | None = None
         self.opened_subtitles: tuple[Path, ...] = ()
+        self._observers = {spec.name: make_observer(spec, self._apply_property_update) for spec in OBSERVED_PROPERTIES}
+
+    def load_video(
+        self,
+        path: str,
+        *,
+        duration: float,
+        time_pos: float,
+        time_remaining: float,
+        percent_pos: float,
+    ) -> None:
+        for name, raw in (
+            ("path", path),
+            ("duration", duration),
+            ("time-pos", time_pos),
+            ("time-remaining", time_remaining),
+            ("percent-pos", percent_pos),
+        ):
+            self._observers[name](name, raw)
 
     @override
     def is_any_video_loaded(self, videos: Iterable[Path]) -> bool:


### PR DESCRIPTION
## Manual checks before merging

### 🌐 Anywhere

#### Footer

- [x] With a video playing, the time label counts up and the percent label advances
- [x] A config written by the previous build keeps its choice: pick "Hide time" on main, quit, start this build, the time label stays hidden
- [x] On Linux, the time label shows its full text, never clipped, and keeps one steady width while the video plays

#### Window title

- [x] Loading a video mid-session puts its file name in the title, with Application Title set to Video File
- [x] Adding a comment appends `(unsaved)` to the title, and saving the document removes it
- [x] Launched in German, an unsaved document titles as `(ungespeichert)`, never English `(unsaved)`
- [x] Switching the language while a document is unsaved flips the `(unsaved)` suffix to the new language immediately

#### Toolbar

- [x] Loading a video brings the frame-step, subtitle, and audio buttons in as one cascade, not two waves
- [x] Switching from one video straight to another leaves the toolbar buttons in place, no retract-and-reappear flicker
- [x] With a video loaded, opening a broken or unsupported file retracts the frame-step buttons together with the subtitle and audio buttons
- [x] Opening a video and its external subtitle file in one go brings the subtitle button in with the rest

### 🪟 Windows

#### Footer

- [x] The time label shows its full text, never clipped, and keeps one steady width while the video plays, without shoving the percent label as digits tick
