### PR TITLE
test: enforce import rules for feature slices

### DIFF
--- a/.agents/skills/slice-imports/SKILL.md
+++ b/.agents/skills/slice-imports/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: slice-imports
+description: The import rules of the feature slices. Use when creating or editing Python under a feature package (mpvqc/appearance/, mpvqc/importing/) or its test tree, when moving code between roles, and when adding a new feature slice.
+---
+
+# Slice imports
+
+A feature slice imports by the lattice below. `test/test_import_rules.py` enforces every rule on this page: its
+failure message names the rule broken and the fix, and a new slice joins the rules by being listed in its `SLICES`
+table.
+
+## The lattice
+
+An import is allowed when its row lists the target's role. Every role imports freely within its own directory.
+
+Same slice:
+
+| From          | May import (same slice)                     |
+| ------------- | ------------------------------------------- |
+| `domain`      | `domain` only                               |
+| `enums`       | `domain`                                    |
+| `models`      | `domain`, `enums`, `services`               |
+| `services`    | `services`, `domain`                        |
+| `viewmodels`  | everything                                  |
+
+Another slice, and the shared layer (`mpvqc/services/`):
+
+| From          | May import (another slice)                  |
+| ------------- | ------------------------------------------- |
+| `domain`      | `domain`                                    |
+| `enums`       | `domain`                                    |
+| `models`      | `domain`, `enums`                           |
+| `services`    | `services`, `domain`                        |
+| `viewmodels`  | `services`, `domain`, `enums`               |
+
+A foreign slice's `viewmodels` and `models` are off-limits to everyone: presentation never crosses a slice.
+
+## Beyond the tables
+
+- **Role root**: each role's `__init__` is its public API. Import names from the role root (`mpvqc.services`,
+  `mpvqc.<slice>.<role>`), in production and in tests alike. A name worth reaching for is worth exporting from the
+  root.
+- **Domain floor**: a domain imports the standard library and other domains, `mpvqc.datamodels` included, and nothing
+  else. `TYPE_CHECKING` blocks count the same as runtime imports.
+- **Top level**: `mpvqc.datamodels` is shared domain. `mpvqc.jobs` is a helper for services and view models. Any
+  other top-level module needs a row in the checker's tables before a slice uses it.
+- **Composition seams**: `wiring.py` imports first-party and Qt inside its functions only, and the composition roots
+  (`mpvqc/injections.py`, `mpvqc/startup.py`) alone import a slice root. `testqml/` stands outside all of these
+  rules.
+
+## Done when
+
+`just test-python test/test_import_rules.py` passes. A red here is a design signal, not an obstacle: the missing
+concept belongs in one slice's public service, or in the shared layer (ADR 0012). Follow the message's fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,8 @@
   - Don't use getattr
 - A feature package under `mpvqc/<feature>/` bundles everything one area needs: its domain, plus role directories
   (`services/`, `models/`, `viewmodels/`, `enums/`) for what the area owns. Its root exports `bindings` and
-  `register_qml_types` from its `wiring.py`, and the roots call them. A `wiring.py` names no `mpvqc` module and no
-  `PySide6` at module level; each function imports what it needs when it runs.
-- A domain imports no Qt and no injection. QML-registered enums live in the feature's `enums/`, never in its domain.
+  `register_qml_types` from its `wiring.py`, and the roots call them.
+- QML-registered enums live in the feature's `enums/`, never in its domain.
 - A feature's domain is a `domain` module at the package root, one file or a package as the area needs. It always
   imports as `mpvqc.<feature>.domain`, and a package re-exports the flat vocabulary from its `__init__`, so call sites
   never say which one it is.
@@ -38,6 +37,7 @@
   The prefix marks exactly those classes; everything unregistered names itself for its package.
 - Inject-wired classes carry the `Service` suffix wherever they live. `mpvqc/services/` holds what no feature package
   has claimed; helpers that aren't inject-wired live at the top level of `mpvqc/`.
