### PR TITLE
docs: tighten the agent workflow rules

### DIFF
--- a/.agents/skills/committing/SKILL.md
+++ b/.agents/skills/committing/SKILL.md
@@ -5,9 +5,22 @@ description: Use when about to commit in this repo.
 
 # Committing
 
-## Before
+## The gate
 
-The user reviews before you commit. Never run `git commit` on work they haven't seen.
+A code review comes before the commit. Run one over the change and settle every finding it reports: fix it, or say why
+it stands. Then commit.
+
+The change isn't committed yet, so the review reads the working tree against `HEAD` — staged and unstaged, new files
+included. Commits already on the branch passed their own gate.
+
+The user asking for the commit is the one way past the gate. That call is theirs. Deciding to commit yourself is not,
+however small the change.
+
+A review already run this session covers the code it read. Code that changed after it is unreviewed.
+
+The user sees the work before it lands, too: every commit is on a change they have already looked at.
+
+## The working tree
 
 `git add` the new files this change brings, and only those. `just fmt` reads the working tree, but only for files git
 already tracks, so a file that was never added is invisible and every hook passes without having read it. A file git
@@ -15,6 +28,10 @@ already tracks is read whether or not its changes are staged.
 
 Leave everything else where it is. The tree can hold new or already-staged files belonging to other work, and they
 stay out of this commit.
+
+Now run `just build-develop`. It rewrites the pyside6 project file list in `pyproject.toml` from what is on disk, and
+nothing else does: a file this change adds, removes, or renames leaves that list stale, and nothing warns. The rewrite
+belongs in this commit. It has to run before the formatter, which is what formats the list it wrote.
 
 Then run `just fmt`. It has to come back clean, not merely run. It works over the whole repo and several of its hooks
 rewrite files in place, so check what it touched: a fix that lands outside this change is someone else's, and it stays
@@ -55,13 +72,17 @@ fault, no talk of reporting anything upstream.
 
 ## After
 
-When a larger chunk of work is done, offer to push, and to write the manual checks with the `manual-checks` skill.
+A ticket this commit completes gets its closing comment now — see the `filing-tickets` skill.
 
-Work that traces to a ticket: once it is pushed, the ticket gets its closing comment — see the `filing-tickets` skill.
+When a larger chunk of work is done, offer to push, and to write the manual checks with the `manual-checks` skill.
 
 ## Done when
 
+- The change was code reviewed, or the user asked for the commit.
+- Every finding the review reported is fixed or answered.
 - The new files this change brings are added, and nothing else is.
+- `just build-develop` ran, and the file list it rewrote in `pyproject.toml` is in the commit.
 - `just fmt` came back clean, and whatever it rewrote outside this change stayed out of the commit.
 - Each doc in the table that the change reaches now describes what the code does.
 - The message claims only what was verified, in everyday words, and names no culprit.
+- A ticket this commit completes is closed.

--- a/.agents/skills/filing-tickets/SKILL.md
+++ b/.agents/skills/filing-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: filing-tickets
-description: File a ticket where it belongs, in the shape the tracker expects. Use when the user directs you to file something, to file the findings from a review report, to record a finding they rejected, or to close out a ticket whose work has landed. Fires only when directed.
+description: File a ticket where it belongs, in the shape the tracker expects. Use when the user directs you to file something, to file the findings from a review report, to record a finding they rejected, when you pick up a ticket to work on, or when a commit completes a ticket. Filing fires only when directed.
 ---
 
 # Filing tickets
@@ -141,11 +141,21 @@ gh issue close <n> --repo mpvqc/internal-tickets --reason "not planned" --commen
 - Where the same argument keeps coming back and keeps being re-argued, it graduates to an **ADR**. ADRs are numbered
   and curated, so inflation shows.
 
-## Closing a ticket
+## Working a ticket
 
