### PR TITLE
docs: add agent skills and a private tracker

### DIFF
--- a/.agents/skills/committing/SKILL.md
+++ b/.agents/skills/committing/SKILL.md
@@ -57,6 +57,8 @@ fault, no talk of reporting anything upstream.
 
 When a larger chunk of work is done, offer to push, and to write the manual checks with the `manual-checks` skill.
 
+Work that traces to a ticket: once it is pushed, the ticket gets its closing comment — see the `filing-tickets` skill.
+
 ## Done when
 
 - The new files this change brings are added, and nothing else is.

--- a/.agents/skills/filing-tickets/SKILL.md
+++ b/.agents/skills/filing-tickets/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: filing-tickets
+description: File a ticket where it belongs, in the shape the tracker expects. Use when the user directs you to file something, to file the findings from a review report, to record a finding they rejected, or to close out a ticket whose work has landed. Fires only when directed.
+---
+
+# Filing tickets
+
+A tracker is worth reading only while everything in it is worth doing. An agent that files what it notices fills the
+list with its own opinions, and then nobody trusts the list. So **file only when the user directs it**, and expect most
+of what you find to leave through some other door.
+
+## Something you found while doing other work
+
+Say it in your **final message**: a title and a `file:line`, worded so the user can hand it straight back as "file
+these". Write nothing, anywhere. If it matters, they will tell you.
+
+## The four outlets
+
+When you find something, you have four moves, not two:
+
+1. **Fix it now** — inside the current change's blast radius, and small. No ticket.
+2. **File it** — it clears the bar below, and the user asked for it.
+3. **Record a decline** — only for a finding the _user_ rejected. See below.
+4. **Say it and let it go** — observations, opinions, "we could maybe someday". It goes in your response or the PR
+   body and dies there.
+
+Outlet 4 is a real outcome, not a failure to decide. Most of what a review turns up leaves through it.
+
+## The bar
+
+A **defect** gets a ticket. An **opinion** does not, and a review report emits both in the same confident voice. Three
+tests, and all three have to pass:
+
+1. It names **a change to make**, not a fact that is true.
+2. You can tell when it is **done** without redoing the analysis that found it.
+3. **If nobody ever does it, something is actually wrong.**
+
+Test 3 carries the weight. The one-line form: _what breaks, degrades, or misleads if this is never done?_ When the
+honest answer is _"nothing, it would just be nicer"_, you are holding an opinion.
+
+- **Defect**: "`accent_color_preference_for` is public but has no caller outside its own file." Never done, the
+  service permanently advertises a method nobody uses, and the next reader wires against it.
+- **Defect**: "'Overlay' means two different things in the glossary." Never done, every future agent that reads
+  `CONTEXT.md` picks one of the two at random.
+- **Opinion**: "The appearance package has more files than the other feature packages." Never done, nothing breaks,
+  degrades or misleads. It is an observation about shape.
+- **Opinion**: "`MpvqcAppearance` might deserve a better name someday." Never done, the name is exactly as good as it
+  is now.
+
+## Where it goes
+
+Resolve the substrate before writing anything. `docs/agents/issue-tracker.md` holds the probe, the three destinations
+and every `gh` recipe this skill names. The probe is silent on the happy paths, so run it and say nothing about it.
+
+## The ticket
+
+Every ticket wears the same two headings, whether it came out of a review report, a grilling session or a one-line ask.
+`to-tickets` publishes this shape too, so nobody has to work out which skill wrote which issue. An **epic** is the
+exception: its body is a spec, not a ticket.
+
+````markdown
+## What to build
+
+The end-to-end behaviour this ticket makes work, told from outside the code — not a layer-by-layer implementation
+list.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+---
+
+🤖&nbsp;&nbsp;_Written by Claude Opus 5_
+````
+
+- **Title**: plain, and it states the change.
+- **Self-contained.** The analysis that produced it gets deleted, so _What to build_ carries the whole argument: what
+  is wrong, why that is worth anyone's afternoon, and what the code does instead.
+- **Acceptance criteria are how you discharge test 2 of the bar.** Each one checkable by a reader who never saw the
+  analysis. A criterion that needs the review report reopened to evaluate is not yet a criterion.
+- **Name the thing, not where it lives.** A symbol, a component, a command — not `label_width_calculator.py:40-41`.
+  Line numbers go stale before anyone picks the ticket up, and this is the rule `CONTEXT.md` and the ADRs already run
+  on. A code snippet earns its place only where it pins a decision prose cannot — a state machine, a schema, a type
+  shape — trimmed to the decision rather than left as a working demo.
+- **One fresh context window.** A ticket an agent cannot finish in one is an epic, and the work is its children.
+- **Relationships go through the API, never into the prose.** A parent is a sub-issue link, a blocker is a `blocked_by`
+  edge, and `docs/agents/issue-tracker.md` has both calls. The graph moves as tickets close and get reparented, and a
+  sentence in a body does not, so a body that names its own edges is wrong within a week with nothing to catch it.
+  `what-next` computes the frontier off the API for the same reason.
+- **Provenance**: one line at most, at the end of _What to build_ — _"found during an architecture review,
+  2026-08-03"_. The only reason to record a source is to go back and read it, and the source is thrown away.
+- **Platform**: when the work can only be done on one OS, _What to build_ says which. `what-next` reads this.
+- **Footer**: on the private tracker, the body ends with the agent footer, and so does every comment you leave —
+  including the closing one. `docs/agents/issue-tracker.md` has the exact line.
+- **Labels**: one readiness label, and nothing else. Area labels are not used — the body says what a ticket touches
+  better than `python` vs `qml` does, and most work crosses both anyway.
+
+| The ticket is                                                                             | Label                                |
+| ----------------------------------------------------------------------------------------- | ------------------------------------ |
+| Something an agent can take unattended                                                     | `ready-for-agent`                    |
+| An accepted finding, not yet broken down                                                   | `ready-for-human` + `needs-grilling` |
+| Work needing a human for another reason: manual testing, the Windows box, design taste     | `ready-for-human`                    |
+
+An issue **with children carries no readiness label**. An epic is not work — its readiness is whatever its children
+say, and labelling it would let one effort fill several slots in `what-next`'s capped list. That makes a _childless_
+issue with no readiness label a detectable filing bug, which `what-next` flags.
+
+`needs-grilling` is the only qualifier. Add a second one only after wanting it twice: a wrong qualifier is worse than
+none, because it sends the recommendation the wrong way.
+
+## Structure
+
+- **The spec is the epic.** An effort's spec is the parent issue's body, so any agent on any machine gets the whole
+  thing from one `gh issue view`, with no clone.
+- **An epic is not a kind of issue. It is an issue that has children.** No type, no label, no ceremony. A finding filed
+  as a plain ticket becomes an epic the day a grilling session rewrites its body into a spec and hangs sub-issues off
+  it.
+- **Three levels is the norm**: epic (the spec) → ticket (planned work) → split (a ticket you _started_ that turned out
+  to be two). Level 3 is for decomposition you discover, not decomposition you plan.
+- **The rule that keeps a hierarchy honest**: _finishing the children finishes the parent._ Where that sentence is
+  false it is not a sub-issue. Grouping by topic, or by which afternoon the findings came from, is the mistake to watch
+  for.
+- **Every filed issue goes on the board.**
+
+## Declines
+
+A finding the user rejected — one that is real, and that the next review will find again — is **filed as an issue and
+immediately closed as not planned**, with the reasoning in the body:
+
+```bash
+gh issue close <n> --repo mpvqc/internal-tickets --reason "not planned" --comment "..."
+```
+
+- Only a finding the **user** rejected earns a record. A finding you filtered out yourself under the bar leaves
+  nothing behind, and that is correct: they never saw it, so there is nothing to stop from being re-proposed.
+- **A comment earns its place on the `load-bearing-comments` test alone.** Where the _why_ is a fact from outside the
+  code ("Qt ignores `setColorScheme` from then on"), it was worth writing before any review ran. The review is the
+  occasion, never the justification — a code comment written because a review flagged something is comment sprawl, and
+  comment sprawl is invisible where a closed issue is visible and prunable.
+- Where the same argument keeps coming back and keeps being re-argued, it graduates to an **ADR**. ADRs are numbered
+  and curated, so inflation shows.
+
+## Closing a ticket
+
+**A ticket closes when the work is done and pushed, not when it is merged.** Many tickets land on one feature branch,
+and the branch merges once the user has tested it, sometimes through a different PR, sometimes as a cherry-pick. Merge
+state belongs to the branch rather than to twelve tickets, and it already has a perfect display: the open PR list.
+
+The closing comment records **branch and SHA**:
+
+```bash
+gh issue close <n> --repo mpvqc/internal-tickets --comment "Done on \`appearance-domain\`, \`abc1234\`"
+```
+
+That stays true after a cherry-pick, because it states something about the past instead of being a pointer that has to
+keep resolving.
+
+**The link runs from the internal ticket out to the public side, and only that way.** Keep internal issue references
+out of public PRs and commit messages: they are plain, permanent text that everyone can read and nobody outside can
+open.
+
+**Claiming**: an agent picking up a ticket sets the board `Status` to `In Progress` before starting. That is the claim
+signal — branch names cannot carry it, because many tickets share one branch.
+
+## Filing a batch
+
+More than one finding at once — anything out of a review report, a survey or a sweep — goes through
+[`batch.md`](batch.md) **before the user sees any of it**. It puts a dedupe pass in front of everything above, and
+without it you will re-file things that were filed, fixed or declined months ago. Read it now if that is the job.
+
+## Done when
+
+- The user directed this filing.
+- Every finding left through exactly one of the four outlets, and the ones that left through outlet 4 were said out
+  loud.
+- Every filed ticket clears all three tests, and its body still stands once the analysis behind it is deleted.
+- Every filed ticket carries the two headings, with acceptance criteria a stranger can check, and every edge it has —
+  parent, blockers — recorded through the API rather than written in the body.
+- Every childless ticket carries exactly one readiness label, and every epic carries none.
+- Every body and every comment you wrote on the private tracker ends with the agent footer.
+- Every filed issue is on the board.

