### PR TITLE
refactor: move two more view models onto the snapshot pattern

### DIFF
--- a/mpvqc/viewmodels/utility/label_width_calculator.py
+++ b/mpvqc/viewmodels/utility/label_width_calculator.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass, replace
 
 import inject
 from PySide6.QtCore import Property, QCoreApplication, QObject, Signal, Slot
@@ -24,6 +25,39 @@ def _time_candidates(*, long_format: bool) -> Iterator[str]:
     return (pattern.format(digit)[:-1] for digit in range(10))
 
 
+def _translate_comment_types(types: frozenset[str]) -> tuple[str, ...]:
+    # sorted, so that equal type sets always give an equal snapshot: frozenset iteration is hash order
+    return tuple(QCoreApplication.translate("CommentTypes", comment_type) for comment_type in sorted(types))
+
+
+@dataclass(frozen=True)
+class LabelWidthCalculatorInputs:
+    displayable_comment_types: frozenset[str]
+    """The derivation never reads this. The retranslation fold does, to translate the types under the new language."""
+
+    comment_type_labels: tuple[str, ...]
+    table_long_format: bool
+
+    def with_types(self, types: frozenset[str]) -> "LabelWidthCalculatorInputs":
+        return replace(self, displayable_comment_types=types, comment_type_labels=_translate_comment_types(types))
+
+
+@dataclass(frozen=True)
+class LabelWidthCalculatorProps:
+    comment_types_label_width: int
+    time_label_width: int
+
+
+def derive_label_width_calculator_props(
+    inputs: LabelWidthCalculatorInputs,
+    measure_width: Callable[[Iterable[str]], int],
+) -> LabelWidthCalculatorProps:
+    return LabelWidthCalculatorProps(
+        comment_types_label_width=measure_width(inputs.comment_type_labels),
+        time_label_width=measure_width(_time_candidates(long_format=inputs.table_long_format)),
+    )
+
+
 @QmlElement
 class MpvqcLabelWidthCalculatorViewModel(QObject):
     _i18n = inject.attr(InternationalizationService)
@@ -37,40 +71,48 @@ class MpvqcLabelWidthCalculatorViewModel(QObject):
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
 
-        self._comment_types_label_width = self._compute_comment_types_label_width()
-        self._time_label_width = self._compute_time_label_width()
+        types = self._comment_types_policy.displayable_comment_types
+        self._inputs = LabelWidthCalculatorInputs(
+            displayable_comment_types=types,
+            comment_type_labels=_translate_comment_types(types),
+            table_long_format=self._time_format_policy.table_long_format,
+        )
+        self._props = self._derive()
 
-        self._i18n.retranslated.connect(self._update_comment_types_label_width)
-        self._comment_types_policy.displayable_comment_types_changed.connect(self._update_comment_types_label_width)
-        self._time_format_policy.table_long_format_changed.connect(self._update_time_label_width)
+        self._i18n.retranslated.connect(self._fold_retranslated)
+        self._comment_types_policy.displayable_comment_types_changed.connect(self._fold_displayable_comment_types)
+        self._time_format_policy.table_long_format_changed.connect(self._fold_table_long_format)
+
+    def _derive(self) -> LabelWidthCalculatorProps:
+        return derive_label_width_calculator_props(self._inputs, self._width_service.calculate_width_for)
+
+    @Slot()
+    def _fold_retranslated(self) -> None:
+        self._update(self._inputs.with_types(self._inputs.displayable_comment_types))
+
+    @Slot(frozenset)
+    def _fold_displayable_comment_types(self, value: frozenset[str]) -> None:
+        self._update(self._inputs.with_types(value))
+
+    @Slot(bool)
+    def _fold_table_long_format(self, value: bool) -> None:
+        self._update(replace(self._inputs, table_long_format=value))
+
+    def _update(self, inputs: LabelWidthCalculatorInputs) -> None:
+        self._inputs = inputs
+        new, old = self._derive(), self._props
+        if new == old:
+            return
+        self._props = new
+        if new.comment_types_label_width != old.comment_types_label_width:
+            self.commentTypesLabelWidthChanged.emit(new.comment_types_label_width)
+        if new.time_label_width != old.time_label_width:
+            self.timeLabelWidthChanged.emit(new.time_label_width)
 
     @Property(int, notify=commentTypesLabelWidthChanged)
     def commentTypesLabelWidth(self) -> int:
