### PR TITLE
refactor: cut the popup relay chains in the comment table

### DIFF
--- a/mpvqc/comments/viewmodels/comment_table.py
+++ b/mpvqc/comments/viewmodels/comment_table.py
@@ -47,9 +47,9 @@ class MpvqcCommentTableViewModel(QObject):
     quickSelectionRequested = Signal(int)
     selectionRequested = Signal(int)
 
-    commentEditRequested = Signal(int)
+    editCommentRequested = Signal(int)
 
-    deleteCommentRequested = Signal(int, int, str, str)  # index, time, commentType, commentText
+    deleteConfirmationRequested = Signal(int, int, str, str)  # index, time, commentType, commentText
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -71,7 +71,7 @@ class MpvqcCommentTableViewModel(QObject):
                 self.quickSelectionRequested.emit(row)
             case QuickSelectionAndEdit(row=row):
                 self.quickSelectionRequested.emit(row)
-                self.commentEditRequested.emit(row)
+                self.editCommentRequested.emit(row)
             case NoViewAction():
                 pass
             case _ as unreachable:
@@ -97,7 +97,7 @@ class MpvqcCommentTableViewModel(QObject):
     @Slot(int)
     def askToDeleteRow(self, index: int) -> None:
         comment = self._comments.comment_at(index)
