### PR TITLE
fix: scale Wayland margins to native units

### DIFF
--- a/build-aux/update-wayland-symbols.sh
+++ b/build-aux/update-wayland-symbols.sh
@@ -26,10 +26,12 @@ lib_dir="$(uv run python -c 'import PySide6, pathlib; print(pathlib.Path(PySide6
 
 declare -A library=(
     [_HANDLE_SYMBOL]="Qt6Gui"
+    [_SCALE_AND_ORIGIN_SYMBOL]="Qt6Gui"
     [_SET_CUSTOM_MARGINS_SYMBOL]="Qt6WaylandClient"
 )
 declare -A signature=(
     [_HANDLE_SYMBOL]="QWindow::handle() const"
+    [_SCALE_AND_ORIGIN_SYMBOL]="QHighDpiScaling::scaleAndOrigin(QWindow const*, QHighDpiScaling::Point)"
     [_SET_CUSTOM_MARGINS_SYMBOL]="QtWaylandClient::QWaylandWindow::setCustomMargins(QMargins const&)"
 )
 

--- a/docs/adr/0003-linux-place-wayland-window-through-private-abi.md
+++ b/docs/adr/0003-linux-place-wayland-window-through-private-abi.md
@@ -7,20 +7,22 @@ instead of on what the user sees. Dropping the padding fixes the placement and c
 because there is nowhere left to paint them.
 
 Qt has the correction. `QWaylandWindow::setCustomMargins` takes the inset from the padded rectangle to the visible one.
-No public API reaches it: `QWindow` has no geometry inset, and the PySide6 wheel ships `libQt6WaylandClient` with no
-bindings for it. So the Linux window-geometry code opens the bundled Qt GUI and Wayland client libraries with ctypes,
-resolves two mangled C++ symbols, and calls the setter. `QWindow::handle()` returns a `QPlatformWindow*`, which is not
-the pointer the setter expects: a `QWaylandWindow` carries a `QObject` base ahead of its `QPlatformWindow` base, so the
-code subtracts `sizeof(QObject)`, two pointers on any build. That is as far as the claim goes: the code declares the
-visible rectangle through Qt's private margin API.
+It takes it in native surface units, while the app computes the inset in Qt logical pixels;
+`QHighDpiScaling::scaleAndOrigin` supplies the factor between the two, the layer the env scale factors set and
+compositor scaling never enters. No public API reaches either: `QWindow` has no geometry inset, and the PySide6 wheel
+ships `libQt6WaylandClient` with no bindings for it. So the Linux window-geometry code opens the bundled Qt GUI and
+Wayland client libraries with ctypes, resolves three mangled C++ symbols, and calls the setter with the scaled inset.
+`QWindow::handle()` returns a `QPlatformWindow*`, which is not the pointer the setter expects: a `QWaylandWindow`
+carries a `QObject` base ahead of its `QPlatformWindow` base, so the code subtracts `sizeof(QObject)`, two pointers on
+any build. That is as far as the claim goes: the code declares the visible rectangle through Qt's private margin API.
 
 ## Consequences
 
 - The frameless window flags, the drop shadow margin the Linux desktop backend picks, the input mask and the resize
   band all assume the declaration happens. Remove the ctypes call and they stay, but the window is placed by its
   padding.
-- The two mangled names are generated, never written. `just update-python-dependencies` runs the symbol updater, which
-  demangles the bundled libraries and rewrites both constants. Hand-editing them defeats the check. When nothing in a
+- The three mangled names are generated, never written. `just update-python-dependencies` runs the symbol updater, which
+  demangles the bundled libraries and rewrites the constants. Hand-editing them defeats the check. When nothing in a
   library demangles to the wanted signature the updater stops with an error: that is the signal that the private API
   moved and the code needs a look.
 - Failure is quiet by design. Symbols resolve once; if they don't, one warning goes to the log and the call is skipped.
@@ -29,4 +31,5 @@ visible rectangle through Qt's private margin API.
   no ctypes, with the sign reversed: a negative top margin that pushes the client area out over the caption strip. See
   ADR 0004.
 - Delete this when PySide6 exposes a public window-geometry inset on `QWindow` or ships QtWaylandClient bindings. The
-  margin call then becomes the public one and the ctypes goes; nothing else in the Linux shell changes.
+  margin call then becomes the public one and the ctypes goes, the factor conversion with it, since a public `QWindow`
+  API would take logical pixels; nothing else in the Linux shell changes.

--- a/mpvqc/services/platform/linux/surface.py
+++ b/mpvqc/services/platform/linux/surface.py
@@ -63,6 +63,7 @@ class SurfaceController(QObject):
         window.widthChanged.connect(self._apply_input_mask)
         window.heightChanged.connect(self._apply_input_mask)
         window.windowStateChanged.connect(self._sync_drop_shadow_margin)
+        window.screenChanged.connect(self._on_screen_changed)
 
         self._sync_drop_shadow_margin()
 
@@ -95,6 +96,10 @@ class SurfaceController(QObject):
     def _on_visible_changed(self, visible: bool) -> None:
         if visible:
             self._reassert_surface()