-        return self._comment_types_label_width
+        return self._props.comment_types_label_width
 
     @Property(int, notify=timeLabelWidthChanged)
     def timeLabelWidth(self) -> int:
-        return self._time_label_width
-
-    @Slot()
-    def _update_comment_types_label_width(self) -> None:
-        value = self._compute_comment_types_label_width()
-        if value != self._comment_types_label_width:
-            self._comment_types_label_width = value
-            self.commentTypesLabelWidthChanged.emit(value)
-
-    @Slot()
-    def _update_time_label_width(self) -> None:
-        value = self._compute_time_label_width()
-        if value != self._time_label_width:
-            self._time_label_width = value
-            self.timeLabelWidthChanged.emit(value)
-
-    def _compute_comment_types_label_width(self) -> int:
-        types = self._comment_types_policy.displayable_comment_types
-        labels = (QCoreApplication.translate("CommentTypes", ct) for ct in types)
-        return self._width_service.calculate_width_for(labels)
-
-    def _compute_time_label_width(self) -> int:
-        candidates = _time_candidates(long_format=self._time_format_policy.table_long_format)
-        return self._width_service.calculate_width_for(candidates)
+        return self._props.time_label_width

--- a/mpvqc/viewmodels/views/header/window_buttons.py
+++ b/mpvqc/viewmodels/views/header/window_buttons.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from dataclasses import dataclass, replace
+
 import inject
 from PySide6.QtCore import Property, QObject, Signal, Slot
 from PySide6.QtQml import QmlElement
@@ -10,6 +12,26 @@ from mpvqc.services import PlatformService, WindowButtonPreference
 
 QML_IMPORT_NAME = "io.github.mpvqc.mpvQC.Python"
 QML_IMPORT_MAJOR_VERSION = 1
+
+
+@dataclass(frozen=True)
+class WindowButtonsInputs:
+    preference: WindowButtonPreference
+
+
+@dataclass(frozen=True)
+class WindowButtonsProps:
+    show_minimize_button: bool
+    show_maximize_button: bool
+    show_close_button: bool
+
+
+def derive_window_buttons_props(inputs: WindowButtonsInputs) -> WindowButtonsProps:
+    return WindowButtonsProps(
+        show_minimize_button=inputs.preference.minimize,
+        show_maximize_button=inputs.preference.maximize,
+        show_close_button=inputs.preference.close,
+    )
 
 
 @QmlElement
@@ -22,29 +44,36 @@ class MpvqcWindowButtonsViewModel(QObject):
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._preference = self._platform.window_button_preference
-        self._platform.window_button_preference_changed.connect(self._on_preference_changed)
+        self._inputs = WindowButtonsInputs(preference=self._platform.window_button_preference)
+        self._props = derive_window_buttons_props(self._inputs)
+
+        self._platform.window_button_preference_changed.connect(self._fold_preference)
+
+    @Slot(WindowButtonPreference)
+    def _fold_preference(self, value: WindowButtonPreference) -> None:
+        self._update(replace(self._inputs, preference=value))
+
+    def _update(self, inputs: WindowButtonsInputs) -> None:
+        self._inputs = inputs
+        new, old = derive_window_buttons_props(self._inputs), self._props
+        if new == old:
+            return
+        self._props = new
+        if new.show_minimize_button != old.show_minimize_button:
+            self.showMinimizeButtonChanged.emit(new.show_minimize_button)
+        if new.show_maximize_button != old.show_maximize_button:
+            self.showMaximizeButtonChanged.emit(new.show_maximize_button)
+        if new.show_close_button != old.show_close_button:
+            self.showCloseButtonChanged.emit(new.show_close_button)
 
     @Property(bool, notify=showMinimizeButtonChanged)
     def showMinimizeButton(self) -> bool:
-        return self._preference.minimize
+        return self._props.show_minimize_button
 
     @Property(bool, notify=showMaximizeButtonChanged)
     def showMaximizeButton(self) -> bool:
-        return self._preference.maximize
+        return self._props.show_maximize_button
 
     @Property(bool, notify=showCloseButtonChanged)
     def showCloseButton(self) -> bool:
-        return self._preference.close
-
-    @Slot(WindowButtonPreference)
-    def _on_preference_changed(self, preference: WindowButtonPreference) -> None:
-        old = self._preference
-        self._preference = preference
-
-        if old.minimize != preference.minimize:
-            self.showMinimizeButtonChanged.emit(preference.minimize)
-        if old.maximize != preference.maximize:
-            self.showMaximizeButtonChanged.emit(preference.maximize)
-        if old.close != preference.close:
-            self.showCloseButtonChanged.emit(preference.close)
+        return self._props.show_close_button

--- a/test/viewmodels/test_label_width_calculator.py
+++ b/test/viewmodels/test_label_width_calculator.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Iterable
+from typing import NamedTuple
+
 import inject
 import pytest
 from PySide6.QtCore import QObject, Signal
@@ -15,6 +18,11 @@ from mpvqc.services import (
     TimeFormatPolicyService,
 )
 from mpvqc.viewmodels import MpvqcLabelWidthCalculatorViewModel
+from mpvqc.viewmodels.utility.label_width_calculator import (
+    LabelWidthCalculatorInputs,
+    LabelWidthCalculatorProps,
+    derive_label_width_calculator_props,
+)
 
 
 class CommentTypesPolicyServiceMock(QObject):
@@ -69,60 +77,133 @@ def view_model() -> MpvqcLabelWidthCalculatorViewModel:
     return MpvqcLabelWidthCalculatorViewModel()
 
 