--- a/.agents/skills/filing-tickets/batch.md
+++ b/.agents/skills/filing-tickets/batch.md
@@ -1,0 +1,68 @@
+# Filing a batch
+
+Same bar, same four outlets, applied to N findings — with a dedupe pass in front of everything else.
+
+The dedupe has to live here. A review skill that comes from a marketplace cannot be taught about this tracker, so it
+will re-find the same things forever. Nothing upstream will ever stop it.
+
+## 1. Dedupe on intake
+
+Before the user sees a single finding, fetch what the tracker already holds and match the report against it:
+
+```bash
+gh issue list --repo mpvqc/internal-tickets --state all --limit 500 \
+  --json number,title,body,state,stateReason,labels
+```
+
+Match on what a finding _claims_, not on wording — the review re-words the same defect every run.
+
+| The finding matches an issue that is | It means             | Do                                        |
+| ------------------------------------ | -------------------- | ----------------------------------------- |
+| Open                                 | Already on the backlog | Drop it                                 |
+| Closed, `not planned`                | Already declined     | Drop it                                   |
+| Closed, `completed`                  | Already fixed        | The review still sees it: **a regression** |
+
+A regression is the one thing in this pass that gets louder rather than quieter. Say which issue closed it, and put it
+in front of the user first — a fix that came undone outranks anything new the report found.
+
+## 2. Report every drop
+
+One line per group, before the walkthrough:
+
+> Skipped 3 already on the backlog: #4, #7, #9.
+> Skipped 3 already declined: #12, #18, #23.
+
+A finding declined in March can be valid in August, because the code moved underneath it. A silent filter hides
+exactly that, so the drops are always spoken.
+
+## 3. Walk through what is left
+
+One at a time, with the user: accept, decline, or noise. The bar in `SKILL.md` decides what you even bring — a finding
+that fails it is an opinion, and opinions go through outlet 4 rather than into the walkthrough.
+
+## 4. File the accepted findings
+
+All at once, each as its own ordinary ticket in the shape `SKILL.md` describes.
+
+Not an epic with sub-issues. A review is a _source_, not a goal: its findings have nothing in common but the afternoon
+they were found, so "finishing the children finishes the parent" is false and nobody can ever finish the epic. It also
+burns the level you need for splitting one big finding into real work.
+
+No per-review label either. One label per review is unbounded growth.
+
+## 5. File the declines
+
+Each one closed as not planned, per the Declines section of `SKILL.md`. Only findings the user rejected in step 3 —
+never the ones you dropped in step 1 or filtered out under the bar.
+
+## 6. Say the report can go
+
+End with it plainly: the report is now safe to delete. Everything worth keeping is in the tracker, which is the thing
+that survives a machine switch. That is the whole point of the pass.
+
+## Done when
+
+- Every finding in the report is accounted for: dropped with its reason spoken, filed, declined, or named as noise.
+- Any regression was surfaced before the walkthrough, with the issue that closed it.
+- Every accepted finding is its own ticket — no epic, no per-review label.
+- You told the user the report can be deleted.

