### PR TITLE
fix: keep comment type menu order on Windows

### DIFF
--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditCommentTypeMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditCommentTypeMenu.qml
@@ -43,28 +43,22 @@ MpvqcPositionedMenu {
         }
     }
 
-    Instantiator {
-        model: root.isCommentTypeUnknown ? 1 : 0
-
-        delegate: MenuSeparator {}
-
-        onObjectAdded: (_index, object) => root.addItem(object)
+    MenuSeparator {
+        visible: root.isCommentTypeUnknown
+        // Menu lays out invisible items; only a zero height collapses the slot.
+        height: visible ? implicitHeight : 0
     }
 
-    Instantiator {
-        model: root.isCommentTypeUnknown ? 1 : 0
+    MenuItem {
+        readonly property string commentType: root.currentCommentType
 
-        delegate: MenuItem {
-            readonly property string commentType: root.currentCommentType
+        visible: root.isCommentTypeUnknown
+        height: visible ? implicitHeight : 0
+        text: qsTranslate("CommentTypes", commentType)
+        autoExclusive: true
+        checkable: true
+        checked: root.isCommentTypeUnknown
 
-            text: qsTranslate("CommentTypes", commentType)
-            autoExclusive: true
-            checkable: true
-            checked: true
-
-            onTriggered: root._handleTriggered(commentType)
-        }
-
-        onObjectAdded: (_index, object) => root.addItem(object)
+        onTriggered: root._handleTriggered(commentType)
     }
 }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditLoader.qml
@@ -34,7 +34,9 @@ Loader {
     }
 
     function startEditingCommentType(index: int, currentCommentType: string, coordinates: point, commentTypes: var): void {
-        asynchronous = true;
+        // Sync on purpose: async creation hits a Qt race that mis-stacks
+        // Repeater-built menu items under popupType Window (QTBUG-84125).
+        asynchronous = false;
         setSource(editCommentTypeMenu, {
             currentCommentType: currentCommentType,
             currentListIndex: index,
@@ -117,7 +119,7 @@ Loader {
             // Guard: bail out if another editor is already open or still loading, to avoid
             // killing an in-flight async load triggered by a rapid editor transition.
             Qt.callLater(() => {
-                const anotherEditorIsOpen = root.item && root.item.opened;
+                const anotherEditorIsOpen = root.item && root.item.visible;
                 const anotherEditorIsLoading = !root.item && root.active;
                 if (anotherEditorIsOpen || anotherEditorIsLoading) {
                     return;

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBoxStacking.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_SearchBoxStacking.qml
@@ -89,7 +89,7 @@ TestCase {
 
         for (let i = menu.count - 1; i >= 0; --i) {
             const entry = menu.itemAt(i); // qmllint disable
-            if (entry && entry.commentType !== currentCommentType && _covers(bounds, _globalCenterOf(entry))) {
+            if (entry && entry.visible && entry.commentType && entry.commentType !== currentCommentType && _covers(bounds, _globalCenterOf(entry))) {
                 return entry;
             }
         }


### PR DESCRIPTION
Fixes the comment type edit menu on Windows sometimes listing the types in reverse order.

## Manual checks before merging

### 🌐 Anywhere

#### Comment type menu

- [x] On Linux, the menu lists the comment types in settings order
- [x] With a known comment type, the menu ends flush after the last entry, with no blank area at the bottom
- [x] On a comment whose type is not in the settings (an imported document), the menu ends with a separator and that type as a checked entry

### 🪟 Windows

#### Comment type menu

- [x] The menu opens on every double-click of a comment type cell, across ~20 tries
- [x] Every one of those opens lists the comment types in settings order
- [x] With another editor open, double-clicking a comment type cell still opens the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