-def test_comment_types_width_follows_displayable_types(view_model, comment_types_policy_mock, make_spy):
-    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+@pytest.fixture
+def spy_notifies(make_spy):
+    def _spy(view_model: MpvqcLabelWidthCalculatorViewModel) -> dict:
+        return {
+            "commentTypesLabelWidth": make_spy(view_model.commentTypesLabelWidthChanged),
+            "timeLabelWidth": make_spy(view_model.timeLabelWidthChanged),
+        }
+
+    return _spy
+
+
+def emissions(spies: dict) -> dict[str, int]:
+    return {name: spy.count() for name, spy in spies.items()}
+
+
+def measure_by_length(texts: Iterable[str]) -> int:
+    return max((len(text) for text in texts), default=0)
+
+
+class DerivationCase(NamedTuple):
+    name: str
+    inputs: LabelWidthCalculatorInputs
+    expected: LabelWidthCalculatorProps
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        DerivationCase(
+            name="no comment types leave that column at zero",
+            inputs=LabelWidthCalculatorInputs(
+                displayable_comment_types=frozenset(),
+                comment_type_labels=(),
+                table_long_format=False,
+            ),
+            expected=LabelWidthCalculatorProps(comment_types_label_width=0, time_label_width=len("00:00")),
+        ),
+        DerivationCase(
+            name="the longest label sets the comment types width",
+            inputs=LabelWidthCalculatorInputs(
+                displayable_comment_types=frozenset({"i", "Spelling"}),
+                comment_type_labels=("i", "Spelling"),
+                table_long_format=False,
+            ),
+            expected=LabelWidthCalculatorProps(
+                comment_types_label_width=len("Spelling"),
+                time_label_width=len("00:00"),
+            ),
+        ),
+        DerivationCase(
+            name="the long format widens the time column",
+            inputs=LabelWidthCalculatorInputs(
+                displayable_comment_types=frozenset({"i"}),
+                comment_type_labels=("i",),
+                table_long_format=True,
+            ),
+            expected=LabelWidthCalculatorProps(
+                comment_types_label_width=len("i"),
+                time_label_width=len("00:00:00"),
+            ),
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_derivation(case: DerivationCase):
+    assert derive_label_width_calculator_props(case.inputs, measure_by_length) == case.expected
+
+
+def test_comment_types_width_follows_displayable_types(view_model, comment_types_policy_mock, spy_notifies):
+    spies = spy_notifies(view_model)
 
     comment_types_policy_mock.change_displayable_types("i")
     narrow_width = view_model.commentTypesLabelWidth
     assert narrow_width > 0
-    assert spy.count() == 1
+    assert spies["commentTypesLabelWidth"].count() == 1
 
     comment_types_policy_mock.change_displayable_types("i", "Wwwwwwwwwwwwwwwwwwww")
     wide_width = view_model.commentTypesLabelWidth
     assert wide_width > narrow_width
-    assert spy.count() == 2
-    assert spy.at(invocation=1, argument=0) == wide_width
+    assert spies["commentTypesLabelWidth"].count() == 2
+    assert spies["commentTypesLabelWidth"].at(invocation=1, argument=0) == wide_width
 
     comment_types_policy_mock.change_displayable_types("i")
     assert view_model.commentTypesLabelWidth == narrow_width
-    assert spy.count() == 3
+
+    assert emissions(spies) == {"commentTypesLabelWidth": 3, "timeLabelWidth": 0}
 
 
-def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, comment_types_policy_mock, make_spy):
+def test_comment_types_width_recomputes_on_retranslation(qt_app, view_model, comment_types_policy_mock, spy_notifies):
     # "Spelling" -> "Rechtschreibung" grows on every font engine; near-equal pairs tie on Windows.
     comment_types_policy_mock.change_displayable_types("Spelling")
-    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+    spies = spy_notifies(view_model)
     english_width = view_model.commentTypesLabelWidth
     assert english_width > 0
 
     inject.instance(InternationalizationService).retranslate(qt_app, "de-DE")
 
     assert view_model.commentTypesLabelWidth > english_width
-    assert spy.count() == 1
-    assert spy.at(invocation=0, argument=0) == view_model.commentTypesLabelWidth
+    assert emissions(spies) == {"commentTypesLabelWidth": 1, "timeLabelWidth": 0}
+    assert spies["commentTypesLabelWidth"].at(invocation=0, argument=0) == view_model.commentTypesLabelWidth
 
 
-def test_unknown_type_measures_verbatim_after_retranslation(qt_app, view_model, comment_types_policy_mock):
+def test_unknown_type_measures_verbatim_after_retranslation(
+    qt_app, view_model, comment_types_policy_mock, spy_notifies
+):
     comment_types_policy_mock.change_displayable_types("CustomTypeXyz")
+    spies = spy_notifies(view_model)
     english_width = view_model.commentTypesLabelWidth
     assert english_width > 0
 
     inject.instance(InternationalizationService).retranslate(qt_app, "de-DE")
 
     assert view_model.commentTypesLabelWidth == english_width
+    assert emissions(spies) == {"commentTypesLabelWidth": 0, "timeLabelWidth": 0}
 
 
-def test_comment_types_width_of_same_value_does_not_emit(view_model, comment_types_policy_mock, make_spy):
+def test_comment_types_width_of_same_value_does_not_emit(view_model, comment_types_policy_mock, spy_notifies):
     comment_types_policy_mock.change_displayable_types("Wwwwwwwwww")
-    spy = make_spy(view_model.commentTypesLabelWidthChanged)
+    spies = spy_notifies(view_model)
 
     comment_types_policy_mock.change_displayable_types("Wwwwwwwwww", "i")
 