--- a/.agents/skills/load-bearing-comments/SKILL.md
+++ b/.agents/skills/load-bearing-comments/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: load-bearing-comments
+description: Load-bearing comments and restatements. Use when reviewing code or a diff, when adding or trimming a comment or docstring, or when another skill needs the test for whether a comment earns its keep.
+---
+
+# Load-bearing comments
+
+Good code needs few comments. A comment is load-bearing when it says something the code cannot say and nothing else
+already records. The rest are restatements: they cost a read, and they go stale the moment someone changes the code
+and not the text.
+
+Be strict. Most comments do not survive this.
+
+## The test
+
+Both halves have to pass, or the comment goes:
+
+1. **Could the code say it?** A name, a type, a match arm, a test.
+2. **Is it already written down?** `CONTEXT.md` defines the domain terms. `docs/adr/` holds the decisions and their
+   why. Read both before ruling on a comment, not just the one you remember.
+
+## Move it rather than keep it
+
+| What the comment holds       | Where it belongs |
+| ---------------------------- | ---------------- |
+| A domain term                | `CONTEXT.md`     |
+| A decision and its reasoning | an ADR           |
+| Behaviour                    | a test           |
+| What a name should have said | the name         |
+
+## What stays
+
+- An invariant a reader cannot check from where they stand: the order of a tuple that some other file indexes into.
+- A fact from outside the repo: Qt's `setColorScheme` ignores the system from then on.
+- A choice nothing derives: Dark is mpvQC's historic default.
+- A guard on an edit that looks safe and is not: this `__init__` stays empty or the imports cycle.
+- Why an opaque shape was picked: `Signal(object)`, because Qt signals cannot carry type aliases.
+
+Site it at the trap. The comment sits on the line someone is about to change, not in a header far from it.
+
+## How a restatement reads
+
+- It repeats the name or the signature. "Read a color scheme off a boundary" over `parse_color_scheme`.
+- It narrates the branch the code right below it already takes.
+- It copies a glossary entry or a sentence from an ADR.
+- It says what a comment at the consumer already says. Two copies in two languages drift apart.
+- It is a docstring on a marker type whose name is the whole meaning.
+
+A docstring that was the entire class body leaves `pass` behind. No pydocstyle rules run here, so that is fine.
+
+## Verify the claim before keeping it
+
+A comment that asserts something — "the only place X happens", "callers always Y" — is worth keeping only while it
+is true. Grep it and confirm. A false comment is worse than no comment, because it is the one a reader believes.
+
+## Done when
+
+- Every comment still standing passed both halves of the test.
+- The claims they make were checked against the code, not assumed.
+- Whatever moved out landed in `CONTEXT.md`, an ADR, a test, or a better name.

--- a/.agents/skills/what-next/SKILL.md
+++ b/.agents/skills/what-next/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: what-next
+description: An overview of everything open, with one recommendation.
+disable-model-invocation: true
+---
+
+# What next
+
+One picture of everything that is open, so the user can see where they are. It keeps them organised; it does not
+dispatch agents, and it never starts work.
+
+## 1. Resolve the substrate and the board
+
+`docs/agents/issue-tracker.md` holds the probe, the board lookup and every `gh` recipe below. Run it silently.
+
+On the contributor substrate there is no private tracker and no board, so sources 1 and 4 come back empty and the
+overview is whatever the rest of the sources give. That is a normal run, not a degraded one — say nothing about it.
+
+## 2. Gather
+
+Five sources. Fetch them concurrently.
+
+1. **Open issues in `mpvqc/internal-tickets`.** Readiness labels drive everything. Fetch sub-issue counts for progress,
+   and `blocked_by` so a blocked ticket can be kept out of the recommendation.
+2. **Open PRs in `mpvqc/mpvQC`.** The only place "done but not merged" lives.
+3. **The current branch and working tree.** What the user is already mid-way through.
+4. **`.scratch/` files carrying `Substrate: fallback`.** Offer to migrate each into `internal-tickets`.
+5. **The public tracker, split by triage label:**
+
+   | Label                                | Treated as                                        |
+   | ------------------------------------ | ------------------------------------------------- |
+   | `ready-for-agent`, `ready-for-human` | Real work, and a candidate for the recommendation  |
+   | `needs-triage`                       | Its own bucket: cheap, time-sensitive, someone is waiting |
+   | `needs-info`                         | Blocked on the reporter, excluded                  |
+   | `wontfix`                            | Excluded                                           |
+
+   Most of those labels do not exist on the public tracker yet — see `triage-labels.md`. The rule holds as they appear.
+
+   `needs-triage` stays its own bucket instead of being ranked with the rest, because it is cheap and time-sensitive
+   while backlog work is expensive and patient. Ranked together, one always buries the other.
+
+`TODO` comments and the rest of `.scratch/` are not sources. Leave them alone.
+
+## 3. Reconcile drift
+
+Agents forget to update tickets, and the instruction telling them to is advisory. So assume non-compliance and detect
+it instead of trusting the state:
+
+| What you see                                                                | What it means            | Where it prints              |
+| --------------------------------------------------------------------------- | ------------------------ | ---------------------------- |
+| `In Progress`, no closing comment, no recent commits                         | Started and dropped      | In flight, marked stalled    |
+| Closed with a recorded SHA that is not on `main` (`git merge-base --is-ancestor <sha> main`), on a branch that still exists | Unmerged work the branch's own row already covers | Nowhere of its own |
+| The same, but the recorded branch is gone from the remote                    | The cherry-pick case     | In flight, flagged for a human to check rather than guessed at |
+| A childless issue with no readiness label                                    | A filing bug             | One line under Backlog       |
+
+## 4. Rank
+
+Fixed precedence:
+
+1. **Land what exists.** Unmerged work decays — it conflicts, it goes stale, and only the user can test it.
+2. **Their flow.** What they are already doing beats starting something new.
+3. **Handoff-ready work.** `ready-for-agent` items, presented as information — "these could be handed off" — never as a
+   dispatch queue.
+
+A ticket with a live `blocked_by` cannot be the recommendation. It still counts in the backlog.
+
+**Platform.** An item that can only be done on the other OS stays **visible but demoted**: it is marked "not here" and
+never becomes the recommendation. Hiding it would make the same overview report different totals on different
+machines, which is the exact disorientation this skill exists to remove.
+
+## 5. Print it
+
+Straight to the terminal as markdown. No artifact, no file: an overview is true for about an hour, and writing one
+would leave a stale copy behind on every run, which is `.scratch/` failing all over again.
+
+Four layers, and the detail in each is proportional to how soon it matters:
+
+1. **In flight** — one row per piece of unmerged work. A branch and the PR carrying it are one piece, so they share a
+   row: branch, arrow, PR, then its state. Usually 1 to 3 rows. Everything here is still open; work that is closed is
+   done with, and the user is reading this to find what is left.
+2. **Waiting on you** — listed, **capped at 10**, then `+N more`. `needs-grilling`, `ready-for-human`, and the public
+   `needs-triage` bucket.
+3. **Backlog** — not listed. One line per epic with its progress, then counts for loose tickets and `ready-for-agent`.
+4. **Next** — one sentence, plus why.
+
+**Every section's last line is a bare URL** opening that same view on GitHub with the filter already applied — written
+out in full, starting `https://`, on a line of its own. Bare, because this skill ships to whatever terminal a
+contributor runs and a plain URL survives one that renders no links at all, as well as being copy-pasteable.
+
+Items stay plain `#31` text. Twenty lines of link syntax is harder to read than twenty lines of numbers, and the
+section footer is what carries the user to GitHub.
+
+Fill these in, one per section:
+
+| Section        | URL                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------ |
+| In flight      | `https://github.com/mpvqc/mpvQC/pulls`                                                 |
+| Waiting on you | `https://github.com/mpvqc/internal-tickets/issues?q=is%3Aopen+label%3Aneeds-grilling` and `https://github.com/mpvqc/mpvQC/issues?q=is%3Aopen+label%3Aneeds-triage` |
+| Backlog        | the board's `url`, from `gh project list --owner mpvqc --format json`                  |
+| Next           | whichever of the above the recommendation came from                                    |
+
+The overview is a jumping-off point, not a dead end.
+
+````markdown
+## In flight
+
+- `appearance-domain` → PR #31 Colour scheme follows the system — draft, 12 commits, 2 unpushed, waiting on your testing
+- #7 closed on `abc1234`, and the branch that carried it is gone from the remote — check whether it landed
+
+https://github.com/mpvqc/mpvQC/pulls
+
+## Waiting on you
+
+- #1 Colour scheme — `needs-grilling`
+- #9 Window resize on a tiling compositor — `ready-for-human`, **not here** (Windows)
+- mpvQC#204 Crash when opening a document — `needs-triage`
+
+https://github.com/mpvqc/internal-tickets/issues?q=is%3Aopen+label%3Aneeds-grilling
+https://github.com/mpvqc/mpvQC/issues?q=is%3Aopen+label%3Aneeds-triage
+
+## Backlog
+
+- #1 Colour scheme — 0/5
+- #2 View model dataflow — 0/2
+- 3 loose tickets, 4 `ready-for-agent`
+- #22 has no readiness label
+
+https://github.com/orgs/mpvqc/projects/4
+
+## Next
+
+Test PR #31 and land `appearance-domain`. Nobody else can test it, and it goes stale while it waits.
+
+https://github.com/mpvqc/mpvQC/pull/31
+````
+
+The four sections are the whole reply, and the URL under **Next** is the last thing you print. Deeper detail is a
+follow-up question in the same session — "show me the loose ones" — rather than something every run prints.
+
+## Done when
+
+- Every one of the five sources was read, or was empty because the substrate says so.
+- Every open in-flight item appears in section 1, including the ones drift reconciliation found rather than the tickets
+  claimed, and each branch shares its row with the PR that carries it.
+- Nothing is hidden for being on the other OS; those items are listed and marked "not here".
+- Each of the four sections ends on a bare `https://` URL of its own, on its own line.
+- The recommendation is one sentence with its reason, and nothing was written to disk.
+- The reply ends on the **Next** URL.