+- Load the `slice-imports` skill before creating or editing Python in a feature package or its test tree.
 - Load the `load-bearing-comments` skill before adding a comment or docstring, and when reviewing code.
 - Load the `writing-qml` skill before writing or editing a QML file.
 - Load the `writing-view-models` skill before writing or editing a view model that reads service state.

--- a/mpvqc/appearance/services/palette_catalog.py
+++ b/mpvqc/appearance/services/palette_catalog.py
@@ -19,7 +19,7 @@ from mpvqc.appearance.domain import (
     Palette,
     parse_color_scheme,
 )
-from mpvqc.services.resource import ResourceService
+from mpvqc.services import ResourceService
 
 
 def _dark_palette(accent_color: AccentColor, colors: dict[str, str]) -> Palette:

--- a/mpvqc/importing/services/importer.py
+++ b/mpvqc/importing/services/importer.py
@@ -23,10 +23,7 @@ from mpvqc.importing.domain import (
     make_plan,
 )
 from mpvqc.jobs import Err, Ok, SerialJobRunner
-from mpvqc.services.comments import CommentsService
-from mpvqc.services.player import PlayerService
-from mpvqc.services.resetter import ResetService
-from mpvqc.services.state import StateService
+from mpvqc.services import CommentsService, PlayerService, ResetService, StateService
 
 from .scan import scan
 from .settings import ImportSettingsService

--- a/mpvqc/importing/services/reader.py
+++ b/mpvqc/importing/services/reader.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from mpvqc.importing.domain import DocumentRejectionReason, ParsedDocument, RejectedDocument, parse_classic, parse_v1
-from mpvqc.services.reverse_translator import ReverseTranslatorService
+from mpvqc.services import ReverseTranslatorService
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/test/importing/services/test_importer.py
+++ b/test/importing/services/test_importer.py
@@ -23,10 +23,7 @@ from mpvqc.importing.domain import (
     VideoSkip,
 )
 from mpvqc.importing.services import ImporterService, ImportSettingsService