-    assert spy.count() == 0
+    assert emissions(spies) == {"commentTypesLabelWidth": 0, "timeLabelWidth": 0}
 
 
-def test_time_width_flips_with_format(view_model, fake_player_service, make_spy):
-    spy = make_spy(view_model.timeLabelWidthChanged)
+def test_time_width_flips_with_format(view_model, fake_player_service, spy_notifies):
+    spies = spy_notifies(view_model)
     short_width = view_model.timeLabelWidth
     assert short_width > 0
 
@@ -130,10 +211,41 @@ def test_time_width_flips_with_format(view_model, fake_player_service, make_spy)
 
     long_width = view_model.timeLabelWidth
     assert long_width > short_width
-    assert spy.count() == 1
-    assert spy.at(invocation=0, argument=0) == long_width
+    assert spies["timeLabelWidth"].count() == 1
+    assert spies["timeLabelWidth"].at(invocation=0, argument=0) == long_width
 
     fake_player_service.update(duration=3599.0)
 
     assert view_model.timeLabelWidth == short_width
-    assert spy.count() == 2
+    assert emissions(spies) == {"commentTypesLabelWidth": 0, "timeLabelWidth": 2}
+
+
+def test_props_swap_completes_before_the_comment_types_emission(view_model, comment_types_policy_mock):
+    comment_types_policy_mock.change_displayable_types("i")
+    narrow_width = view_model.commentTypesLabelWidth
+    observed: list[tuple[int, int]] = []
+
+    view_model.commentTypesLabelWidthChanged.connect(
+        lambda _: observed.append((view_model.commentTypesLabelWidth, view_model.timeLabelWidth))
+    )
+
+    comment_types_policy_mock.change_displayable_types("Wwwwwwwwwwwwwwwwwwww")
+
+    settled = (view_model.commentTypesLabelWidth, view_model.timeLabelWidth)
+    assert observed == [settled]
+    assert settled[0] > narrow_width
+
+
+def test_props_swap_completes_before_the_time_emission(view_model, fake_player_service):
+    short_width = view_model.timeLabelWidth
+    observed: list[tuple[int, int]] = []
+
+    view_model.timeLabelWidthChanged.connect(
+        lambda _: observed.append((view_model.commentTypesLabelWidth, view_model.timeLabelWidth))
+    )
+
+    fake_player_service.update(duration=3600.0)
+
+    settled = (view_model.commentTypesLabelWidth, view_model.timeLabelWidth)
+    assert observed == [settled]
+    assert settled[1] > short_width