--- a/.agents/skills/writing-glossary/SKILL.md
+++ b/.agents/skills/writing-glossary/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: writing-glossary
+description: Glossary entries in CONTEXT.md. Use when adding, changing, or reviewing a domain term in this repo.
+---
+
+# Writing glossary entries
+
+An entry answers one question: what is this thing? A reader who has never opened the code comes away able to
+recognise the term in the wild, and to tell it from its neighbours.
+
+## The concept, nothing else
+
+A term outlives the implementation it was coined for, and the entry has to survive it too. So write what the term
+means and stop.
+
+The test: would this sentence change if the code changed while the concept stayed the same? Then it is
+implementation, and it belongs in the code and its tests, where it can be checked. Counts of what ships today,
+tie-breaks, defaults, what an entity carries, file formats, lookup keys — implementation, all of it.
+
+## Define positively
+
+Say what the term is, in one or two sentences, in plain words.
+
+- **Straw terms**: "Family, not set" argues with a name the reader never had. Contrast only if absolutely necessary
+  with another entry in the file, where a reader can genuinely mix the two up: "A request, not a result."
+- **Circles**: "the color choice that selects the colored variant of what it colors" restates the term. Reach instead
+  for what the thing is made of, or what it decides.
+- **Wit**: "A key, not a promise" reads well and defines nothing.
+
+## Borrow only defined words
+
+Every noun in an entry is plain English or another term in the file. A compound invented while writing the entry —
+"accent palette", "one design" — is a new term you now owe a definition; use an existing one instead.
+
+Where a word needs a qualifier, name it: "the system's color scheme", never a bare "color scheme".
+
+## Done when
+
+- A reader who does not know this codebase can say what the term means and when it applies.
+- Every word in the entry is plain English or another entry in the file.
+- Nothing in the entry would change if the implementation changed and the concept did not.