-        self.deleteCommentRequested.emit(index, comment.time, comment.comment_type, comment.comment)
+        self.deleteConfirmationRequested.emit(index, comment.time, comment.comment_type, comment.comment)
 
     @Slot(int)
     def jumpToTime(self, time: int) -> None:

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
@@ -77,16 +77,17 @@ Item {
     MpvqcContextMenuLoader {
         id: _contextMenuLoader
 
+        viewModel: root.viewModel
+
         onEditCommentRequested: index => root._openCommentEditor(index)
-        onCopyCommentRequested: index => root.viewModel.copyToClipboard(index)
-        onDeleteCommentRequested: index => root.viewModel.askToDeleteRow(index)
         onDismissed: root.commentList.forceActiveFocus()
     }
 
     MpvqcDeleteConfirmationLoader {
         id: _deleteConfirmationLoader
 
-        onDeleteConfirmed: index => root.viewModel.removeRow(index)
+        viewModel: root.viewModel
+
         onClosed: root.commentList.forceActiveFocus()
     }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
@@ -12,42 +12,47 @@ Item {
     id: root
 
     required property MpvqcCommentTableViewModel viewModel
-    required property ListView listView
+    required property MpvqcCommentList commentList
 
     readonly property bool anyRowPopupOpen: _editLoader.active || _contextMenuLoader.active || _deleteConfirmationLoader.active
 
     readonly property string searchQuery: _searchBoxLoader.searchQuery
 
-    signal focusWanted
-    signal selectRequested(index: int)
-
-    function openTimeEditor(index: int, time: int, coordinates: point): void {
-        _editLoader.startEditingTime(index, time, coordinates, root.viewModel.videoDuration);
-    }
-
-    function openCommentTypeEditor(index: int, commentType: string, coordinates: point): void {
-        _editLoader.startEditingCommentType(index, commentType, coordinates, root.viewModel.commentTypes);
-    }
-
-    function openCommentEditor(index: int): void {
-        root.listView.positionViewAtIndex(index, ListView.Contain);
-        const item = root.listView.itemAtIndex(index) as MpvqcCommentListDelegate;
+    function _openCommentEditor(index: int): void {
+        root.commentList.positionViewAtIndex(index, ListView.Contain);
+        const item = root.commentList.itemAtIndex(index) as MpvqcCommentListDelegate;
         _editLoader.startEditingComment(index, item.comment, item.commentLabel);
     }
 
-    function openContextMenu(index: int, coordinates: point): void {
-        _contextMenuLoader.show(index, coordinates);
-    }
+    Connections {
+        target: root.commentList
 
-    function openSearchBox(): void {
-        _searchBoxLoader.show();
+        function onEditTimeRequested(index: int, time: int, coordinates: point): void {
+            _editLoader.startEditingTime(index, time, coordinates, root.viewModel.videoDuration);
+        }
+
+        function onEditCommentTypeRequested(index: int, commentType: string, coordinates: point): void {
+            _editLoader.startEditingCommentType(index, commentType, coordinates, root.viewModel.commentTypes);
+        }
+
+        function onEditCommentRequested(index: int): void {
+            root._openCommentEditor(index);
+        }
+
+        function onContextMenuRequested(index: int, coordinates: point): void {
+            _contextMenuLoader.show(index, coordinates);
+        }
+
+        function onSearchRequested(): void {
+            _searchBoxLoader.show();
+        }
     }
 
     Connections {
         target: root.viewModel
 
         function onCommentEditRequested(index: int): void {
-            root.openCommentEditor(index);
+            root._openCommentEditor(index);
         }
 
         function onDeleteCommentRequested(index: int, time: int, commentType: string, commentText: string): void {
@@ -71,30 +76,30 @@ Item {
         onCommentTypeEdited: (index, newCommentType) => root.viewModel.updateCommentType(index, newCommentType)
         onCommentEdited: (index, newComment) => root.viewModel.updateComment(index, newComment)
 
-        onClosed: root.focusWanted()
+        onClosed: root.commentList.forceActiveFocus()
     }
 
     MpvqcContextMenuLoader {
         id: _contextMenuLoader
 
-        onEditCommentRequested: index => root.openCommentEditor(index)
+        onEditCommentRequested: index => root._openCommentEditor(index)
         onCopyCommentRequested: index => root.viewModel.copyToClipboard(index)
         onDeleteCommentRequested: index => root.viewModel.askToDeleteRow(index)
-        onDismissed: root.focusWanted()
+        onDismissed: root.commentList.forceActiveFocus()
     }
 
     MpvqcDeleteConfirmationLoader {
         id: _deleteConfirmationLoader
 
         onDeleteConfirmed: index => root.viewModel.removeRow(index)
-        onClosed: root.focusWanted()
+        onClosed: root.commentList.forceActiveFocus()
     }
 
     MpvqcSearchBoxLoader {
         id: _searchBoxLoader
 
-        onHighlightRequested: index => root.selectRequested(index)
-        onClosed: root.focusWanted()
+        onHighlightRequested: index => root.commentList.selectRow(index)
+        onClosed: root.commentList.forceActiveFocus()
     }
 
     MpvqcWindowsMenuClickGuard {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
@@ -51,11 +51,11 @@ Item {
     Connections {
         target: root.viewModel
 
-        function onCommentEditRequested(index: int): void {
+        function onEditCommentRequested(index: int): void {
             root._openCommentEditor(index);
         }
 
-        function onDeleteCommentRequested(index: int, time: int, commentType: string, commentText: string): void {
+        function onDeleteConfirmationRequested(index: int, time: int, commentType: string, commentText: string): void {
             _deleteConfirmationLoader.requestDeletion(index, time, commentType, commentText);
         }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcCommentListOverlays.qml
@@ -28,11 +28,11 @@ Item {
         target: root.commentList
 
         function onEditTimeRequested(index: int, time: int, coordinates: point): void {
-            _editLoader.startEditingTime(index, time, coordinates, root.viewModel.videoDuration);
+            _editLoader.startEditingTime(index, time, coordinates);
         }
 
         function onEditCommentTypeRequested(index: int, commentType: string, coordinates: point): void {
-            _editLoader.startEditingCommentType(index, commentType, coordinates, root.viewModel.commentTypes);
+            _editLoader.startEditingCommentType(index, commentType, coordinates);
         }
 
         function onEditCommentRequested(index: int): void {
@@ -69,12 +69,7 @@ Item {
     MpvqcEditLoader {
         id: _editLoader
 
-        onTimeTemporaryChanged: time => root.viewModel.jumpToTime(time)
-        onTimeKept: oldTime => root.viewModel.jumpToTime(oldTime)
-
-        onTimeEdited: (index, newTime) => root.viewModel.updateTime(index, newTime)
-        onCommentTypeEdited: (index, newCommentType) => root.viewModel.updateCommentType(index, newCommentType)
-        onCommentEdited: (index, newComment) => root.viewModel.updateComment(index, newComment)
+        viewModel: root.viewModel
 
         onClosed: root.commentList.forceActiveFocus()
     }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcContextMenuLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcContextMenuLoader.qml
@@ -9,10 +9,13 @@ import QtQuick.Controls
 import QtQuick.Controls.Material as M
 
 import io.github.mpvqc.mpvQC.Components
+import io.github.mpvqc.mpvQC.Python
 import io.github.mpvqc.mpvQC.Utility
 
 Loader {
     id: root
+
+    required property MpvqcCommentTableViewModel viewModel
 
     property int currentListIndex: -1
     property point openedAt: Qt.point(0, 0)
@@ -20,8 +23,6 @@ Loader {
     property bool _actionTriggered: false
 
     signal editCommentRequested(index: int)
-    signal copyCommentRequested(index: int)
-    signal deleteCommentRequested(index: int)
     signal dismissed
 
     function show(index: int, coordinates: point): void {
@@ -81,7 +82,7 @@ Loader {
 
                 onTriggered: {
                     root._actionTriggered = true;
-                    _menu.deferToOnClose = () => root.copyCommentRequested(root.currentListIndex);
+                    _menu.deferToOnClose = () => root.viewModel.copyToClipboard(root.currentListIndex);
                 }
             }
 
@@ -97,7 +98,7 @@ Loader {
                 onTriggered: {
                     root._actionTriggered = true;
                     _menu.exit = null;
-                    _menu.deferToOnClose = () => root.deleteCommentRequested(root.currentListIndex);
+                    _menu.deferToOnClose = () => root.viewModel.askToDeleteRow(root.currentListIndex);
                 }
             }
         }

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcDeleteConfirmationLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcDeleteConfirmationLoader.qml
@@ -9,17 +9,19 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import io.github.mpvqc.mpvQC.Components
+import io.github.mpvqc.mpvQC.Python
 import io.github.mpvqc.mpvQC.Utility
 
 Loader {
     id: root
+
+    required property MpvqcCommentTableViewModel viewModel
 
     property int commentIndex: -1
     property int commentTime: 0
     property string commentType: ""
     property string commentText: ""
 
-    signal deleteConfirmed(index: int)
     signal closed
 
     function requestDeletion(index: int, time: int, commentType: string, commentText: string): void {
@@ -88,7 +90,7 @@ Loader {
             }
 
             onAccepted: {
-                root.deleteConfirmed(root.commentIndex);
+                root.viewModel.removeRow(root.commentIndex);
             }
 
             onClosed: {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditCommentPopup.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditCommentPopup.qml
@@ -5,18 +5,19 @@
 import QtQuick
 import QtQuick.Controls
 
+import io.github.mpvqc.mpvQC.Python
 import io.github.mpvqc.mpvQC.Utility
 
 Popup {
     id: root
     objectName: "editCommentPopup"
 
+    required property MpvqcCommentTableViewModel viewModel
+
     required property int currentListIndex
     required property string currentComment
 
     property bool acceptValue: true
-
-    signal commentEdited(index: int, newComment: string)
 
     width: root.parent.width
 
@@ -67,7 +68,7 @@ Popup {
         const sanitizedText = MpvqcTableUtility.sanitizeText(text);
 
         if (root.currentComment !== sanitizedText) {
-            root.commentEdited(root.currentListIndex, sanitizedText);
+            root.viewModel.updateComment(root.currentListIndex, sanitizedText);
         }
     }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditCommentTypeMenu.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditCommentTypeMenu.qml
@@ -8,27 +8,27 @@ import QtQuick
 import QtQuick.Controls
 
 import io.github.mpvqc.mpvQC.Components
+import io.github.mpvqc.mpvQC.Python
 
 MpvqcPositionedMenu {
     id: root
     objectName: "editCommentTypeMenu"
 
+    required property MpvqcCommentTableViewModel viewModel
+
     required property string currentCommentType
     required property int currentListIndex
-    required property list<string> commentTypes
 
-    readonly property bool isCommentTypeUnknown: !commentTypes.includes(currentCommentType)
-
-    signal commentTypeEdited(index: int, newCommentType: string)
+    readonly property bool isCommentTypeUnknown: !root.viewModel.commentTypes.includes(root.currentCommentType)
 
     function _handleTriggered(newCommentType: string): void {
         if (root.currentCommentType !== newCommentType) {
-            root.commentTypeEdited(root.currentListIndex, newCommentType);
+            root.viewModel.updateCommentType(root.currentListIndex, newCommentType);
         }
     }
 
     Repeater {
-        model: root.commentTypes
+        model: root.viewModel.commentTypes
 
         delegate: MenuItem {
             required property string modelData

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditLoader.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditLoader.qml
@@ -4,9 +4,14 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Templates as T
+
+import io.github.mpvqc.mpvQC.Python
 
 Loader {
     id: root
+
+    required property MpvqcCommentTableViewModel viewModel
 
     readonly property url editCommentTypeMenu: Qt.resolvedUrl("MpvqcEditCommentTypeMenu.qml")
     readonly property url editCommentPopup: Qt.resolvedUrl("MpvqcEditCommentPopup.qml")
@@ -14,33 +19,27 @@ Loader {
 
     readonly property bool isEditingCommentType: active && source === editCommentTypeMenu
 
-    signal timeTemporaryChanged(time: int)
-    signal timeKept(oldTime: int)
-
-    signal timeEdited(index: int, newTime: int)
-    signal commentTypeEdited(index: int, newCommentType: string)
-    signal commentEdited(index: int, newComment: string)
     signal closed
 
-    function startEditingTime(index: int, time: int, coordinates: point, videoDuration: real): void {
+    function startEditingTime(index: int, time: int, coordinates: point): void {
         asynchronous = true;
         setSource(editTimePopup, {
+            viewModel: root.viewModel,
             currentTime: time,
             currentListIndex: index,
-            videoDuration: videoDuration,
             openedAt: coordinates
         });
         active = true;
     }
 
-    function startEditingCommentType(index: int, currentCommentType: string, coordinates: point, commentTypes: var): void {
+    function startEditingCommentType(index: int, currentCommentType: string, coordinates: point): void {
         // Sync on purpose: async creation hits a Qt race that mis-stacks
         // Repeater-built menu items under popupType Window (QTBUG-84125).
         asynchronous = false;
         setSource(editCommentTypeMenu, {
+            viewModel: root.viewModel,
             currentCommentType: currentCommentType,
             currentListIndex: index,
-            commentTypes: commentTypes,
             position: coordinates
         });
         active = true;
@@ -50,6 +49,7 @@ Loader {
         asynchronous = false;
         setSource(editCommentPopup, {
             parent: parentItem,
+            viewModel: root.viewModel,
             currentComment: currentComment,
             currentListIndex: index,
             leftPadding: parentItem.leftPadding / 2,
@@ -88,28 +88,9 @@ Loader {
     onLoaded: item.open() // qmllint disable
 
     Connections {
-        target: root.item
-        ignoreUnknownSignals: true
-
-        function onTimeTemporaryChanged(time: int): void {
-            root.timeTemporaryChanged(time);
-        }
-
-        function onTimeEdited(index: int, newTime: int): void {
-            root.timeEdited(index, newTime);
-        }
-
-        function onTimeKept(oldTime: int): void {
-            root.timeKept(oldTime);
-        }
-
-        function onCommentTypeEdited(index: int, newCommentType: string): void {
-            root.commentTypeEdited(index, newCommentType);
-        }
-
-        function onCommentEdited(index: int, newComment: string): void {
-            root.commentEdited(index, newComment);
-        }
+        // A style implements Popup and Menu as separate files over T.Popup and T.Menu, so
+        // casting a Menu to the styled Popup yields null. T.Popup is the only shared base.
+        target: root.item as T.Popup
 
         function onClosed(): void {
             // Focus loss fires onClosed() synchronously, before any click handler on the delegate runs.

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditTimePopup.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcEditTimePopup.qml
@@ -7,15 +7,17 @@ import QtQuick.Controls
 import QtQuick.Controls.Material as M
 
 import io.github.mpvqc.mpvQC.Components
+import io.github.mpvqc.mpvQC.Python
 import io.github.mpvqc.mpvQC.Utility
 
 Popup {
     id: root
     objectName: "editTimePopup"
 
+    required property MpvqcCommentTableViewModel viewModel
+
     required property int currentTime
     required property int currentListIndex
-    required property int videoDuration
     required property point openedAt
 
     readonly property bool isOpenedInBottomRegion: {
@@ -34,10 +36,6 @@ Popup {
 
     property bool acceptValue: true
 
-    signal timeEdited(index: int, newTime: int)
-    signal timeKept(oldTime: int)
-    signal timeTemporaryChanged(newTemporaryValue: int)
-
     // Workaround for QTBUG-145174: SpinBox.increase() and SpinBox.decrease()
     // throw "TypeError: … is not a function" in Qt 6.11. Manually clamp instead.
     function decrementValue(): void {
@@ -48,6 +46,10 @@ Popup {
     function incrementValue(): void {
         _spinBox.value = Math.min(_spinBox.to, _spinBox.value + _spinBox.stepSize);
         _spinBox.valueModified();
+    }
+
+    function _restorePlaybackPosition(): void {
+        root.viewModel.jumpToTime(root.currentTime);
     }
 
     x: mirrored ? openedAt.x - width : openedAt.x
@@ -67,7 +69,7 @@ Popup {
         value: root.currentTime
 
         from: 0
-        to: root.videoDuration > 0 ? root.videoDuration * 1000 : (24 * 60 * 60 - 1) * 1000
+        to: root.viewModel.videoDuration > 0 ? root.viewModel.videoDuration * 1000 : (24 * 60 * 60 - 1) * 1000
         stepSize: 1000
 
         textFromValue: value => MpvqcTableUtility.formatTime(value)
@@ -99,7 +101,7 @@ Popup {
 
         onValueModified: {
             if (root.acceptValue) {
-                root.timeTemporaryChanged(_spinBox.value);
+                root.viewModel.jumpToTime(_spinBox.value);
             }
         }
     }
@@ -110,9 +112,9 @@ Popup {
 
     onAboutToHide: {
         if (acceptValue && root.currentTime !== _spinBox.value) {
-            root.timeEdited(root.currentListIndex, _spinBox.value);
+            root.viewModel.updateTime(root.currentListIndex, _spinBox.value);
         } else {
-            root.timeKept(root.currentTime);
+            root._restorePlaybackPosition();
         }
     }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcTableView.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/MpvqcTableView.qml
@@ -36,12 +36,6 @@ Item {
 
         rowPopupOpen: _overlays.anyRowPopupOpen
         searchQuery: _overlays.searchQuery
-
-        onEditTimeRequested: (index, time, coordinates) => _overlays.openTimeEditor(index, time, coordinates)
-        onEditCommentTypeRequested: (index, commentType, coordinates) => _overlays.openCommentTypeEditor(index, commentType, coordinates)
-        onEditCommentRequested: index => _overlays.openCommentEditor(index)
-        onContextMenuRequested: (index, coordinates) => _overlays.openContextMenu(index, coordinates)
-        onSearchRequested: _overlays.openSearchBox()
     }
 
     MpvqcCommentListOverlays {
@@ -50,10 +44,7 @@ Item {
         anchors.fill: _commentList
 
         viewModel: root.viewModel
-        listView: _commentList
-
-        onFocusWanted: _commentList.forceActiveFocus()
-        onSelectRequested: index => _commentList.selectRow(index)
+        commentList: _commentList
     }
 
     MpvqcPlaceholderView {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/TestHelpers.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/TestHelpers.qml
@@ -57,10 +57,12 @@ QtObject {
                 property int videoDuration: 10
                 property var commentTypes: ["Comment Type 1", "Comment Type 2", "Comment Type 3", "Comment Type 4", "Comment Type 5"]
                 property int lastJumpToTime: -1
+                property int pauseCount: 0
                 function jumpToTime(time) {
                     lastJumpToTime = time;
                 }
                 function pauseVideo() {
+                    pauseCount += 1;
                 }
             }
 
@@ -352,6 +354,10 @@ QtObject {
 
         function hasLastJumpedToTime(control: MpvqcTableView, expected: int): void {
             root.testCase.compare(control.viewModel.lastJumpToTime, expected);
+        }
+
+        function hasPauseCount(control: MpvqcTableView, expected: int): void {
+            root.testCase.compare(control.viewModel.pauseCount, expected);
         }
 
         function describesRow(payload: string, control: MpvqcTableView, index: int): void {

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_CommentTypes.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_CommentTypes.qml
@@ -17,8 +17,6 @@ TestCase {
     name: "MpvqcTableView::CommentTypes"
 
     readonly property alias _clickHelper: _helpers.clickHelper
-    readonly property alias _expect: _helpers.expect
-    readonly property alias _find: _helpers.find
     readonly property alias _wait: _helpers.wait
 
     readonly property int timeout: 2000
@@ -35,13 +33,16 @@ TestCase {
 
         const pt = _clickHelper.centerOfCommentTypeLabel(control, 0);
         testCase.mouseDoubleClickSequence(control, pt.x, pt.y);
-        _helpers.wait.editControlOpened(control);
+        _wait.editControlOpened(control);
 
-        const menu = _find.editCommentTypeMenu(control);
-        verify(menu.commentTypes.length >= expected.length);
+        const offered = [];
+        for (const item of _helpers.getCommentTypeItems(control)) {
+            offered.push(item.commentType);
+        }
+        verify(offered.length >= expected.length);
 
         for (const commentType of expected) {
-            verify(menu.commentTypes.includes(commentType), `Missing comment type: ${commentType}. Menu has types: ${menu.commentTypes.join(", ")} includes`);
+            verify(offered.includes(commentType), `Missing comment type: ${commentType}. Menu offers: ${offered.join(", ")}`);
         }
     }
 

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingComment.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingComment.qml
@@ -297,6 +297,24 @@ TestCase {
         _expect.isNotEditing(control);
     }
 
+    function test_importCommitsEdit(): void {
+        const editedValue = "edited";
+        _helpers.typeWord(editedValue);
+
+        _helpers.bridge.importComments([
+            {
+                "time": 99 * 1000,
+                "commentType": "Comment Type 1",
+                "comment": "Imported"
+            },
+        ]);
+
+        _wait.editControlClosed(control);
+        _expect.isNotEditing(control);
+        _expect.hasItemComment(control, 2, editedValue);
+        _expect.hasActiveFocus(control);
+    }
+
     function test_editorCanBeReopened(): void {
         keyPress(Qt.Key_Escape);
         _wait.editControlClosed(control);

--- a/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingTime.qml
+++ b/qt/qml/io/github/mpvqc/mpvQC/Views/Table/tst_MpvqcTableView_EditingTime.qml
@@ -188,6 +188,11 @@ TestCase {
         _expect.isNotInteractive(control);
     }
 
+    function test_openingPausesAndJumpsToRowTime(): void {
+        _expect.hasPauseCount(control, 1);
+        _expect.hasLastJumpedToTime(control, 3 * 1000);
+    }
+
     function test_playButtonDoesNotJumpToTime(): void {
         const timeBefore = control.viewModel.lastJumpToTime;
         const pt = _clickHelper.centerOfPlayButton(control, 2);

--- a/test/comments/viewmodels/test_comment_table.py
+++ b/test/comments/viewmodels/test_comment_table.py
@@ -141,7 +141,7 @@ def test_add_row_reaches_quick_selection_and_edit(make_view_model, fake_player_s
     fake_player_service.update(time_pos=5.0)
     quick_spy = make_spy(vm.quickSelectionRequested)
     animated_spy = make_spy(vm.selectionRequested)
-    edit_spy = make_spy(vm.commentEditRequested)
+    edit_spy = make_spy(vm.editCommentRequested)
 
     vm.addRow("Translation")
 
@@ -161,7 +161,7 @@ def test_update_comment_type_reaches_quick_selection(make_view_model, make_spy):
     )
     quick_spy = make_spy(vm.quickSelectionRequested)
     animated_spy = make_spy(vm.selectionRequested)
-    edit_spy = make_spy(vm.commentEditRequested)
+    edit_spy = make_spy(vm.editCommentRequested)
 
     vm.updateCommentType(1, "Phrasing")
 
@@ -181,7 +181,7 @@ def test_update_time_reaches_animated_selection(make_view_model, comments_servic
     )
     quick_spy = make_spy(vm.quickSelectionRequested)
     animated_spy = make_spy(vm.selectionRequested)
-    edit_spy = make_spy(vm.commentEditRequested)
+    edit_spy = make_spy(vm.editCommentRequested)
 
     vm.updateTime(0, 3000)
 
@@ -197,7 +197,7 @@ def test_remove_row_reaches_no_view_action(make_view_model, comments_service, ma
     vm = make_view_model(comments=[Comment(time=0, comment_type="Type", comment="text")])
     quick_spy = make_spy(vm.quickSelectionRequested)
     animated_spy = make_spy(vm.selectionRequested)
-    edit_spy = make_spy(vm.commentEditRequested)
+    edit_spy = make_spy(vm.editCommentRequested)
 
     vm.removeRow(0)
 


### PR DESCRIPTION
Every popup in the comment table used to hand its result back along a chain. The popup raised a signal, the loader relayed it, the overlays caught it and called the view model, and the table view sat in the middle tying the comment list and the overlays together. Adding one popup meant editing four files, and the loader's relay listened with `ignoreUnknownSignals`, so renaming a popup signal would have quietly stopped the edit from landing instead of failing loudly.

The popups now get the view model when they are created and call it themselves, the way the search box already did. The loaders are back to what a loader is for: load, open, abort, hand focus back. The overlays take the comment list and listen to it directly, so the table view only places the two items.

One relay stays on purpose. The context menu's edit action still raises a signal, because opening the editor needs the list scrolled to the row first, and that coordination belongs with the overlays.

Two signals on the view model are renamed along the way. `commentEditRequested` becomes `editCommentRequested`, the name the three QML components already use for the same event. `deleteCommentRequested` becomes `deleteConfirmationRequested`, because the view-side signal of that name runs the other way: the view asks to delete a row, the view model asks to show the confirmation.

Nothing changes for the user, apart from the time popup. It reads the video duration off the view model now instead of taking a truncated copy, so the spin box stops one step short of the end of the video less often.

## Manual checks before merging

### 🌐 Anywhere

#### Time editor

- [x] With a video loaded, double-click a time cell and scrub the spin box, the video seeks along
- [x] Close that popup with Escape, the video jumps back to where it was before the edit
- [x] Scrub to a new time and press Enter, the row shows it and the video stays there
- [x] Hold the spin box up arrow, it stops at the end of the video

#### Row editors

- [x] Double-click a comment cell, type, press Enter, the row shows the new text
- [x] Double-click a comment type cell, pick another type, the row shows it

#### Context menu

- [x] Right-click a row and pick Copy, the clipboard holds the comment
- [x] Right-click a row and pick Delete, the confirmation opens and confirming removes the row
- [x] Right-click a row and pick Edit, the comment editor opens on that row

#### New comment

- [x] Add a comment with a comment type hotkey, the new row is selected and its editor opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