--- a/test/viewmodels/test_window_buttons.py
+++ b/test/viewmodels/test_window_buttons.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from collections.abc import Callable
+from typing import NamedTuple
+
+import inject
+import pytest
+
+from mpvqc.services import PlatformService, WindowButtonPreference
+from mpvqc.services.platform.backend import PlatformBackend
+from mpvqc.services.platform.embedded_player import NoEmbeddedPlayerTracker
+from mpvqc.services.platform.surface import NoSurfaceHandler
+from mpvqc.services.platform.window_configuration import NoWindowConfigurator
+from mpvqc.services.platform.window_reveal import NoWindowRevealer
+from mpvqc.services.platform.window_state import QtWindowStateHandler
+from mpvqc.viewmodels import MpvqcWindowButtonsViewModel
+from mpvqc.viewmodels.views.header.window_buttons import (
+    WindowButtonsInputs,
+    WindowButtonsProps,
+    derive_window_buttons_props,
+)
+
+ALL_BUTTONS = WindowButtonPreference(minimize=True, maximize=True, close=True)
+NO_BUTTONS = WindowButtonPreference(minimize=False, maximize=False, close=False)
+NO_MAXIMIZE = WindowButtonPreference(minimize=True, maximize=False, close=True)
+CLOSE_ONLY = WindowButtonPreference(minimize=False, maximize=False, close=True)
+
+
+class FakeWindowButtons:
+    def __init__(self, preference: WindowButtonPreference) -> None:
+        self._preference = preference
+        self._callbacks: list[Callable[[WindowButtonPreference], None]] = []
+
+    @property
+    def preference(self) -> WindowButtonPreference:
+        return self._preference
+
+    def on_preference_changed(self, callback: Callable[[WindowButtonPreference], None]) -> None:
+        self._callbacks.append(callback)
+
+    def push(self, preference: WindowButtonPreference) -> None:
+        self._preference = preference
+        for callback in self._callbacks:
+            callback(preference)
+
+
+@pytest.fixture
+def window_button_source() -> FakeWindowButtons:
+    return FakeWindowButtons(ALL_BUTTONS)
+
+
+@pytest.fixture
+def platform_service(qt_app, window_button_source) -> PlatformService:
+    backend = PlatformBackend(
+        keeps_native_frame=False,
+        draws_drop_shadow=False,
+        embeds_native_player=False,
+        sizes_own_window=False,
+        window_state=QtWindowStateHandler(),
+        surface=NoSurfaceHandler(),
+        window_configuration=NoWindowConfigurator(),
+        window_reveal=NoWindowRevealer(),
+        embedded_player=NoEmbeddedPlayerTracker(),
+        window_buttons=window_button_source,
+    )
+    return PlatformService(backend)
+
+
+@pytest.fixture(autouse=True)
+def configure_inject(common_bindings_with, platform_service):
+    def custom_bindings(binder: inject.Binder):
+        binder.bind(PlatformService, platform_service)
+
+    common_bindings_with(custom_bindings)
+
+
+@pytest.fixture
+def make_view_model():
+    def _make() -> MpvqcWindowButtonsViewModel:
+        # noinspection PyCallingNonCallable
+        return MpvqcWindowButtonsViewModel()
+
+    return _make
+
+
+@pytest.fixture
+def spy_notifies(make_spy):
+    def _spy(view_model: MpvqcWindowButtonsViewModel) -> dict:
+        return {
+            "showMinimizeButton": make_spy(view_model.showMinimizeButtonChanged),
+            "showMaximizeButton": make_spy(view_model.showMaximizeButtonChanged),
+            "showCloseButton": make_spy(view_model.showCloseButtonChanged),
+        }
+
+    return _spy
+
+
+def emissions(spies: dict) -> dict[str, int]:
+    return {name: spy.count() for name, spy in spies.items()}
+
+
+class DerivationCase(NamedTuple):
+    name: str
+    inputs: WindowButtonsInputs
+    expected: WindowButtonsProps
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        DerivationCase(
+            name="every button drawn",
+            inputs=WindowButtonsInputs(preference=ALL_BUTTONS),
+            expected=WindowButtonsProps(
+                show_minimize_button=True,
+                show_maximize_button=True,
+                show_close_button=True,
+            ),
+        ),
+        DerivationCase(
+            name="no button drawn",
+            inputs=WindowButtonsInputs(preference=NO_BUTTONS),
+            expected=WindowButtonsProps(
+                show_minimize_button=False,
+                show_maximize_button=False,
+                show_close_button=False,
+            ),
+        ),
+        DerivationCase(
+            name="maximize dropped",
+            inputs=WindowButtonsInputs(preference=NO_MAXIMIZE),
+            expected=WindowButtonsProps(
+                show_minimize_button=True,
+                show_maximize_button=False,
+                show_close_button=True,
+            ),
+        ),
+        DerivationCase(
+            name="close alone",
+            inputs=WindowButtonsInputs(preference=CLOSE_ONLY),
+            expected=WindowButtonsProps(
+                show_minimize_button=False,
+                show_maximize_button=False,
+                show_close_button=True,
+            ),
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_derivation(case: DerivationCase):
+    assert derive_window_buttons_props(case.inputs) == case.expected
+
+
+def test_initial_snapshot_reads_the_platform_at_construction(make_view_model, window_button_source):
+    window_button_source.push(CLOSE_ONLY)
+
+    view_model = make_view_model()
+
+    assert not view_model.showMinimizeButton
+    assert not view_model.showMaximizeButton
+    assert view_model.showCloseButton
+
+
+def test_dropped_maximize_emits_the_maximize_notify_alone(make_view_model, window_button_source, spy_notifies):
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    window_button_source.push(NO_MAXIMIZE)
+
+    assert emissions(spies) == {"showMinimizeButton": 0, "showMaximizeButton": 1, "showCloseButton": 0}
+    assert spies["showMaximizeButton"].at(0, 0) is False
+    assert view_model.showMinimizeButton
+    assert not view_model.showMaximizeButton
+    assert view_model.showCloseButton
+
+
+def test_losing_every_button_emits_all_three(make_view_model, window_button_source, spy_notifies):
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    window_button_source.push(NO_BUTTONS)
+
+    assert emissions(spies) == {"showMinimizeButton": 1, "showMaximizeButton": 1, "showCloseButton": 1}
+    assert spies["showMinimizeButton"].at(0, 0) is False
+    assert spies["showMaximizeButton"].at(0, 0) is False
+    assert spies["showCloseButton"].at(0, 0) is False
+
+
+def test_repeated_preference_emits_nothing(make_view_model, window_button_source, spy_notifies):
+    # WindowButtonDetector drops a repeat before it pushes, so only this fake can drive one in.
+    view_model = make_view_model()
+    spies = spy_notifies(view_model)
+
+    window_button_source.push(ALL_BUTTONS)
+
+    assert emissions(spies) == {"showMinimizeButton": 0, "showMaximizeButton": 0, "showCloseButton": 0}
+
+
+def test_props_swap_completes_before_the_first_emission(make_view_model, window_button_source):
+    view_model = make_view_model()
+    observed: list[tuple[bool, bool, bool]] = []
+
+    view_model.showMinimizeButtonChanged.connect(
+        lambda _: observed.append(
+            (view_model.showMinimizeButton, view_model.showMaximizeButton, view_model.showCloseButton)
+        )
+    )
+
+    window_button_source.push(NO_BUTTONS)
+
+    assert observed == [(False, False, False)]


### PR DESCRIPTION
Two more view models move onto the snapshot pattern from ADR 0006.

The window buttons view model already ran the cycle by hand. It read the platform preference once, kept the old struct
around and emitted per field on a diff. What it had no names for was any of it, and there was no way to check the
derivation without building the view model first. That made it the cheapest one to move, so it went first.

The label width calculator was the real smear. Both widths were computed in their own method, each reading the policies
straight out of the services, and each carried its own hand-written dedupe. `retranslated` carries no payload, so it
folds the translated labels into the snapshot the way the header view model does.

Neither changes what the user sees. The window buttons had no test at all, so all three kinds are new there. The label
width calculator kept its five wiring tests, and each of them now names the notify that stayed silent.

I also swept the other view models for anything else worth moving. Nothing qualifies. Two of them derive a value, the
window radius and the backup interval, but both derivations are inert today: the drop shadow margin is only ever 0 or
88, and the backup dialog already bounds the interval above the clamp. The rest relay a service signal straight to
their own or only forward slot calls, and a snapshot with no derivation is machinery for nothing.

What is left to check by hand is what the tests can't reach: the portal that reports the desktop's button layout, and
whether a column really fits its text after the app resizes it.

## Manual checks before merging

### 🌐 Anywhere

#### Comment table columns

- [x] Switching the language resizes the comment type column to fit the longest translated type
- [x] Loading a video an hour or longer widens the time column to fit HH:MM:SS

### 🪟 Windows

#### Window controls

- [ ] The title bar shows minimize, maximize and close, all three, right after startup

### 🐧 Linux desktop

#### Window controls

- [x] The title bar shows exactly the buttons the desktop's button layout asks for, right after startup

### 🧱 Linux tiling

#### Window controls

- [x] The title bar shows exactly the buttons the desktop's button layout asks for, right after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