--- a/.agents/skills/writing-view-models/SKILL.md
+++ b/.agents/skills/writing-view-models/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: writing-view-models
+description: The snapshot pattern for dataflow view models. Use when writing, reviewing, or migrating a view model that reads service state and exposes derived properties to QML.
+---
+
+# Writing view models
+
+A view model that reads service state and hands derived values to QML runs on the **snapshot pattern**. Written any
+other way the derivation smears across the file, every consumed signal grows a public setter, and tests push state in
+past the seam production uses.
+
+Out of scope: one-shot commands, and view models that only forward slot calls to services. They stay as they are.
+
+ADR 0006 carries the reasoning and the alternatives that were dropped.
+
+## The two snapshots
+
+Two frozen dataclasses, both private to the view model in intent:
+
+- **Inputs snapshot** — `<Name>Inputs`. One field per consumed upstream signal, holding the scalar the derivation
+  reads. Never an embedded service object: the field list is a projection that names the exact dependency set.
+- **Props snapshot** — `<Name>Props`. One field per QML-facing property, holding its value. Props that always
+  co-change are one composite field behind one notify, where the consumer dedupes at the sink: the palette view model
+  carries the whole palette that way and hands QML a read-only object over it. ADR 0006 holds the measurements.
+
+## The cycle
+
+Fold, derive, emit. Every path through the view model runs all three.
+
+### Fold
+
+One private `_fold_<field>` slot per consumed signal. It replaces its one field and runs the cycle:
+
+```python
+@Slot(bool)
+def _fold_video_loaded(self, value: bool) -> None:
+    self._update(replace(self._inputs, video_loaded=value))
+```
+
+Services are read exactly once, in `__init__`, to build the first inputs snapshot. Afterwards only signal payloads
+arrive. Payloads are trustworthy because every upstream emits from stored state, coerced and deduped at its own
+boundary, so the initial read and the update path cannot end up disagreeing.
+
+Subscribe to the per-field signals the services already emit.
+
+### Derive
+
+One module-level pure function, `derive_<name>_props(inputs, ...) -> <Name>Props`, importable and callable without
+constructing the view model.
+
+Pure static helpers are called inside it directly. A stateful dependency crosses as an injected callable, so the
+signature names the derivation's real dependencies:
+
+```python
+def derive_footer_props(inputs: FooterInputs, measure_width: Callable[[str], int]) -> FooterProps:
+```
+
+When the derivation takes callables bound to `self`, a private `_derive()` binds them in one place and the cycle calls
+that. When it takes the inputs alone, the cycle calls the module function.
+
+### Emit
+
+```python
+def _update(self, inputs: FooterInputs) -> None:
+    self._inputs = inputs
+    new, old = self._derive(), self._props
+    if new == old:
+        return
+    self._props = new
+    if new.time_text != old.time_text:
+        self.timeTextChanged.emit(new.time_text)
+```
+
+`self._props` is swapped in before the first emission. That makes settled-state reads structural: an observer of any
+notify sees fully consistent state, whatever the connection order.
+
+Each notify then fires exactly when its own field changed, carrying the new value.
+
+## Conditional elements
+
+Three additions that are not part of the base pattern. Each one names the upstream that needs it, in a comment or in
+the commit message.
+
+**Unchanged-inputs guard** — returning early when the folded inputs equal the previous snapshot. Every upstream
+dedupes at its source, which leaves the guard unreachable and untestable through the seam. Add it when an upstream can
+refire an unchanged payload.
+
+**Burst coalescing** — a trailing debounce between fold and cycle, for a consumer that needs one settled emission per
+upstream burst. Folds still apply every payload immediately; the timer defers derive-and-emit alone, so the cycle runs
+once against settled inputs and emits only the deltas that survive the burst. The fold side is `_apply`, the timer side
+`_derive_and_emit`, and the window is a keyword-only constructor argument so tests can shrink it.
+
+**Trigger fold** — the fold for a payload-free signal, and how ambient state enters the snapshot. The handler re-reads
+exactly the values the signal announces, nothing else, into dedicated inputs fields, so the derivation stays pure over
+the inputs snapshot alone. Constants read once at construction sit in the inputs snapshot with no fold at all.
+
+## Tests
+
+Three kinds. A migrated view model has all three.
+
+**Derivation** — a table calling `derive_<name>_props` directly, one row per case, no view model constructed.
+
+**Wiring** — drive a real service signal in and assert the exact emission set out: the fields whose derived value
+changed, and a zero count on every field that stayed silent. Cases where a signal changes nothing observable assert
+that everything stayed silent.
+
+**Settled state** — one test that an observer of a notify reads fully consistent props:
+
+```python
+view_model.isDarkChanged.connect(lambda _: observed.append((view_model.isDark, view_model.background)))
+```
+
+## Done when
+
+- Every QML-facing property returns a props field, or an object the view model publishes over one, and no derived
+  value is stored anywhere else.
+- Services are named in `__init__` and in the slots that write back to them, nowhere else.
+- The public surface is the properties, their notifies, and the slots the view binds. No member exists so that
+  something can push state in.
+- `self._props` is swapped before the first emission, and each notify fires exactly when its field changed.
+- The derivation is proven by a table that never constructs the view model, and the wiring by tests that name the
+  fields which stayed silent.

--- a/.gitignore
+++ b/.gitignore
@@ -527,6 +527,7 @@ $RECYCLE.BIN/
 /.claude/skills
 /.flatpak-builder
 /.qtcreator
+/.scratch/
 /appdata
 /build-dir
 /docs/dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,15 +21,19 @@
 - Prefer the correct term over the term already in the repo. When a name contradicts the spec or the project it refers
   to, rename it and record the term in `CONTEXT.md`. Don't keep a wrong name to match other wrong names.
 - Don't use structural comments like `# region` or `# ---`.
-- Avoid comments unless absolutely necessary. In any case, keep them short.
 - Run background work through `SerialJobRunner` from `mpvqc/jobs.py`. Don't use `QThreadPool`, locks, or private queued
   signals in services directly.
 - Prefer code the type checker can verify:
   - Use closures instead of `functools.partial`
   - Don't use getattr
-- Only inject-wired classes live in `mpvqc/services/` and carry the `Service` suffix. Helpers that aren't in
-  `injections.py` live at the top level of `mpvqc/`.
+- A feature package under `mpvqc/<feature>/` bundles everything one area needs: `domain.py` at its root, plus role
+  directories (`services/`, `models/`, `viewmodels/`) for what the area owns. It contributes its own bindings and the
+  composition root calls them.
+- Inject-wired classes carry the `Service` suffix wherever they live. `mpvqc/services/` holds what no feature package
+  has claimed; helpers that aren't inject-wired live at the top level of `mpvqc/`.
+- Load the `load-bearing-comments` skill before adding a comment or docstring, and when reviewing code.
 - Load the `writing-qml` skill before writing or editing a QML file.
+- Load the `writing-view-models` skill before writing or editing a view model that reads service state.
 
 ## Testing
 
@@ -42,6 +46,7 @@
   `viewModel` QML property.
 - In ADRs and `CONTEXT.md`, name the thing, not where it lives. Paths and file names go stale, so describe the component
   or the command instead. Setup and workflow docs are the exception: there the path is the point.
+- Load the `writing-glossary` skill before adding or changing a term in `CONTEXT.md`.
 
 ## Committing
 
@@ -51,14 +56,14 @@
 
 ### Issue tracker
 
-User reports and triage live on GitHub Issues; larger chunks of work are planned as local markdown under
-`.scratch/<feature>/`, and internally found bugs go to `.scratch/bugs/` — never to the public tracker. See
-`docs/agents/issue-tracker.md`.
+Three destinations: the public GitHub tracker for user reports and triage, a private tracker for every internal work
+item, and `.scratch/` for disposable artifacts. Nothing with a status stays local, and an agent never opens an issue on
+the public tracker. Load the `filing-tickets` skill before filing anything; `docs/agents/issue-tracker.md` decides where
+it goes.
 
 ### Triage labels
 
-Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See
-`docs/agents/triage-labels.md`.
+The label vocabulary of each tracker, and which of those labels exist today. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
+++ b/docs/adr/0006-run-dataflow-view-models-on-the-snapshot-pattern.md
@@ -1,73 +1,45 @@
 # Run dataflow view models on the snapshot pattern
 
 A dataflow view model consumes service state and exposes derived values to QML. Written slot by slot, every consumed