-**A ticket closes when the work is done and pushed, not when it is merged.** Many tickets land on one feature branch,
-and the branch merges once the user has tested it, sometimes through a different PR, sometimes as a cherry-pick. Merge
-state belongs to the branch rather than to twelve tickets, and it already has a perfect display: the open PR list.
+The board is only worth reading while it tells the truth, so a ticket moves the moment the work does — claim, update,
+close, each at its own moment:
+
+**Claim**: picking up a ticket, set the board `Status` to `In Progress` before starting. That is the claim signal —
+branch names cannot carry it, because many tickets share one branch.
+
+**Update**: comment the ticket when the work shifts under it — a decision taken, a dead end hit, scope cut or grown.
+The bar: a reader who opens only the ticket knows where the work stands.
+
+**Close**: a ticket closes with the commit that completes it, not when it is merged. Many tickets land on one feature
+branch, and the branch merges once the user has tested it, sometimes through a different PR, sometimes as a
+cherry-pick. Merge state belongs to the branch rather than to twelve tickets, and it already has a perfect display:
+the open PR list.
 
 The closing comment records **branch and SHA**:
 
@@ -159,9 +169,6 @@ keep resolving.
 **The link runs from the internal ticket out to the public side, and only that way.** Keep internal issue references
 out of public PRs and commit messages: they are plain, permanent text that everyone can read and nobody outside can
 open.
-
-**Claiming**: an agent picking up a ticket sets the board `Status` to `In Progress` before starting. That is the claim
-signal — branch names cannot carry it, because many tickets share one branch.
 
 ## Filing a batch
 
@@ -180,3 +187,4 @@ without it you will re-file things that were filed, fixed or declined months ago
 - Every childless ticket carries exactly one readiness label, and every epic carries none.
 - Every body and every comment you wrote on the private tracker ends with the agent footer.
 - Every filed issue is on the board.
+- A ticket you picked up is `In Progress` on the board, and a ticket a commit completed is closed with branch and SHA.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -51,6 +51,16 @@ assert deliveries == [Ok(None)]
 
 The `SerialJobRunner` tests work this way throughout.
 
+### Case bags
+
+A parametrized `NamedTuple` case list reads worst when its entries mix shapes. Pick one shape for the whole bag: if
+every entry fits the line limit as a true one-liner, every entry is one; otherwise every entry is one field per
+line, with a trailing comma on the last field so `just fmt` keeps it exploded. Never leave some entries one-liners
+and others wrapped, and never let the formatter's default partial wrap stand.
+
+Spell out the field names (`InvalidCase(name=..., data=..., match=...)`) rather than passing positional arguments —
+positional calls hide which value is which once a bag has more than one or two fields.
+
 ### Real thread pools
 
 When a test needs the real executor rather than `manual_executor`, wait with
@@ -98,6 +108,7 @@ than a loaded CI machine, and the second one is a flake.
 ## Done when
 
 - Every assertion sits on the test's own stack, never inside a slot or a callback.
+- Every case bag has one shape throughout: all one-liners, or all one field per line.
 - Nothing waits on a duration.
 - `just prepare-tests` has run, if production QML, data, or translations changed.
 - The full suite passes, not only the tests you filtered to while iterating.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@
 
 ## Committing
 
-- Load the `committing` skill before committing.
+- Load the `committing` skill before committing — a code review gates the commit.
 
 ## Agent skills
 
@@ -58,8 +58,8 @@
 
 Three destinations: the public GitHub tracker for user reports and triage, a private tracker for every internal work
 item, and `.scratch/` for disposable artifacts. Nothing with a status stays local, and an agent never opens an issue on
-the public tracker. Load the `filing-tickets` skill before filing anything; `docs/agents/issue-tracker.md` decides where
-it goes.
+the public tracker. Load the `filing-tickets` skill before filing anything and when picking up a tracked ticket;
+`docs/agents/issue-tracker.md` decides where it goes.
 
 ### Triage labels
 


### PR DESCRIPTION
Two rules I kept re-deciding by hand. A commit now goes through a code review first, and rebuilding the pyside6 file
list is part of the routine, so it can't go stale without anyone noticing. Tickets move when the work moves instead of
after a push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