+
+    @Slot()
+    def _on_screen_changed(self) -> None:
+        self._reassert_surface()
 
     def _reassert_surface(self) -> None:
         self._apply_window_geometry()

--- a/mpvqc/services/platform/linux/window_geometry.py
+++ b/mpvqc/services/platform/linux/window_geometry.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import ctypes
 import logging
-from ctypes import Structure, byref, c_int, c_void_p
+from ctypes import Structure, byref, c_double, c_int, c_void_p
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -40,12 +40,23 @@ logger = logging.getLogger(__name__)
 _HANDLE_SYMBOL = "_ZNK7QWindow6handleEv"
 # QtWaylandClient::QWaylandWindow::setCustomMargins(QMargins const&)
 _SET_CUSTOM_MARGINS_SYMBOL = "_ZN15QtWaylandClient14QWaylandWindow16setCustomMarginsERK8QMargins"
+# QHighDpiScaling::scaleAndOrigin(QWindow const*, QHighDpiScaling::Point)
+_SCALE_AND_ORIGIN_SYMBOL = "_ZN15QHighDpiScaling14scaleAndOriginEPK7QWindowNS_5PointE"
 
 _QOBJECT_BASE_OFFSET = 2 * ctypes.sizeof(c_void_p)
 
 
 class _QMargins(Structure):
     _fields_ = (("left", c_int), ("top", c_int), ("right", c_int), ("bottom", c_int))
+
+
+class _QHighDpiPoint(Structure):
+    # QHighDpiScaling::Point; kind 0 is Invalid, which resolves against the window's screen.
+    _fields_ = (("kind", c_int), ("x", c_int), ("y", c_int))
+
+
+class _QScaleAndOrigin(Structure):
+    _fields_ = (("factor", c_double), ("origin_x", c_int), ("origin_y", c_int))
 
 
 def _qt_lib(name: str) -> str:
@@ -76,6 +87,31 @@ def _resolve_symbols() -> tuple[Callable[..., int | None], Callable[..., None]] 
     return handle, set_custom_margins
 
 
+@lru_cache(maxsize=1)
+def _resolve_scale_and_origin() -> Callable[..., _QScaleAndOrigin] | None:
+    try:
+        gui = ctypes.CDLL(_qt_lib("Qt6Gui"))
+        scale_and_origin = gui[_SCALE_AND_ORIGIN_SYMBOL]
+    except (OSError, AttributeError):
+        logger.warning("High-DPI factor symbol unavailable; content margins assume factor 1")
+        return None
+
+    scale_and_origin.argtypes = [c_void_p, _QHighDpiPoint]
+    scale_and_origin.restype = _QScaleAndOrigin
+    return scale_and_origin
+
+
+def high_dpi_factor(window: QWindow) -> float:
+    # Not devicePixelRatio: compositor scaling sits below Qt and is already
+    # native. This is only the layer the env scale factors insert.
+    scale_and_origin = _resolve_scale_and_origin()
+    if scale_and_origin is None:
+        return 1.0
+
+    qwindow_ptr = shiboken6.Shiboken.getCppPointer(window)[0]
+    return scale_and_origin(c_void_p(qwindow_ptr), _QHighDpiPoint(0, 0, 0)).factor
+
+
 def apply_wayland_content_margins(window: QWindow, margin: int) -> None:
     symbols = _resolve_symbols()
     if symbols is None:
@@ -89,5 +125,7 @@ def apply_wayland_content_margins(window: QWindow, margin: int) -> None:
         return
 
     wayland_window_ptr = platform_ptr - _QOBJECT_BASE_OFFSET
-    margins = _QMargins(margin, margin, margin, margin)
+    # int(x + 0.5) is qRound: Qt rounds halves up where round() rounds to even.
+    native_margin = int(margin * high_dpi_factor(window) + 0.5)
+    margins = _QMargins(native_margin, native_margin, native_margin, native_margin)
     set_custom_margins(c_void_p(wayland_window_ptr), byref(margins))

--- a/test/services/platform/test_surface.py
+++ b/test/services/platform/test_surface.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import pytest
 from PySide6.QtCore import Qt
 
+from mpvqc.services.platform.linux import surface
 from mpvqc.services.platform.linux.surface import SurfaceController
 from mpvqc.services.platform.surface import NoSurfaceHandler
 