-signal gets a public setter, every derived value its own update method, and each hand-maintains its own dedupe and
-its own list of dependents. The derivation smears across the file, the interface fills with members that are wiring
-rather than interface, and tests push state through that wiring past the seam production uses. The footer view model
-was the worst case and is the first migration.
+signal gets a public setter and every derived value its own update method, each hand-maintaining its dedupe and its
+list of dependents. The derivation smears across the file, the interface fills with wiring, and tests push state
+through that wiring past the seam production uses.
 
-The pattern runs on two frozen structs private to the view model. The **inputs snapshot** holds exactly the scalars
-the view model derives from, one field per consumed upstream signal — a projection whose field list names the exact
-dependency set, never an embedded service state. The **props snapshot** holds the value of every QML-facing
-property. The cycle between them is three motions:
+The pattern runs on two frozen structs private to the view model. The **inputs snapshot** holds one field per consumed
+upstream signal, so its field list names the exact dependency set. The **props snapshot** holds every QML-facing
+property that carries derived state. The cycle between the two is three motions:
 
-- **Fold**: one private handler per consumed signal replaces that one field in the inputs snapshot and runs the
-  cycle. Services are read exactly once, at construction, to build the initial inputs snapshot; afterwards only
-  signal payloads arrive. Payloads are trustworthy because every upstream emits from stored state, coerced and
-  deduped at its own boundary — so initial-read and update semantics cannot diverge.
-- **Derive**: one pure function takes the inputs snapshot and returns the props snapshot. Pure static helpers are
-  called directly inside it; a stateful dependency crosses as an injected callable, so the signature names the
-  derivation's real dependencies.
-- **Emit**: the new props snapshot is swapped in before the first emission, then each per-field notify emits exactly
-  when its value changed, carrying the new value. The swap completing first makes settled-state reads structural: an
-  observer of any notify sees fully consistent state, independent of connection order.
+- **Fold**: one private handler per signal replaces that one field and runs the cycle. Services are read once, at
+  construction; afterwards only payloads arrive, and they are trustworthy because every upstream emits from stored
+  state, deduped at its own boundary.
+- **Derive**: one pure function takes the inputs snapshot and returns the props snapshot. A stateful dependency crosses
+  as an injected callable, so the signature names the derivation's real dependencies.
+- **Emit**: the props snapshot is swapped in before the first emission, then each per-field notify emits exactly when
+  its value changed. The swap completing first means an observer of any notify sees consistent state, whatever the
+  connection order.
 
-Sourcing is per-field by default: the view model subscribes to the per-field signals the services already emit.
-
-The unchanged-inputs guard — returning early when the folded inputs equal the previous snapshot — is a conditional
-element, not part of the base pattern. While every upstream dedupes at its source, the guard is unreachable and
-untestable through the seam. It is added only when an upstream can refire an unchanged payload. Retranslation is not
-that case: under the trigger fold it is an ordinary fold of a real value.
-
-**Trigger fold** — the fold for a payload-free trigger signal — is how ambient state enters the snapshot. The
-handler re-reads exactly the ambient values the signal announces, nothing else, and folds them into dedicated inputs
-fields, so the derivation stays pure over the inputs snapshot alone — no injected callables for ambient state.
-Constants read once at construction may sit in the inputs snapshot without a fold. The first case is retranslation:
-the header view model folds the translated unsaved-title template on the internationalization service's retranslated
-signal, which fires only after the translators are installed — the read-at-trigger is as trustworthy as a payload,
-and ordering is structural instead of connection-order luck.
-
-**Burst coalescing** — a trailing debounce between fold and cycle — is likewise a conditional element, added only
-when a consumer needs one settled emission per upstream burst. Folds still apply every payload immediately; the
-timer defers only derive-and-emit, so the cycle runs once against settled inputs and emits only the deltas that
-survive the burst. The toolbar view model is the first case: its button cascade animation is designed to settle once
-per change, and the player reports a transient no-path on every video switch — the debounce absorbs that
-video-loaded flip before it can reach QML.
+Granularity follows the props' co-change structure. One field per property with its own notify is the default. Fields
+that always co-change belong in one composite field behind one notify, as long as the consumer dedupes at the sink.
+Per-field notifies exist so an unrelated update cannot wake an unrelated binding, and where every field moves together
+there is no unrelated update: QML's own change detection discards whatever did not move, so the extra signals were
+measured to wake no fewer sinks and to cost the same.
 
 ## Consequences
 
-- The interface holds only what the view binds: the properties, their notifies, and real slots. Service wiring is
-  private, so neither callers nor tests can push state past the production seam.
-- Every derived value is verifiable by calling the derivation directly — one table row per case, no view model
-  construction.
+- The interface holds only what the view binds. Service wiring is private, so neither callers nor tests can push state
+  past the production seam.
+- Every derived value is verifiable by calling the derivation directly, one table row per case.
 - Wiring tests drive real service signals in and assert exact emission sets out: the fields whose derived value
   changed, nothing else.
-- An unrelated update never makes QML re-read the other properties, and an unrelated service field never wakes the
-  view model at all.
-- Roughly thirteen dataflow view models are expected to migrate onto the pattern; the rest of the layer — dialog
-  drivers, one-shot commands — coexists unchanged.
+- An unrelated service field never wakes the view model at all.
 
 ## Dropped alternatives
 
-- **A shared single notify** for all properties: one signal on any change makes QML re-read every property and
-  loses per-property change granularity.
-- **Per-value selector objects**, one per derived value with its own recompute and signal: more objects and
-  connection order back in play, for the same observable behavior.
-- **Descriptor or dependency-graph primitives** that declare fields once and generate the wiring: speculative
-  machinery — the cycle is a dozen plain lines per view model.
-- **Read-everything refresh**, re-reading all services on any signal and diffing: reintroduces the initial-read
-  versus update divergence and hides the dependency set the inputs snapshot exists to name.
-- **A player state-snapshot publication**, the player service emitting its whole reduced state as one payload: no
-  two consumed fields co-change in one reduce today, per-field payloads are equally trustworthy, and per-field
-  sourcing wakes consumers strictly less often. Revisit when a consumer must read co-changing fields in one
-  observation — a path load's video-loaded flag together with its dimensions, or both track counts.
+- **A shared single notify** across props that move independently: QML re-reads every property on any change.
+- **A map payload** for a composite field, its fields crossing as one map: the fastest wiring measured, and the only
+  one that gives up linter checking on the field names.
+- **Per-value selector objects**: more objects and connection order back in play, for the same observable behavior.
+- **Descriptor or dependency-graph primitives** that generate the wiring: speculative machinery, when the cycle is a
+  dozen plain lines per view model.
+- **Read-everything refresh** on any signal: reintroduces the initial-read versus update divergence and hides the
+  dependency set the inputs snapshot exists to name.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,70 +1,163 @@
-# Issue tracker: GitHub + Local Markdown
+# Issue tracker: where work is written down
 