-from mpvqc.services.comments import CommentsService
-from mpvqc.services.player import PlayerService
-from mpvqc.services.resetter import ResetService
-from mpvqc.services.state import StateService
+from mpvqc.services import CommentsService, PlayerService, ResetService, StateService
 from test.importing.plans import (
     SUB_A,
     SUB_A_FROM_DOCUMENT,

--- a/test/test_import_rules.py
+++ b/test/test_import_rules.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Enforces the import rules of the feature slices: the lattice, the role roots, the domain
+floor, and wiring purity. The slice-imports skill carries the same tables for writers; a slice
+joins the rules by being listed in SLICES."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+SLICES = ("appearance", "importing")
+COMPOSITION_ROOTS = "mpvqc/injections.py and mpvqc/startup.py"
+HELPERS = ("jobs",)
+SHARED_ROLES = {"services": "services", "datamodels": "domain"}
+
+SAME_SLICE = {
+    "domain": {"domain"},
+    "enums": {"domain"},
+    "models": {"domain", "enums", "services"},
+    "services": {"services", "domain"},
+    "viewmodels": {"viewmodels", "models", "services", "enums", "domain"},
+}
+
+OTHER_SLICE = {
+    "domain": {"domain"},
+    "enums": {"domain"},
+    "models": {"domain", "enums"},
+    "services": {"services", "domain"},
+    "viewmodels": {"services", "domain", "enums"},
+}
+
+
+def _module_name(path: Path) -> tuple[str, bool]:
+    parts = path.relative_to(REPO).with_suffix("").parts
+    is_package = parts[-1] == "__init__"
+    if is_package:
+        parts = parts[:-1]
+    return ".".join(parts), is_package
+
+
+def _resolve(importer: str, importer_is_package: bool, node: ast.ImportFrom) -> str:
+    if node.level == 0:
+        return node.module or ""
+    parts = importer.split(".")
+    drop = node.level - 1 if importer_is_package else node.level
+    base = parts[: len(parts) - drop]
+    return ".".join([*base, node.module]) if node.module else ".".join(base)
+
+
+def _edges(path: Path):
+    """Yield (target module, imported names, line) for every import statement in the file."""
+    name, is_package = _module_name(path)
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name, [alias.name], node.lineno
+        elif isinstance(node, ast.ImportFrom):
+            target = _resolve(name, is_package, node)
+            names = [alias.name for alias in node.names]
+            if node.module is None:
+                for imported in names:
+                    yield f"{target}.{imported}", [imported], node.lineno
+            else:
+                yield target, names, node.lineno
+
+
+def _classify(target: str) -> tuple[str, str | None, str | None]:
+    """Return (kind, slice, role); kind is slice | shared | helper | stdlib | external | unplaced."""
+    parts = target.split(".")
+    if parts[0] != "mpvqc":
+        kind = "stdlib" if parts[0] in sys.stdlib_module_names else "external"
+        return kind, None, None
+    if len(parts) > 1 and parts[1] in SLICES:
+        return "slice", parts[1], parts[2] if len(parts) > 2 else "root"
+    if len(parts) > 1 and parts[1] in SHARED_ROLES:
+        return "shared", "shared", SHARED_ROLES[parts[1]]
+    if len(parts) > 1 and parts[1] in HELPERS:
+        return "helper", None, None
+    return "unplaced", None, None
+
+
+def _role_root(target: str, kind: str) -> str:
+    parts = target.split(".")
+    return ".".join(parts[:3] if kind == "slice" else parts[:2])
+
+
+_EXPORT_CACHE: dict[str, set[str]] = {}
+
+
+def _root_exports(root: str) -> set[str]:
+    """Names the role root's __init__ binds; an export shadows a submodule of the same name."""
+    if root not in _EXPORT_CACHE:
+        init = REPO / Path(*root.split(".")) / "__init__.py"
+        exports = set()
+        if init.exists():
+            for node in ast.parse(init.read_text(encoding="utf-8")).body:
+                if isinstance(node, (ast.Import, ast.ImportFrom)):
+                    exports.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+        _EXPORT_CACHE[root] = exports
+    return _EXPORT_CACHE[root]
+
+
+def _reaches_past_role_root(target: str, kind: str, names: list[str]) -> bool:
+    root = _role_root(target, kind)
+    if root == "mpvqc.datamodels":
+        return False
+    if target != root:
+        return True
+    root_dir = REPO / Path(*root.split("."))
+    return any(
+        name not in _root_exports(root) and ((root_dir / f"{name}.py").exists() or (root_dir / name).is_dir())
+        for name in names
+    )
+
+
+def _root_import_hint(target: str, kind: str, names: list[str]) -> str:
+    root = _role_root(target, kind)
+    if target == root:
+        return f"it pulls the submodule {', '.join(names)} through the root; import names, not modules"
+    return f"import {', '.join(names)} from {root} instead"
+
+
+def _production_files():
+    for slice_ in SLICES:
+        yield from sorted((REPO / "mpvqc" / slice_).rglob("*.py"))
+
+
+def _non_lattice_violation(where: str, role: str, kind: str, target: str) -> str | None:
+    if kind == "external" and role == "domain":
+        return (
+            f"{where}: the domain imports the third-party module {target}; "
+            f"a domain imports only the standard library and other domains"
+        )
+    if kind == "helper" and role not in ("services", "viewmodels"):
+        return f"{where}: {role} may not import {target}; the helpers under mpvqc/ are for services and view models"
+    if kind == "unplaced":
+        return (
+            f"{where}: {target} has no row in the lattice yet; "
+            f"classify it in {Path(__file__).name} before a slice uses it"
+        )
+    return None
+
+
+def _lattice_violation(where: str, slice_: str, role: str, target: str, names: list[str]) -> str | None:
+    kind, t_slice, t_role = _classify(target)
+    if t_role == "root":
+        return f"{where}: only the composition roots ({COMPOSITION_ROOTS}) import the slice root {target}"
+    same_slice = kind == "slice" and t_slice == slice_
+    if same_slice and t_role == role:
+        return None
+    allowed = SAME_SLICE[role] if same_slice else OTHER_SLICE[role]
+    if t_role not in allowed:
+        whose = (
+            "its own slice" if same_slice else f"another slice ({t_slice})" if kind == "slice" else "the shared layer"
+        )
+        return (
+            f"{where}: {role} may not import from the {t_role} of {whose}; "
+            f"{role} may import: {', '.join(sorted(allowed))}"
+        )
+    if _reaches_past_role_root(target, kind, names):
+        return (
+            f"{where}: reaches past the role root {_role_root(target, kind)}; {_root_import_hint(target, kind, names)}"
+        )
+    return None
+
+
+def check_production() -> list[str]:
+    violations = []
+    for path in _production_files():
+        name, _ = _module_name(path)
+        parts = name.split(".")
+        slice_, role = parts[1], parts[2] if len(parts) > 2 else None
+        if path.name == "wiring.py" or role is None:
+            continue
+        for target, names, line in _edges(path):
+            kind = _classify(target)[0]
+            where = f"{path.relative_to(REPO)}:{line}"
+            if kind in ("slice", "shared"):
+                violation = _lattice_violation(where, slice_, role, target, names)
+            else:
+                violation = _non_lattice_violation(where, role, kind, target)
+            if violation:
+                violations.append(violation)
+    return violations
+
+
+def check_feature_tests() -> list[str]:
+    violations = []
+    for slice_ in SLICES:
+        for path in sorted((REPO / "test" / slice_).rglob("*.py")):
+            for target, names, line in _edges(path):
+                kind, _, t_role = _classify(target)
+                if kind not in ("slice", "shared") or t_role == "root":
+                    continue
+                if _reaches_past_role_root(target, kind, names):
+                    violations.append(
+                        f"{path.relative_to(REPO)}:{line}: the test reaches past the role root "
+                        f"{_role_root(target, kind)}; {_root_import_hint(target, kind, names)}"
+                    )
+    return violations
+
+
+def check_wiring() -> list[str]:
+    violations = []
+    for slice_ in SLICES:
+        path = REPO / "mpvqc" / slice_ / "wiring.py"
+        name, is_package = _module_name(path)
+        for node in ast.parse(path.read_text(encoding="utf-8")).body:
+            if isinstance(node, ast.Import):
+                targets = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                targets = [_resolve(name, is_package, node)]
+            else:
+                continue
+            violations.extend(
+                f"{path.relative_to(REPO)}:{node.lineno}: wiring imports {target} at module level, "
+                f"which registers QML types before QGuiApplication exists; "
+                f"import it inside the function that needs it"
+                for target in targets
+                if target.split(".")[0] in ("mpvqc", "PySide6")
+            )
+    return violations
+
+
+def _fail_on(violations: list[str]) -> None:
+    if violations:
+        pytest.fail(f"{len(violations)} import rule violation(s):\n" + "\n".join(violations), pytrace=False)
+
+
+def test_slices_follow_the_lattice_and_import_role_roots_only():
+    _fail_on(check_production())
+
+
+def test_feature_tests_import_role_roots_only():
+    _fail_on(check_feature_tests())
+
+
+def test_wiring_imports_no_mpvqc_and_no_qt_at_module_level():
+    _fail_on(check_wiring())
+
+
+def test_scan_sees_the_modules_policed_today():
+    modules = {_module_name(path)[0] for path in _production_files()}
+    edges = [edge for path in _production_files() for edge in _edges(path)]
+    assert "mpvqc.importing.services.importer" in modules
+    assert "mpvqc.appearance.domain" in modules
+    assert len(edges) >= 60


### PR DESCRIPTION
Adds an architecture test that enforces the import rules of the feature packages: the role-by-role
import lattice within and across slices, role roots as the only public API in production and tests,
the domain floor (standard library and domains only), and wiring purity (no first-party or Qt
imports at module level). Every failure message names the rule broken and the fix.

Ten pre-existing imports reached past the services role root and are rewritten to import from the
root; every name was already exported there.

A new `slice-imports` skill carries the rule tables for writers, and CLAUDE.md drops the sentences
the test now enforces. No new dependencies; the checks run in about 50 ms inside the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