@@ -135,6 +136,21 @@ def test_drop_shadow_margin_pushes(case: PushTestCase, qt_app, make_recording_wi
         window.setWindowStates(states)
 
     assert pushed == case.pushed
+
+
+def test_screen_change_reapplies_content_margins(qt_app, make_recording_window, monkeypatch):
+    applied: list[int] = []
+    monkeypatch.setattr(surface, "apply_wayland_content_margins", lambda _window, margin: applied.append(margin))
+    monkeypatch.setattr(surface.QGuiApplication, "platformName", staticmethod(lambda: "wayland"))
+
+    window = make_recording_window(NO_STATE)
+    controller = SurfaceController(drop_shadow_margin=88)
+    controller.configure_window(qt_app, window)
+    assert applied == [88]
+
+    window.screenChanged.emit(window.screen())
+
+    assert applied == [88, 88]
 
 
 def test_no_surface_handler_reads_zero_and_never_pushes(make_recording_window):

--- a/test/services/platform/test_window_geometry.py
+++ b/test/services/platform/test_window_geometry.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import multiprocessing
+import os
+import sys
+from typing import NamedTuple
+
+import pytest
+
+from mpvqc.services.platform.linux import window_geometry
+
+
+class ScaledMarginTestCase(NamedTuple):
+    name: str
+    factor: float
+    margin: int
+    expected: int
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        ScaledMarginTestCase(
+            name="factor_one_passes_margin_through",
+            factor=1.0,
+            margin=88,
+            expected=88,
+        ),
+        ScaledMarginTestCase(
+            name="fractional_factor_scales_margin",
+            factor=1.25,
+            margin=88,
+            expected=110,
+        ),
+        ScaledMarginTestCase(
+            name="fractional_result_rounds_to_nearest",
+            factor=1.1,
+            margin=88,
+            expected=97,
+        ),
+        ScaledMarginTestCase(
+            name="half_rounds_up_like_qround",
+            factor=1.25,
+            margin=10,
+            expected=13,
+        ),
+        ScaledMarginTestCase(
+            name="zero_margin_stays_zero",
+            factor=1.25,
+            margin=0,
+            expected=0,
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_content_margins_reach_native_call_in_native_units(
+    case: ScaledMarginTestCase, make_recording_window, monkeypatch
+):
+    recorded: list[tuple[int, int, int, int]] = []
+
+    def fake_handle(_window_ptr):
+        return 4096
+
+    def fake_set_custom_margins(_wayland_window_ptr, margins_ref):
+        margins = margins_ref._obj
+        recorded.append((margins.left, margins.top, margins.right, margins.bottom))
+
+    monkeypatch.setattr(window_geometry, "_resolve_symbols", lambda: (fake_handle, fake_set_custom_margins))
+    monkeypatch.setattr(window_geometry, "high_dpi_factor", lambda _window: case.factor)
+
+    window_geometry.apply_wayland_content_margins(make_recording_window(), case.margin)
+
+    expected = (case.expected, case.expected, case.expected, case.expected)
+    assert recorded == [expected]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="reads the bundled Linux Qt libraries")
+def test_high_dpi_factor_reads_one_without_env_scale_factors(qt_app, make_recording_window):
+    assert window_geometry.high_dpi_factor(make_recording_window()) == pytest.approx(1.0)
+
+
+def test_high_dpi_factor_defaults_to_one_without_symbols(make_recording_window, monkeypatch):
+    monkeypatch.setattr(window_geometry, "_resolve_scale_and_origin", lambda: None)
+
+    assert window_geometry.high_dpi_factor(make_recording_window()) == pytest.approx(1.0)
+
+
+def _read_factor_with_env_scale_factor(env_var, value, result):
+    os.environ[env_var] = value
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    from PySide6.QtGui import QGuiApplication, QWindow
+
+    from mpvqc.services.platform.linux.window_geometry import high_dpi_factor
+
+    QGuiApplication([])
+    result.put(high_dpi_factor(QWindow()))
+
+
+class EnvScaleFactorTestCase(NamedTuple):
+    name: str
+    env_var: str
+    value: str
+    expected: float
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="reads the bundled Linux Qt libraries")
+@pytest.mark.parametrize(
+    "case",
+    [
+        EnvScaleFactorTestCase(
+            name="global_scale_factor",
+            env_var="QT_SCALE_FACTOR",
+            value="1.25",
+            expected=1.25,
+        ),
+        EnvScaleFactorTestCase(
+            name="per_screen_scale_factors",
+            env_var="QT_SCREEN_SCALE_FACTORS",
+            value="1.5",
+            expected=1.5,
+        ),
+    ],
+    ids=lambda case: case.name,
+)
+def test_high_dpi_factor_follows_env_scale_factors(case: EnvScaleFactorTestCase):
+    # A spawned interpreter, because the factor freezes when QGuiApplication
+    # starts and the suite's is already running.
+    context = multiprocessing.get_context("spawn")
+    result = context.Queue()
+    process = context.Process(
+        target=_read_factor_with_env_scale_factor,
+        args=(case.env_var, case.value, result),
+    )
+    process.start()
+    factor = result.get(timeout=30)
+    process.join(timeout=30)
+
+    assert factor == pytest.approx(case.expected)


### PR DESCRIPTION
## Manual checks before merging

### 🐧 Linux desktop

#### Window placement

- [x] Started with `QT_SCALE_FACTOR=1.25` on Wayland, the window snapped left or right sits flush at the screen edge, no transparent gap
- [x] Started with `QT_SCALE_FACTOR=1.25` on Wayland, maximize collapses shadow and corners, restore brings shadow, corners and resize band back
- [x] Started with no Qt env scale factors on Wayland, the frame looks as before: drop shadow, rounded corners, flush snapping
- [x] Started with `QT_SCREEN_SCALE_FACTORS` naming two different factors on two monitors, dragging the window to the other monitor keeps the frame correct and snapping flush there
- [x] Known and accepted: a snapped window keeps its rounded corners