-This repo uses two trackers:
+Three destinations, and this document is the authority on which one a given thing goes to. Everything else defers here
+rather than carrying its own copy of the routing rules.
 
-- **GitHub Issues** (`mpvqc/mpvQC`) — the public tracker. Users report bugs and request features here. Use the `gh` CLI.
-- **Local markdown** under `.scratch/` — the working tracker for a larger chunk of work: the spec and the implementation
-  tickets derived from it.
+| Destination                     | What lives there                                             | Who writes there                              |
+| ------------------------------- | ------------------------------------------------------------ | --------------------------------------------- |
+| `mpvqc/mpvQC` (public)          | User reports, triage, discussion with reporters               | Users. An agent never opens an issue here.    |
+| `mpvqc/internal-tickets` (private) | Every internal work item: findings, tickets, epics, specs   | The maintainer, or an agent they direct       |
+| `.scratch/` (local, gitignored) | Disposable artifacts: review reports, prototypes, surveys     | Anyone. Also the contributor and fallback path for tickets. |
 
-Routing rule: anything public-facing (user reports, triage, discussion with reporters) lives on GitHub. Everything that
-starts inside the project lives in `.scratch/`: working state for a feature effort (specs, implementation tickets,
-wayfinder maps) and bugs we find ourselves. Only reports from users open GitHub issues — a bug found by the maintainer
-or an agent goes to `.scratch/bugs/`, never to the public tracker.
+The rule: **nothing with a status stays local.** If a thing can be open or closed, it belongs in a tracker.
 
-## GitHub Issues (public tracker)
+The test: _if it has to survive a machine switch, it isn't scratch._ `.scratch/` is gitignored, so it exists on one
+machine, in one working directory.
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments` with appropriate `--label`
-  and `--state` filters; use `--jq` to compact the output to the fields you need.
-- **Comment on an issue**: `gh issue comment <number> --body "..."`
+## Substrate resolution
+
+Which of the three you get is probed, not configured, and the probe is **silent on the happy paths**. Identity is
+decided on the **public** repo, because a private repo returns 404 rather than 403 to anyone who cannot see it. Probe
+the private one and a lost token looks exactly like a contributor.
+
+1. `gh api repos/mpvqc/mpvQC --jq .permissions.push`
+   - no `gh`, or no authenticated account → **contributor**
+   - `false` → **contributor**
+   - `true` → maintainer, go to 2
+   - anything else — a `401` from a stale token, a network failure, output you did not expect → **degraded**, go to 3
+2. `gh api repos/mpvqc/internal-tickets`
+   - `200` → file in `mpvqc/internal-tickets`
+   - anything else at all — 404, 401, a lost scope, the repo renamed → **degraded**, go to 3
+3. **Degraded.** Write the ticket to `.scratch/` with a `Substrate: fallback` line near the top, and print one visible
+   line: _"couldn't write to the private tracker, filed to `.scratch/`, re-file once it's reachable."_ Then carry on. An
+   agent mid-task cannot fix this, and a misplaced ticket beats a lost one. `what-next` finds the marker later and
+   offers to push it to `internal-tickets`.
+
+For a contributor, `.scratch/` is the terminal answer, not a fallback: file there and write no marker.
+
+## `mpvqc/internal-tickets` (private tracker)
+
+Everything that starts inside the project. See the `filing-tickets` skill for what earns a ticket and what one looks
+like; the mechanics live here.
+
+- **Create**: `gh issue create --repo mpvqc/internal-tickets --title "..." --body-file <file>`
+- **Read**: `gh issue view <n> --repo mpvqc/internal-tickets --comments`
+- **Read a spec**: `gh issue view <n> --repo mpvqc/internal-tickets --json body --jq .body`
+- **Write a spec**: draft locally, then `gh issue edit <n> --repo mpvqc/internal-tickets --body-file spec.md`
+- **Close**: `gh issue close <n> --repo mpvqc/internal-tickets --comment "..."`
+
+### The agent footer
+
+Every issue body and every comment an agent writes here ends with a rule and one line, both after a blank line:
+
+```text
+---
+
+🤖&nbsp;&nbsp;_Written by Claude Opus 5_
+```
+
+Name whichever model is writing. Keep the emoji outside the italics, and keep both `&nbsp;`, since plain spaces
+collapse to one. Agents file through the maintainer's token, so the footer is the only record of who wrote the text. It
+goes on anything with a body: a new ticket, a spec rewrite, a comment, a closing comment. An agent that rewrites a body
+a human wrote adds it too, under its own name. Not in titles, labels or board fields.
+
+Sub-issues and dependencies are keyed by the **database id**, never the issue number:
+
+```bash
+gh api repos/mpvqc/internal-tickets/issues/<n> --jq .id
+
+# hang a child off a parent
+gh api --method POST repos/mpvqc/internal-tickets/issues/<parent>/sub_issues -F sub_issue_id=<child database id>
+
+# record that <n> waits for another ticket
+gh api --method POST repos/mpvqc/internal-tickets/issues/<n>/dependencies/blocked_by -F issue_id=<blocker database id>
+
+# read them back
+gh api repos/mpvqc/internal-tickets/issues/<n>/dependencies/blocked_by
+```
+
+Use `-F`, not `-f`: the API wants an integer and `-f` sends a string.
+
+An issue has at most one parent, so the structure is a tree. A parent does not auto-close when its last child closes.
+
+### Finding the board
+
+By convention, not configuration. `gh project list --owner mpvqc` and use the single project it returns.
+
+- Exactly one project → that is the board.
+- None → normal and quiet. Contributors cannot see org projects at all, so say nothing and skip every board step.
+- More than one → say which ones you found and skip the board steps rather than guess.
+
+Add an issue with `gh project item-add <number> --owner mpvqc --url <issue url>`. The board's own workflows
+already pull in new issues and sub-issues, so this is a safety net for what they miss, not the thing that puts
+work on the board.
+
+Field ids differ per board, so read them rather than hardcoding them:
+`gh project field-list <number> --owner mpvqc --format json`. `Status` is a single-select with `Todo`, `In Progress`
+and `Done`; setting it needs `gh project item-edit` with the project id, the field id and the option id from that
+listing.
+
+## `mpvqc/mpvQC` (public tracker)
+
+Users report bugs and request features here, and triage happens here. An agent never comments or files here.
+
+- **Read an issue**: `gh issue view <number> --json comments,labels --jq <expr>`
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments` with the `--label` and
+  `--state` filters you need; use `--jq` to compact the output
+- **Comment**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`
 
-Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+Inside a clone, `gh` infers this repo from `git remote -v`, so these need no `--repo`.
 
-Triage labels apply here — see `triage-labels.md`.
+Triage labels apply here. See `docs/agents/triage-labels.md`.
 
-**PRs as a request surface: no.**
-_(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+External PRs are not feature requests.
 
-## Local markdown (working tracker)
+## `.scratch/` (local)
 
-- One feature per directory: `.scratch/<feature-slug>/`
-- Bugs found internally that belong to no feature effort: one file per bug at `.scratch/bugs/<NN>-<slug>.md`, numbered
-  from `01`, with a `Status:` line near the top
-- The spec is `.scratch/<feature-slug>/spec.md`
-- Implementation issues are one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` —
-  never a single combined tickets file
-- Ticket state is recorded as a `Status:` line near the top of each issue file
-- Comments and conversation history append to the bottom of the file under a `## Comments` heading
-- If the effort stems from a public report, put a `Tracks: #<number>` line near the top of the spec so the GitHub issue
-  can be closed when the work lands
+Disposable artifacts need no format. Tickets written here, by a contributor or by a degraded filing, use this one, with
+the same body shape as any filed ticket, which the `filing-tickets` skill owns:
+
+- One effort per directory: `.scratch/<effort-slug>/`, with the spec at `spec.md`
+- One file per ticket at `.scratch/<effort-slug>/issues/<NN>-<slug>.md`, numbered from `01`. Never a single combined
+  tickets file
+- A ticket belonging to no effort: `.scratch/tickets/<NN>-<slug>.md`, numbered the same way
+- A `Status:` line near the top of every ticket file, either `claimed` or `resolved`
+- A `Blocked by: NN, NN` line near the top where order matters. A ticket is unblocked when every file it lists is
+  `resolved`
+- Comments and conversation history append to the bottom under a `## Comments` heading
+- If the effort stems from a public report, a `Tracks: mpvqc/mpvQC#<number>` line near the top of the spec, so the
+  public issue can be closed when the work lands
+- `Substrate: fallback` near the top when a degraded filing put it here
 
 ## When a skill says "publish to the issue tracker"
 
-- Triage outcomes, or comments and labels on a user report → GitHub, via `gh`.
-- A spec or implementation tickets for a feature effort → files under `.scratch/<feature-slug>/` (creating the directory
-  if needed).
-- A bug found while working, unrelated to the current effort → a file under `.scratch/bugs/`.
+- Never publish to the public tracker.
+- A finding, a ticket, a spec, or anything else that starts inside the project → resolve the substrate, then file it
+  there. The `filing-tickets` skill owns this path.
 
 ## When a skill says "fetch the relevant ticket"
 
-- A `#<number>` reference → `gh issue view <number> --comments`.
+- A bare `#<number>` → the substrate you resolved. On the private tracker,
+  `gh issue view <n> --repo mpvqc/internal-tickets --comments`.
+- An `mpvqc/mpvQC#<number>` reference, or a number the user names as a user report → the public tracker.
 - A file path or `NN` ticket number → read the file under `.scratch/`. The user will normally pass the path directly.
 
 ## Wayfinding operations
 
-Used by `/wayfinder`. Wayfinding is internal working state, so it lives in the local tracker. The **map** is a file with
-one **child** file per ticket.
+Used by `/wayfinder`. Wayfinding is internal working state, so it lives on the substrate the probe resolved. On the
+private tracker there is nothing wayfinding-specific to build — the tracker already has every piece:
 
-- **Map**: `.scratch/<effort>/map.md` — the Notes / Decisions-so-far / Fog body.
-- **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`, with the question in the body. A
-  `Type:` line records the ticket type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records
-  `claimed`/`resolved`.
-- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked when every file it lists is `resolved`.
-- **Frontier**: scan `.scratch/<effort>/issues/` for files that are open, unblocked, and unclaimed; first by number
-  wins.
-- **Claim**: set `Status: claimed` and save before any work.
-- **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`, then append a context pointer
-  (gist + link) to the map's Decisions-so-far in `map.md`.
+| Wayfinding term | On `mpvqc/internal-tickets`                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| Map             | The epic's body — the Notes / Decisions-so-far / Fog sections               |
+| Child ticket    | A sub-issue, with the question in its body                                  |
+| Ticket type     | A prose line in the body (`research` / `prototype` / `grilling` / `task`)   |
+| Blocking        | The `blocked_by` dependencies API                                           |
+| Frontier        | Open sub-issues that no `blocked_by` entry holds and nobody is assigned to  |
+| Claim           | Assign yourself, and set the board `Status` to `In Progress`                |
+| Resolve         | Comment the answer, close the issue, then append the gist and its link to the epic's Decisions-so-far |
+
+On `.scratch/`, the same operations run against the file format above: `Status: claimed` / `Status: resolved`, the
+`Blocked by:` line, and an `## Answer` heading for the resolution.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,17 +1,31 @@
 # Triage Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used on
-the public GitHub tracker (`mpvqc/mpvQC`), where triage happens.
+The skills speak in terms of triage roles. This file maps them to the label strings on each of the two trackers.
+Neither tracker uses area labels or issue types.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+## `mpvqc/mpvQC` (public tracker)
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this
-table.
+Triage happens here. `gh label list --repo mpvqc/mpvQC` shows which of these exist today.
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+| Role              | Meaning                                  |
+| ----------------- | ---------------------------------------- |
+| `needs-triage`    | Maintainer needs to evaluate this issue  |
+| `wontfix`         | Will not be actioned                     |
+| `needs-info`      | Waiting on reporter for more information |
+| `ready-for-agent` | An agent can take it unattended          |
+| `ready-for-human` | Requires a human, not an agent           |
+
+`gh issue edit --add-label` fails on a label that does not exist. When `needs-info`, `ready-for-agent`, or
+`ready-for-human` is genuinely the right outcome, create it first with
+`gh label create <name> --repo mpvqc/mpvQC --description "..."` and tell the user.
+
+## `mpvqc/internal-tickets` (private tracker)
+
+`gh label list --repo mpvqc/internal-tickets` shows which of these exist today, and every other `gh` call against this
+tracker needs the same `--repo`. Which label a ticket gets is the `filing-tickets` skill's call.
+
+| Label             | Meaning                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `ready-for-agent` | An agent can take it unattended                                                      |
+| `ready-for-human` | Requires a human, not an agent                                                       |
+| `needs-grilling`  | Qualifier alongside a readiness label: accepted finding, not yet broken down          |


### PR DESCRIPTION
Part of #376, which lands as several PRs.

This one adds the agent skills and moves internal work off local markdown onto a private tracker.
