### PR TITLE
refactor: use typed descriptor for settings

### DIFF
--- a/mpvqc/comments/services/settings.py
+++ b/mpvqc/comments/services/settings.py
@@ -4,14 +4,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from PySide6.QtCore import QT_TRANSLATE_NOOP, QObject, Signal
 
-if TYPE_CHECKING:
-    from PySide6.QtCore import QSettings
+from mpvqc.services import MISSING, Setting
 
-_COMMENT_TYPES_KEY = "Common/commentTypes"
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from PySide6.QtCore import QSettings
 
 
 def default_comment_types() -> list[str]:
@@ -27,7 +29,9 @@ def default_comment_types() -> list[str]:
 
 
 # Until something writes the key this run, an untyped read hands back the ini text, never the type that was stored
-def _read_comment_types(stored: object) -> list[str]:
+def _read_comment_types(stored: object, default: Callable[[], list[str]]) -> list[str]:
+    if stored is MISSING:
+        return default()
     if isinstance(stored, list):
         return [str(comment_type) for comment_type in stored]
     if isinstance(stored, str):
@@ -41,17 +45,14 @@ class CommentsSettingsService(QObject):
 
     def __init__(self, qsettings: QSettings, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._qsettings = qsettings
+        self.qsettings = qsettings
 
-    @property
-    def comment_types(self) -> list[str]:
-        if not self._qsettings.contains(_COMMENT_TYPES_KEY):
-            return default_comment_types()
-        return _read_comment_types(self._qsettings.value(_COMMENT_TYPES_KEY))
-
-    @comment_types.setter
-    def comment_types(self, comment_types: list[str]) -> None:
-        if self.comment_types == comment_types:
-            return
-        self._qsettings.setValue(_COMMENT_TYPES_KEY, comment_types)
+    def _notify_comment_types(self, comment_types: list[str]) -> None:
         self.comment_types_changed.emit(comment_types)
+
+    comment_types: Setting[Self, list[str]] = Setting[Self, list[str]](
+        "Common/commentTypes",
+        default=default_comment_types,
+        decode=_read_comment_types,
+        notify=_notify_comment_types,
+    )

--- a/mpvqc/exporting/services/settings.py
+++ b/mpvqc/exporting/services/settings.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING, Self
 
 from PySide6.QtCore import QObject, Signal
 
-from mpvqc.services import Setting, read_bool, read_int
+from mpvqc.services import MISSING, Setting, read_bool, read_int, stored_text
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from PySide6.QtCore import QSettings
 
 _BACKUP_ENABLED_KEY = "Backup/enabled"
@@ -26,6 +28,12 @@ _WRITE_HEADER_SUBTITLES_KEY = "Export/writeHeaderSubtitles"
 
 def _default_username() -> str:
     return os.environ.get("USERNAME", os.environ.get("USER", "nickname"))
+
+
+def _read_nickname(stored: object, default: Callable[[], str]) -> str:
+    if stored is MISSING:
+        return default()
+    return stored if isinstance(stored, str) else ""
 
 
 class ExportSettingsService(QObject):
@@ -56,17 +64,12 @@ class ExportSettingsService(QObject):
         notify=_notify_backup_interval,
     )
 
-    @property
-    def nickname(self) -> str:
-        # A cleared nickname stores @Invalid, which an untyped read cannot tell apart from a missing key
-        if self.qsettings.contains(_NICKNAME_KEY):
-            stored = self.qsettings.value(_NICKNAME_KEY, type=str)
-            return stored if isinstance(stored, str) else ""
-        return _default_username()
-
-    @nickname.setter
-    def nickname(self, nickname: str | None) -> None:
-        self.qsettings.setValue(_NICKNAME_KEY, nickname)
+    nickname: Setting[Self, str] = Setting[Self, str](
+        _NICKNAME_KEY,
+        default=_default_username,
+        read=stored_text,
+        decode=_read_nickname,
+    )
 
     write_header_date: Setting[Self, bool] = Setting[Self, bool](
         _WRITE_HEADER_DATE_KEY,

--- a/mpvqc/exporting/services/settings.py
+++ b/mpvqc/exporting/services/settings.py
@@ -5,10 +5,11 @@
 from __future__ import annotations
 
 import os
-from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from PySide6.QtCore import QObject, Signal
+
+from mpvqc.services import Setting, read_bool, read_int
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
@@ -27,104 +28,72 @@ def _default_username() -> str:
     return os.environ.get("USERNAME", os.environ.get("USER", "nickname"))
 
 
-# Until something writes the key this run, an untyped read hands back the ini text, never the type that was stored
-def _read_bool(stored: object, default: bool) -> bool:
-    if isinstance(stored, bool):
-        return stored
-    if isinstance(stored, str) and stored.lower() in {"true", "false"}:
-        return stored.lower() == "true"
-    return default
-
-
-def _read_int(stored: object, default: int) -> int:
-    if isinstance(stored, bool):
-        return default
-    if isinstance(stored, int):
-        return stored
-    if isinstance(stored, str):
-        with suppress(ValueError):
-            return int(stored)
-    return default
-
-
 class ExportSettingsService(QObject):
     backup_enabled_changed = Signal(bool)
     backup_interval_changed = Signal(int)
 
     def __init__(self, qsettings: QSettings, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._qsettings = qsettings
+        self.qsettings = qsettings
 
-    @property
-    def backup_enabled(self) -> bool:
-        return _read_bool(self._qsettings.value(_BACKUP_ENABLED_KEY), default=True)
-
-    @backup_enabled.setter
-    def backup_enabled(self, enabled: bool) -> None:
-        if self.backup_enabled == enabled:
-            return
-        self._qsettings.setValue(_BACKUP_ENABLED_KEY, enabled)
+    def _notify_backup_enabled(self, enabled: bool) -> None:
         self.backup_enabled_changed.emit(enabled)
 
-    @property
-    def backup_interval(self) -> int:
-        return _read_int(self._qsettings.value(_BACKUP_INTERVAL_KEY), default=60)
-
-    @backup_interval.setter
-    def backup_interval(self, seconds: int) -> None:
-        if self.backup_interval == seconds:
-            return
-        self._qsettings.setValue(_BACKUP_INTERVAL_KEY, seconds)
+    def _notify_backup_interval(self, seconds: int) -> None:
         self.backup_interval_changed.emit(seconds)
+
+    backup_enabled: Setting[Self, bool] = Setting[Self, bool](
+        _BACKUP_ENABLED_KEY,
+        default=lambda: True,
+        decode=read_bool,
+        notify=_notify_backup_enabled,
+    )
+
+    backup_interval: Setting[Self, int] = Setting[Self, int](
+        _BACKUP_INTERVAL_KEY,
+        default=lambda: 60,
+        decode=read_int,
+        notify=_notify_backup_interval,
+    )
 
     @property
     def nickname(self) -> str:
         # A cleared nickname stores @Invalid, which an untyped read cannot tell apart from a missing key
-        if self._qsettings.contains(_NICKNAME_KEY):
-            stored = self._qsettings.value(_NICKNAME_KEY, type=str)
+        if self.qsettings.contains(_NICKNAME_KEY):
+            stored = self.qsettings.value(_NICKNAME_KEY, type=str)
             return stored if isinstance(stored, str) else ""
         return _default_username()
 
     @nickname.setter
     def nickname(self, nickname: str | None) -> None:
-        self._qsettings.setValue(_NICKNAME_KEY, nickname)
+        self.qsettings.setValue(_NICKNAME_KEY, nickname)
 
-    @property
-    def write_header_date(self) -> bool:
-        return _read_bool(self._qsettings.value(_WRITE_HEADER_DATE_KEY), default=True)
+    write_header_date: Setting[Self, bool] = Setting[Self, bool](
+        _WRITE_HEADER_DATE_KEY,
+        default=lambda: True,
+        decode=read_bool,
+    )
 
-    @write_header_date.setter
-    def write_header_date(self, write: bool) -> None:
-        self._qsettings.setValue(_WRITE_HEADER_DATE_KEY, write)
+    write_header_generator: Setting[Self, bool] = Setting[Self, bool](
+        _WRITE_HEADER_GENERATOR_KEY,
+        default=lambda: True,
+        decode=read_bool,
+    )
 
-    @property
-    def write_header_generator(self) -> bool:
-        return _read_bool(self._qsettings.value(_WRITE_HEADER_GENERATOR_KEY), default=True)
+    write_header_nickname: Setting[Self, bool] = Setting[Self, bool](
+        _WRITE_HEADER_NICKNAME_KEY,
+        default=lambda: False,
+        decode=read_bool,
+    )
 
-    @write_header_generator.setter
-    def write_header_generator(self, write: bool) -> None:
-        self._qsettings.setValue(_WRITE_HEADER_GENERATOR_KEY, write)
+    write_header_video_path: Setting[Self, bool] = Setting[Self, bool](
+        _WRITE_HEADER_VIDEO_PATH_KEY,
+        default=lambda: True,
+        decode=read_bool,
+    )
 
-    @property
-    def write_header_nickname(self) -> bool:
-        return _read_bool(self._qsettings.value(_WRITE_HEADER_NICKNAME_KEY), default=False)
-
-    @write_header_nickname.setter
-    def write_header_nickname(self, write: bool) -> None:
-        self._qsettings.setValue(_WRITE_HEADER_NICKNAME_KEY, write)
-
-    @property
-    def write_header_video_path(self) -> bool:
-        return _read_bool(self._qsettings.value(_WRITE_HEADER_VIDEO_PATH_KEY), default=True)
-
-    @write_header_video_path.setter
-    def write_header_video_path(self, write: bool) -> None:
-        self._qsettings.setValue(_WRITE_HEADER_VIDEO_PATH_KEY, write)
-
-    @property
-    def write_header_subtitles(self) -> bool:
-        return _read_bool(self._qsettings.value(_WRITE_HEADER_SUBTITLES_KEY), default=False)
-
-    @write_header_subtitles.setter
-    def write_header_subtitles(self, write: bool) -> None:
-        self._qsettings.setValue(_WRITE_HEADER_SUBTITLES_KEY, write)
+    write_header_subtitles: Setting[Self, bool] = Setting[Self, bool](
+        _WRITE_HEADER_SUBTITLES_KEY,
+        default=lambda: False,
+        decode=read_bool,
+    )

--- a/mpvqc/i18n/services/settings.py
+++ b/mpvqc/i18n/services/settings.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from PySide6.QtCore import QObject, Signal
+
+from mpvqc.services import Setting, stored_text
 
 from .languages import default_language
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-
-_LANGUAGE_KEY = "Common/language"
 
 
 class I18nSettingsService(QObject):
@@ -21,19 +21,15 @@ class I18nSettingsService(QObject):
 
     def __init__(self, qsettings: QSettings, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._qsettings = qsettings
+        self.qsettings = qsettings
 
-    @property
-    def language(self) -> str:
-        # A typed read of a missing key hands back "", never None
-        if not self._qsettings.contains(_LANGUAGE_KEY):
-            return default_language()
-        stored = self._qsettings.value(_LANGUAGE_KEY, type=str)
-        return stored if isinstance(stored, str) else default_language()
-
-    @language.setter
-    def language(self, language: str) -> None:
-        if self.language == language:
-            return
-        self._qsettings.setValue(_LANGUAGE_KEY, language)
+    def _notify_language(self, language: str) -> None:
         self.language_changed.emit(language)
+
+    language: Setting[Self, str] = Setting[Self, str](
+        "Common/language",
+        default=default_language,
+        read=stored_text,
+        decode=lambda stored, default: stored if isinstance(stored, str) else default(),
+        notify=_notify_language,
+    )

--- a/mpvqc/importing/services/settings.py
+++ b/mpvqc/importing/services/settings.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from PySide6.QtCore import QStandardPaths, QUrl
+
+from mpvqc.services import Setting, read_member
 
 from .concerns import LoadFoundVideo
 
@@ -15,11 +16,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from PySide6.QtCore import QSettings
-
-_LOAD_FOUND_VIDEO_KEY = "Import/loadFoundVideo"
-_LAST_DIRECTORY_VIDEO_KEY = "Import/lastDirectoryVideo"
-_LAST_DIRECTORY_DOCUMENTS_KEY = "Import/lastDirectoryDocuments"
-_LAST_DIRECTORY_SUBTITLES_KEY = "Import/lastDirectorySubtitles"
 
 
 def _movies_location() -> QUrl:
@@ -30,47 +26,39 @@ def _documents_location() -> QUrl:
     return QUrl.fromLocalFile(QStandardPaths.writableLocation(QStandardPaths.StandardLocation.DocumentsLocation))
 
 
+def _read_directory(stored: object, default: Callable[[], QUrl]) -> QUrl:
+    return stored if isinstance(stored, QUrl) else default()
+
+
 class ImportSettingsService:
     def __init__(self, qsettings: QSettings) -> None:
         self._qsettings = qsettings
 
     @property
-    def import_found_video(self) -> LoadFoundVideo:
-        # Reading with type=int would coerce a corrupted value to 0, which means ALWAYS
-        stored = self._qsettings.value(_LOAD_FOUND_VIDEO_KEY)
-        if isinstance(stored, str | int):
-            with suppress(ValueError):
-                return LoadFoundVideo(int(stored))
-        return LoadFoundVideo.ASK_EVERY_TIME
+    def qsettings(self) -> QSettings:
+        return self._qsettings
 
-    @import_found_video.setter
-    def import_found_video(self, setting: LoadFoundVideo) -> None:
-        self._qsettings.setValue(_LOAD_FOUND_VIDEO_KEY, setting.value)
+    import_found_video: Setting[Self, LoadFoundVideo] = Setting[Self, LoadFoundVideo](
+        "Import/loadFoundVideo",
+        default=lambda: LoadFoundVideo.ASK_EVERY_TIME,
+        decode=lambda stored, default: read_member(stored, LoadFoundVideo, default),
+        encode=lambda setting: setting.value,
+    )
 
-    @property
-    def last_directory_video(self) -> QUrl:
-        return self._stored_directory(_LAST_DIRECTORY_VIDEO_KEY, _movies_location)
+    last_directory_video: Setting[Self, QUrl] = Setting[Self, QUrl](
+        "Import/lastDirectoryVideo",
+        default=_movies_location,
+        decode=_read_directory,
+    )
 
-    @last_directory_video.setter
-    def last_directory_video(self, directory: QUrl) -> None:
-        self._qsettings.setValue(_LAST_DIRECTORY_VIDEO_KEY, directory)
+    last_directory_documents: Setting[Self, QUrl] = Setting[Self, QUrl](
+        "Import/lastDirectoryDocuments",
+        default=_documents_location,
+        decode=_read_directory,
+    )
 
-    @property
-    def last_directory_documents(self) -> QUrl:
-        return self._stored_directory(_LAST_DIRECTORY_DOCUMENTS_KEY, _documents_location)
-
-    @last_directory_documents.setter
-    def last_directory_documents(self, directory: QUrl) -> None:
-        self._qsettings.setValue(_LAST_DIRECTORY_DOCUMENTS_KEY, directory)
-
-    @property
-    def last_directory_subtitles(self) -> QUrl:
-        return self._stored_directory(_LAST_DIRECTORY_SUBTITLES_KEY, _documents_location)
-
-    @last_directory_subtitles.setter
-    def last_directory_subtitles(self, directory: QUrl) -> None:
-        self._qsettings.setValue(_LAST_DIRECTORY_SUBTITLES_KEY, directory)
-
-    def _stored_directory(self, key: str, default: Callable[[], QUrl]) -> QUrl:
-        stored = self._qsettings.value(key)
-        return stored if isinstance(stored, QUrl) else default()
+    last_directory_subtitles: Setting[Self, QUrl] = Setting[Self, QUrl](
+        "Import/lastDirectorySubtitles",
+        default=_documents_location,
+        decode=_read_directory,
+    )

--- a/mpvqc/services/__init__.py
+++ b/mpvqc/services/__init__.py
@@ -9,6 +9,10 @@ from .font_loader import FontLoaderService as FontLoaderService
 from .formatter_time import TimeFormatterService as TimeFormatterService
 from .label_width_calculator import LabelWidthCalculatorService as LabelWidthCalculatorService
 from .resource import ResourceService as ResourceService
+from .settings import Setting as Setting
+from .settings import read_bool as read_bool
+from .settings import read_int as read_int
+from .settings import read_member as read_member
 from .settings_file import SettingsFileService as SettingsFileService
 from .state import StateService as StateService
 from .version_checker import HOME_URL as HOME_URL

--- a/mpvqc/services/__init__.py
+++ b/mpvqc/services/__init__.py
@@ -9,10 +9,12 @@ from .font_loader import FontLoaderService as FontLoaderService
 from .formatter_time import TimeFormatterService as TimeFormatterService
 from .label_width_calculator import LabelWidthCalculatorService as LabelWidthCalculatorService
 from .resource import ResourceService as ResourceService
+from .settings import MISSING as MISSING
 from .settings import Setting as Setting
 from .settings import read_bool as read_bool
 from .settings import read_int as read_int
 from .settings import read_member as read_member
+from .settings import stored_text as stored_text
 from .settings_file import SettingsFileService as SettingsFileService
 from .state import StateService as StateService
 from .version_checker import HOME_URL as HOME_URL

--- a/mpvqc/services/settings.py
+++ b/mpvqc/services/settings.py
@@ -25,7 +25,7 @@ class Setting[Owner: SettingsOwner, T]:
         key: str,
         *,
         default: Callable[[], T],
-        decode: Callable[[object, T], T],
+        decode: Callable[[object, Callable[[], T]], T],
         encode: Callable[[T], object] = lambda value: value,
         notify: Callable[[Owner, T], None] | None = None,
     ) -> None:
@@ -44,7 +44,7 @@ class Setting[Owner: SettingsOwner, T]:
     def __get__(self, instance: Owner | None, owner: type[Owner] | None = None) -> Setting[Owner, T] | T:
         if instance is None:
             return self
-        return self._decode(instance.qsettings.value(self.key), self._default())
+        return self._decode(instance.qsettings.value(self.key), self._default)
 
     def __set__(self, instance: Owner, value: T) -> None:
         if self._notify is not None and self.__get__(instance) == value:
@@ -55,27 +55,27 @@ class Setting[Owner: SettingsOwner, T]:
 
 
 # A later run reads INI text, not the native value QSettings caches for its writer.
-def read_bool(stored: object, default: bool) -> bool:
+def read_bool(stored: object, default: Callable[[], bool]) -> bool:
     if isinstance(stored, bool):
         return stored
     if isinstance(stored, str) and stored.lower() in {"true", "false"}:
         return stored.lower() == "true"
-    return default
+    return default()
 
 
-def read_int(stored: object, default: int) -> int:
+def read_int(stored: object, default: Callable[[], int]) -> int:
     if isinstance(stored, bool):
-        return default
+        return default()
     if isinstance(stored, int):
         return stored
     if isinstance(stored, str):
         with suppress(ValueError):
             return int(stored)
-    return default
+    return default()
 
 
-def read_member[M: IntEnum](stored: object, of: type[M], default: M) -> M:
+def read_member[M: IntEnum](stored: object, of: type[M], default: Callable[[], M]) -> M:
     # QSettings' type=int coercion turns corrupt text into 0, which may name a valid member.
     with suppress(ValueError):
-        return of(read_int(stored, default.value))
-    return default
+        return of(read_int(stored, lambda: default().value))
+    return default()

--- a/mpvqc/services/settings.py
+++ b/mpvqc/services/settings.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from contextlib import suppress
+from enum import IntEnum
+from typing import TYPE_CHECKING, Protocol, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from PySide6.QtCore import QSettings
+
+
+class SettingsOwner(Protocol):
+    @property
+    def qsettings(self) -> QSettings: ...
+
+
+class Setting[Owner: SettingsOwner, T]:
+    def __init__(
+        self,
+        key: str,
+        *,
+        default: Callable[[], T],
+        decode: Callable[[object, T], T],
+        encode: Callable[[T], object] = lambda value: value,
+        notify: Callable[[Owner, T], None] | None = None,
+    ) -> None:
+        self.key = key
+        self._default = default
+        self._decode = decode
+        self._encode = encode
+        self._notify = notify
+
+    @overload
+    def __get__(self, instance: None, owner: type[Owner] | None = None) -> Setting[Owner, T]: ...
+
+    @overload
+    def __get__(self, instance: Owner, owner: type[Owner] | None = None) -> T: ...
+
+    def __get__(self, instance: Owner | None, owner: type[Owner] | None = None) -> Setting[Owner, T] | T:
+        if instance is None:
+            return self
+        return self._decode(instance.qsettings.value(self.key), self._default())
+
+    def __set__(self, instance: Owner, value: T) -> None:
+        if self._notify is not None and self.__get__(instance) == value:
+            return
+        instance.qsettings.setValue(self.key, self._encode(value))
+        if self._notify is not None:
+            self._notify(instance, value)
+
+
+# A later run reads INI text, not the native value QSettings caches for its writer.
+def read_bool(stored: object, default: bool) -> bool:
+    if isinstance(stored, bool):
+        return stored
+    if isinstance(stored, str) and stored.lower() in {"true", "false"}:
+        return stored.lower() == "true"
+    return default
+
+
+def read_int(stored: object, default: int) -> int:
+    if isinstance(stored, bool):
+        return default
+    if isinstance(stored, int):
+        return stored
+    if isinstance(stored, str):
+        with suppress(ValueError):
+            return int(stored)
+    return default
+
+
+def read_member[M: IntEnum](stored: object, of: type[M], default: M) -> M:
+    # QSettings' type=int coercion turns corrupt text into 0, which may name a valid member.
+    with suppress(ValueError):
+        return of(read_int(stored, default.value))
+    return default

--- a/mpvqc/services/settings.py
+++ b/mpvqc/services/settings.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
 
 
+MISSING = object()
+
+
 class SettingsOwner(Protocol):
     @property
     def qsettings(self) -> QSettings: ...
@@ -26,12 +29,14 @@ class Setting[Owner: SettingsOwner, T]:
         *,
         default: Callable[[], T],
         decode: Callable[[object, Callable[[], T]], T],
+        read: Callable[[QSettings, str], object] = lambda store, key: store.value(key),
         encode: Callable[[T], object] = lambda value: value,
         notify: Callable[[Owner, T], None] | None = None,
     ) -> None:
         self.key = key
         self._default = default
         self._decode = decode
+        self._read = read
         self._encode = encode
         self._notify = notify
 
@@ -44,7 +49,8 @@ class Setting[Owner: SettingsOwner, T]:
     def __get__(self, instance: Owner | None, owner: type[Owner] | None = None) -> Setting[Owner, T] | T:
         if instance is None:
             return self
-        return self._decode(instance.qsettings.value(self.key), self._default)
+        stored = self._read(instance.qsettings, self.key) if instance.qsettings.contains(self.key) else MISSING
+        return self._decode(stored, self._default)
 
     def __set__(self, instance: Owner, value: T) -> None:
         if self._notify is not None and self.__get__(instance) == value:
@@ -52,6 +58,10 @@ class Setting[Owner: SettingsOwner, T]:
         instance.qsettings.setValue(self.key, self._encode(value))
         if self._notify is not None:
             self._notify(instance, value)
+
+
+def stored_text(store: QSettings, key: str) -> object:
+    return store.value(key, type=str)
 
 
 # A later run reads INI text, not the native value QSettings caches for its writer.

--- a/mpvqc/shell/services/settings.py
+++ b/mpvqc/shell/services/settings.py
@@ -4,51 +4,16 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
-from enum import IntEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from PySide6.QtCore import QObject, Qt, Signal
+
+from mpvqc.services import Setting, read_bool, read_int, read_member
 
 from .vocabulary import TimeDisplayMode, WindowTitleFormat
 
 if TYPE_CHECKING:
     from PySide6.QtCore import QSettings
-
-_SHOW_PERCENTAGE_KEY = "StatusBar/statusbarPercentage"
-_TIME_DISPLAY_MODE_KEY = "StatusBar/timeFormat"
-_LAYOUT_ORIENTATION_KEY = "SplitView/layoutOrientation"
-_WINDOW_TITLE_FORMAT_KEY = "Window/titleFormat"
-
-
-# Until something writes the key this run, an untyped read hands back the ini text, never the type that was stored
-def _read_bool(stored: object, default: bool) -> bool:
-    if isinstance(stored, bool):
-        return stored
-    if isinstance(stored, str) and stored.lower() in {"true", "false"}:
-        return stored.lower() == "true"
-    return default
-
-
-def _read_int(stored: object, default: int) -> int:
-    if isinstance(stored, bool):
-        return default
-    if isinstance(stored, int):
-        return stored
-    if isinstance(stored, str):
-        with suppress(ValueError):
-            return int(stored)
-    return default
-
-
-def _read_member[M: IntEnum](stored: object, of: type[M], default: M) -> M:
-    # Reading with type=int would coerce a corrupted value to 0, which both enums name
-    if isinstance(stored, bool):
-        return default
-    if isinstance(stored, str | int):
-        with suppress(ValueError):
-            return of(int(stored))
-    return default
 
 
 class ShellSettingsService(QObject):
@@ -59,50 +24,47 @@ class ShellSettingsService(QObject):
 
     def __init__(self, qsettings: QSettings, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._qsettings = qsettings
+        self.qsettings = qsettings
 
-    @property
-    def show_percentage(self) -> bool:
-        return _read_bool(self._qsettings.value(_SHOW_PERCENTAGE_KEY), default=True)
-
-    @show_percentage.setter
-    def show_percentage(self, show: bool) -> None:
-        if self.show_percentage == show:
-            return
-        self._qsettings.setValue(_SHOW_PERCENTAGE_KEY, show)
+    def _notify_show_percentage(self, show: bool) -> None:
         self.show_percentage_changed.emit(show)
 
-    @property
-    def time_display_mode(self) -> TimeDisplayMode:
-        stored = self._qsettings.value(_TIME_DISPLAY_MODE_KEY)
-        return _read_member(stored, TimeDisplayMode, default=TimeDisplayMode.CURRENT_TOTAL_TIME)
+    def _notify_time_display_mode(self, mode: TimeDisplayMode) -> None:
+        self.time_display_mode_changed.emit(mode.value)
 
-    @time_display_mode.setter
-    def time_display_mode(self, mode: TimeDisplayMode) -> None:
-        if self.time_display_mode == mode:
-            return
-        self._qsettings.setValue(_TIME_DISPLAY_MODE_KEY, mode.value)
-        self.time_display_mode_changed.emit(mode)
-
-    @property
-    def layout_orientation(self) -> int:
-        return _read_int(self._qsettings.value(_LAYOUT_ORIENTATION_KEY), default=Qt.Orientation.Vertical.value)
-
-    @layout_orientation.setter
-    def layout_orientation(self, orientation: int) -> None:
-        if self.layout_orientation == orientation:
-            return
-        self._qsettings.setValue(_LAYOUT_ORIENTATION_KEY, orientation)
+    def _notify_layout_orientation(self, orientation: int) -> None:
         self.layout_orientation_changed.emit(orientation)
 
-    @property
-    def window_title_format(self) -> WindowTitleFormat:
-        stored = self._qsettings.value(_WINDOW_TITLE_FORMAT_KEY)
-        return _read_member(stored, WindowTitleFormat, default=WindowTitleFormat.DEFAULT)
+    def _notify_window_title_format(self, title_format: WindowTitleFormat) -> None:
+        self.window_title_format_changed.emit(title_format.value)
 
-    @window_title_format.setter
-    def window_title_format(self, title_format: WindowTitleFormat) -> None:
-        if self.window_title_format == title_format:
-            return
-        self._qsettings.setValue(_WINDOW_TITLE_FORMAT_KEY, title_format.value)
-        self.window_title_format_changed.emit(title_format)
+    # PySide's metadata scanner cannot parse generic calls in unannotated class assignments.
+    show_percentage: Setting[Self, bool] = Setting[Self, bool](
+        "StatusBar/statusbarPercentage",
+        default=lambda: True,
+        decode=read_bool,
+        notify=_notify_show_percentage,
+    )
+
+    time_display_mode: Setting[Self, TimeDisplayMode] = Setting[Self, TimeDisplayMode](
+        "StatusBar/timeFormat",
+        default=lambda: TimeDisplayMode.CURRENT_TOTAL_TIME,
+        decode=lambda stored, default: read_member(stored, TimeDisplayMode, default),
+        encode=lambda mode: mode.value,
+        notify=_notify_time_display_mode,
+    )
+
+    layout_orientation: Setting[Self, int] = Setting[Self, int](
+        "SplitView/layoutOrientation",
+        default=lambda: Qt.Orientation.Vertical.value,
+        decode=read_int,
+        notify=_notify_layout_orientation,
+    )
+
+    window_title_format: Setting[Self, WindowTitleFormat] = Setting[Self, WindowTitleFormat](
+        "Window/titleFormat",
+        default=lambda: WindowTitleFormat.DEFAULT,
+        decode=lambda stored, default: read_member(stored, WindowTitleFormat, default),
+        encode=lambda title_format: title_format.value,
+        notify=_notify_window_title_format,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,7 @@ files = [
     "mpvqc/services/formatter_time.py",
     "mpvqc/services/label_width_calculator.py",
     "mpvqc/services/resource.py",
+    "mpvqc/services/settings.py",
     "mpvqc/services/settings_file.py",
     "mpvqc/services/state.py",
     "mpvqc/services/version_checker.py",

--- a/test/appearance/services/test_settings.py
+++ b/test/appearance/services/test_settings.py
@@ -60,12 +60,18 @@ def test_set_accent_color_preference_stores_one_value_per_color_scheme(appearanc
     assert appearance_settings_service.appearance_preference.accent_color_preference_for(DARK) == AccentColor("#3f51b5")
 
 
-def test_set_accent_color_preference_to_no_preference_clears_the_stored_entry(appearance_settings_service):
+def test_set_accent_color_preference_to_no_preference_clears_the_stored_entry(
+    appearance_settings_service, settings_file, make_spy
+):
     appearance_settings_service.set_accent_color_preference(DARK, AccentColor("#3f51b5"))
+    spy = make_spy(appearance_settings_service.appearance_preference_changed)
 
+    appearance_settings_service.set_accent_color_preference(DARK, NO_PREFERENCE)
     appearance_settings_service.set_accent_color_preference(DARK, NO_PREFERENCE)
 
     assert appearance_settings_service.appearance_preference.accent_color_preference_for(DARK) == NO_PREFERENCE
+    assert not settings_file.qsettings.contains("Appearance/accentColor/dark")
+    assert spy.count() == 1
 
 
 def test_set_accent_color_preference_writes_into_the_appearance_ini_section(appearance_settings_service, ini_section):
@@ -110,7 +116,7 @@ def test_preference_write_emits_the_appearance_preference(appearance_settings_se
     assert spy.count() == 1
 
 
-def test_restore_writes_every_key_and_emits_once(appearance_settings_service, make_spy):
+def test_restore_writes_every_key_before_emitting_once(appearance_settings_service, settings_file, make_spy):
     appearance_settings_service.color_scheme_preference = DARK
     appearance_settings_service.set_accent_color_preference(LIGHT, AccentColor("#ff5722"))
     baseline = appearance_settings_service.appearance_preference
@@ -118,12 +124,26 @@ def test_restore_writes_every_key_and_emits_once(appearance_settings_service, ma
     appearance_settings_service.set_accent_color_preference(LIGHT, AccentColor("#3f51b5"))
     appearance_settings_service.set_accent_color_preference(DARK, AccentColor("#009688"))
     spy = make_spy(appearance_settings_service.appearance_preference_changed)
+    deliveries = []
+    store = settings_file.qsettings
+    appearance_settings_service.appearance_preference_changed.connect(
+        lambda preference: deliveries.append(
+            (
+                preference,
+                appearance_settings_service.appearance_preference,
+                store.value("Appearance/colorSchemePreference"),
+                store.value("Appearance/accentColor/light"),
+                store.contains("Appearance/accentColor/dark"),
+            )
+        )
+    )
 
     appearance_settings_service.restore(baseline)
 
     assert spy.count() == 1
     assert spy.at(0, 0) == baseline
     assert appearance_settings_service.appearance_preference == baseline
+    assert deliveries == [(baseline, baseline, "dark", "#ff5722", False)]
 
 
 def test_restore_of_what_is_already_stored_emits_nothing(appearance_settings_service, make_spy):

--- a/test/comments/services/test_settings.py
+++ b/test/comments/services/test_settings.py
@@ -8,6 +8,8 @@ import pytest
 
 from mpvqc.comments.services import CommentsSettingsService, default_comment_types
 
+SHIPPED_TYPES = ["Translation", "Spelling", "Punctuation", "Phrasing", "Timing", "Typeset", "Note"]
+
 
 @pytest.fixture
 def existing_settings_service(read_existing_settings) -> Callable[[str], CommentsSettingsService]:
@@ -44,14 +46,22 @@ def test_comment_types_write_into_the_common_ini_section(comments_settings_servi
     assert ini_section("Common")["commentTypes"] == "Translation, Phrasing"
 
 
+def test_a_cleared_list_stays_empty_instead_of_restoring_the_defaults(comments_settings_service, ini_section):
+    comments_settings_service.comment_types = []
+
+    assert comments_settings_service.comment_types == []
+    assert ini_section("Common")["commentTypes"] == "@Invalid()"
+
+
 @pytest.mark.parametrize(
     ("stored", "expected"),
     [
-        ("Translation, Phrasing", ["Translation", "Phrasing"]),
-        ("Translation", ["Translation"]),
-        ("@Invalid()", []),
+        pytest.param("Translation, Phrasing", ["Translation", "Phrasing"], id="several"),
+        pytest.param("Translation", ["Translation"], id="single"),
+        pytest.param("@Invalid()", [], id="emptied"),
+        pytest.param("", [""], id="empty-text"),
+        pytest.param("Custom type", ["Custom type"], id="custom"),
     ],
-    ids=["several", "single", "emptied"],
 )
 def test_comment_types_stored_by_an_earlier_run_read_on(existing_settings_service, stored, expected):
     service = existing_settings_service(f"""
@@ -60,3 +70,37 @@ def test_comment_types_stored_by_an_earlier_run_read_on(existing_settings_servic
     """)
 
     assert service.comment_types == expected
+
+
+def test_missing_comment_types_return_a_fresh_default_list_on_each_read(
+    comments_settings_service, settings_file, make_spy
+):
+    spy = make_spy(comments_settings_service.comment_types_changed)
+
+    first = comments_settings_service.comment_types
+    first.clear()
+    assert comments_settings_service.comment_types == SHIPPED_TYPES
+
+    comments_settings_service.comment_types = SHIPPED_TYPES.copy()
+    assert not settings_file.qsettings.contains("Common/commentTypes")
+    assert spy.count() == 0
+
+
+@pytest.mark.parametrize(
+    ("stored", "value"),
+    [
+        pytest.param("@Invalid()", [], id="emptied"),
+        pytest.param("Custom", ["Custom"], id="custom"),
+    ],
+)
+def test_equal_comment_types_preserve_earlier_run_encoding(read_existing_settings, make_spy, stored, value):
+    store = read_existing_settings(f"[Common]\ncommentTypes={stored}\n")
+    original = store.value("Common/commentTypes")
+    service = CommentsSettingsService(store)
+    spy = make_spy(service.comment_types_changed)
+
+    service.comment_types = value
+
+    assert store.contains("Common/commentTypes")
+    assert store.value("Common/commentTypes") == original
+    assert spy.count() == 0

--- a/test/exporting/services/test_settings.py
+++ b/test/exporting/services/test_settings.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections.abc import Callable
+from unittest.mock import call, patch
 
 import pytest
 
@@ -17,6 +18,14 @@ def existing_settings_service(read_existing_settings) -> Callable[[str], ExportS
     return read
 
 
+@pytest.fixture
+def backup_spies(export_settings_service, make_spy):
+    return (
+        make_spy(export_settings_service.backup_enabled_changed),
+        make_spy(export_settings_service.backup_interval_changed),
+    )
+
+
 def test_backup_enabled_defaults_to_on(export_settings_service):
     assert export_settings_service.backup_enabled
 
@@ -29,17 +38,6 @@ def test_backup_enabled_set_and_get(export_settings_service):
     assert export_settings_service.backup_enabled
 
 
-def test_backup_enabled_signals_a_change(export_settings_service, make_spy):
-    spy = make_spy(export_settings_service.backup_enabled_changed)
-
-    export_settings_service.backup_enabled = False
-    assert spy.count() == 1
-    assert spy.at(0, 0) is False
-
-    export_settings_service.backup_enabled = False
-    assert spy.count() == 1
-
-
 def test_backup_interval_defaults_to_one_minute(export_settings_service):
     assert export_settings_service.backup_interval == 60
 
@@ -49,21 +47,38 @@ def test_backup_interval_set_and_get(export_settings_service):
     assert export_settings_service.backup_interval == 120
 
 
-def test_backup_interval_signals_a_change(export_settings_service, make_spy):
-    spy = make_spy(export_settings_service.backup_interval_changed)
+def test_each_backup_change_is_stored_before_its_one_signal(export_settings_service, settings_file):
+    service = export_settings_service
+    store = settings_file.qsettings
+    deliveries: list[tuple[str, object, object, object]] = []
+    service.backup_enabled_changed.connect(
+        lambda payload: deliveries.append(("enabled", payload, store.value("Backup/enabled"), service.backup_enabled))
+    )
+    service.backup_interval_changed.connect(
+        lambda payload: deliveries.append(
+            ("interval", payload, store.value("Backup/interval"), service.backup_interval)
+        )
+    )
 
-    export_settings_service.backup_interval = 90
-    assert spy.count() == 1
-    assert spy.at(0, 0) == 90
+    for _ in range(2):
+        service.backup_enabled = False
+        service.backup_interval = 90
 
-    export_settings_service.backup_interval = 90
-    assert spy.count() == 1
+    assert deliveries == [
+        ("enabled", False, False, False),
+        ("interval", 90, 90, 90),
+    ]
+    assert [type(payload) for _, payload, _, _ in deliveries] == [bool, int]
 
 
 @pytest.mark.parametrize(
     "stored",
-    [42, "banana", "", ["a", "b"]],
-    ids=["number", "text", "empty", "comma-separated"],
+    [
+        pytest.param(42, id="number"),
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param(["a", "b"], id="comma-separated"),
+    ],
 )
 def test_unreadable_backup_enabled_falls_back_to_on(export_settings_service, settings_file, stored):
     settings_file.qsettings.setValue("Backup/enabled", stored)
@@ -73,13 +88,20 @@ def test_unreadable_backup_enabled_falls_back_to_on(export_settings_service, set
 
 @pytest.mark.parametrize(
     "stored",
-    ["banana", "", ["a", "b"], 4.5],
-    ids=["text", "empty", "comma-separated", "fractional"],
+    [
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param(["a", "b"], id="comma-separated"),
+        pytest.param(4.5, id="fractional"),
+        pytest.param(True, id="true"),
+        pytest.param(False, id="false"),
+    ],
 )
 def test_unreadable_backup_interval_falls_back_to_one_minute(export_settings_service, settings_file, stored):
     settings_file.qsettings.setValue("Backup/interval", stored)
 
     assert export_settings_service.backup_interval == 60
+    assert type(export_settings_service.backup_interval) is int
 
 
 def test_nickname_defaults_to_the_os_username(export_settings_service, monkeypatch):
@@ -142,8 +164,54 @@ def test_write_header_subtitles_set_and_get(export_settings_service):
     assert export_settings_service.write_header_subtitles
 
 
+@pytest.mark.parametrize(
+    "storage",
+    [
+        "missing",
+        "malformed",
+        "text-defaults",
+    ],
+)
+def test_header_defaults_are_written_unconditionally_without_signals(
+    export_settings_service, settings_file, ini_section, backup_spies, storage
+):
+    qsettings = settings_file.qsettings
+    expected = {
+        "writeHeaderDate": "true",
+        "writeHeaderGenerator": "true",
+        "writeHeaderNickname": "false",
+        "writeHeaderVideoPath": "true",
+        "writeHeaderSubtitles": "false",
+    }
+    if storage != "missing":
+        for key, value in expected.items():
+            qsettings.setValue(f"Export/{key}", "banana" if storage == "malformed" else value)
+
+    with patch.object(qsettings, "setValue", wraps=qsettings.setValue) as writes:
+        for _ in range(2):
+            export_settings_service.write_header_date = True
+            export_settings_service.write_header_generator = True
+            export_settings_service.write_header_nickname = False
+            export_settings_service.write_header_video_path = True
+            export_settings_service.write_header_subtitles = False
+
+    assert (
+        writes.call_args_list
+        == [
+            call("Export/writeHeaderDate", True),
+            call("Export/writeHeaderGenerator", True),
+            call("Export/writeHeaderNickname", False),
+            call("Export/writeHeaderVideoPath", True),
+            call("Export/writeHeaderSubtitles", False),
+        ]
+        * 2
+    )
+    assert dict(ini_section("Export")) == expected
+    assert [spy.count() for spy in backup_spies] == [0, 0]
+
+
 def test_every_write_lands_under_its_stored_key_in_the_backup_and_export_ini_sections(
-    export_settings_service, ini_section
+    export_settings_service, ini_section, backup_spies
 ):
     export_settings_service.backup_enabled = False
     export_settings_service.backup_interval = 90
@@ -165,6 +233,7 @@ def test_every_write_lands_under_its_stored_key_in_the_backup_and_export_ini_sec
     assert export["writeHeaderNickname"] == "true"
     assert export["writeHeaderVideoPath"] == "false"
     assert export["writeHeaderSubtitles"] == "true"
+    assert [spy.count() for spy in backup_spies] == [1, 1]
 
 
 def test_a_settings_file_from_an_earlier_run_reads_back_unchanged(existing_settings_service):
@@ -196,8 +265,38 @@ def test_a_settings_file_from_an_earlier_run_reads_back_unchanged(existing_setti
 
 @pytest.mark.parametrize(
     "stored",
-    ["banana", "", "2", "1.0"],
-    ids=["text", "empty", "number", "fractional"],
+    [
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param("1", id="number"),
+        pytest.param("@Invalid()", id="invalid"),
+    ],
+)
+def test_an_earlier_run_with_unreadable_headers_keeps_defaults(existing_settings_service, stored):
+    service = existing_settings_service(f"""
+        [Export]
+        writeHeaderDate={stored}
+        writeHeaderGenerator={stored}
+        writeHeaderNickname={stored}
+        writeHeaderVideoPath={stored}
+        writeHeaderSubtitles={stored}
+    """)
+
+    assert service.write_header_date is True
+    assert service.write_header_generator is True
+    assert service.write_header_nickname is False
+    assert service.write_header_video_path is True
+    assert service.write_header_subtitles is False
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param("2", id="number"),
+        pytest.param("1.0", id="fractional"),
+    ],
 )
 def test_an_earlier_run_storing_an_unreadable_backup_enabled_falls_back_to_on(existing_settings_service, stored):
     assert existing_settings_service(f"[Backup]\nenabled={stored}\n").backup_enabled
@@ -205,8 +304,12 @@ def test_an_earlier_run_storing_an_unreadable_backup_enabled_falls_back_to_on(ex
 
 @pytest.mark.parametrize(
     "stored",
-    ["banana", "", "true", "4.5"],
-    ids=["text", "empty", "boolean", "fractional"],
+    [
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param("true", id="boolean"),
+        pytest.param("4.5", id="fractional"),
+    ],
 )
 def test_an_earlier_run_storing_an_unreadable_backup_interval_falls_back_to_one_minute(
     existing_settings_service, stored

--- a/test/exporting/services/test_settings.py
+++ b/test/exporting/services/test_settings.py
@@ -104,9 +104,13 @@ def test_unreadable_backup_interval_falls_back_to_one_minute(export_settings_ser
     assert type(export_settings_service.backup_interval) is int
 
 
-def test_nickname_defaults_to_the_os_username(export_settings_service, monkeypatch):
+def test_nickname_defaults_to_the_current_os_username(export_settings_service, settings_file, monkeypatch):
     monkeypatch.setenv("USERNAME", "os-user")
     assert export_settings_service.nickname == "os-user"
+
+    monkeypatch.setenv("USERNAME", "new-user")
+    assert export_settings_service.nickname == "new-user"
+    assert not settings_file.qsettings.contains("Export/nickname")
 
 
 def test_nickname_set_and_get(export_settings_service):
@@ -114,9 +118,29 @@ def test_nickname_set_and_get(export_settings_service):
     assert export_settings_service.nickname == "lorem"
 
 
-def test_a_nickname_cleared_to_none_reads_back_as_empty(export_settings_service):
-    export_settings_service.nickname = None
+def test_a_cleared_nickname_stays_empty(export_settings_service, ini_section, monkeypatch):
+    monkeypatch.setenv("USERNAME", "os-user")
+    export_settings_service.nickname = "previous-user"
+    export_settings_service.nickname = ""
+
+    assert isinstance(export_settings_service.nickname, str)
     assert not export_settings_service.nickname
+    assert not ini_section("Export")["nickname"]
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("@Invalid()", id="invalid"),
+    ],
+)
+def test_an_earlier_run_with_a_cleared_nickname_stays_empty(existing_settings_service, monkeypatch, encoded):
+    monkeypatch.setenv("USERNAME", "os-user")
+
+    nickname = existing_settings_service(f"[Export]\nnickname={encoded}\n").nickname
+    assert isinstance(nickname, str)
+    assert not nickname
 
 
 def test_write_header_date_defaults_to_on(export_settings_service):

--- a/test/i18n/services/test_settings.py
+++ b/test/i18n/services/test_settings.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import pytest
+from PySide6.QtCore import QLocale
+
 from mpvqc.i18n.services import I18nSettingsService, default_language
 
 
@@ -42,3 +45,51 @@ def test_language_write_emits_the_language_once(i18n_settings_service, make_spy)
 
     i18n_settings_service.language = "he-IL"
     assert spy.count() == 1
+
+
+def test_missing_language_uses_current_system_language_only_when_needed(settings_file, monkeypatch, make_spy):
+    calls = []
+    locale = "de_DE"
+
+    def system_locale():
+        calls.append(locale)
+        return QLocale(locale)
+
+    monkeypatch.setattr(QLocale, "system", system_locale)
+    service = I18nSettingsService(settings_file.qsettings)
+    spy = make_spy(service.language_changed)
+    assert calls == []
+    assert service.language == "de-DE"
+    locale = "he_IL"
+    assert service.language == "he-IL"
+    service.language = "he-IL"
+    assert calls == ["de_DE", "he_IL", "he_IL"]
+    assert not settings_file.qsettings.contains("Common/language")
+    assert spy.count() == 0
+
+    settings_file.qsettings.setValue("Common/language", "")
+    assert (service.language, calls) == ("", ["de_DE", "he_IL", "he_IL"])
+    settings_file.qsettings.remove("Common/language")
+    assert service.language == "he-IL"
+    assert calls == ["de_DE", "he_IL", "he_IL", "he_IL"]
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("@Invalid()", id="invalid"),
+    ],
+)
+def test_a_present_empty_language_stays_empty_without_rewriting(read_existing_settings, make_spy, stored):
+    store = read_existing_settings(f"[Common]\nlanguage={stored}\n")
+    original = store.value("Common/language")
+    service = I18nSettingsService(store)
+    spy = make_spy(service.language_changed)
+
+    assert not service.language
+    service.language = ""
+
+    assert store.contains("Common/language")
+    assert store.value("Common/language") == original
+    assert spy.count() == 0

--- a/test/importing/services/test_settings.py
+++ b/test/importing/services/test_settings.py
@@ -2,8 +2,14 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import json
+import sys
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import call, patch
+
 import pytest
-from PySide6.QtCore import QSettings, QStandardPaths, QUrl
+from PySide6.QtCore import QObject, QProcess, QSettings, QStandardPaths, QUrl
 
 from mpvqc.importing.services import ImportSettingsService, LoadFoundVideo
 
@@ -30,14 +36,45 @@ def test_import_found_video_set_and_get(import_settings_service, setting):
 
 
 @pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (0, LoadFoundVideo.ALWAYS),
+        (1, LoadFoundVideo.ASK_EVERY_TIME),
+        (2, LoadFoundVideo.NEVER),
+        ("0", LoadFoundVideo.ALWAYS),
+        ("1", LoadFoundVideo.ASK_EVERY_TIME),
+        ("2", LoadFoundVideo.NEVER),
+        (" +2 ", LoadFoundVideo.NEVER),
+    ],
+)
+def test_native_and_text_members_read_without_rewriting(import_settings_service, settings_file, stored, expected):
+    settings_file.qsettings.setValue("Import/loadFoundVideo", stored)
+
+    assert import_settings_service.import_found_video is expected
+    assert settings_file.qsettings.value("Import/loadFoundVideo") == stored
+
+
+@pytest.mark.parametrize(
     "stored",
-    [42, -1, "banana", "", ["a", "b"]],
-    ids=["out-of-range", "negative", "text", "empty", "comma-separated"],
+    [
+        pytest.param(42, id="out-of-range"),
+        pytest.param("42", id="text-out-of-range"),
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param(["a", "b"], id="comma-separated"),
+        pytest.param(True, id="native-bool"),
+        pytest.param("true", id="text-bool"),
+        pytest.param(0.0, id="native-float"),
+        pytest.param("0.0", id="text-float"),
+        pytest.param(None, id="none"),
+    ],
 )
 def test_unreadable_import_found_video_falls_back_to_ask_every_time(import_settings_service, settings_file, stored):
     settings_file.qsettings.setValue("Import/loadFoundVideo", stored)
 
-    assert import_settings_service.import_found_video == LoadFoundVideo.ASK_EVERY_TIME
+    assert import_settings_service.import_found_video is LoadFoundVideo.ASK_EVERY_TIME
+    assert settings_file.qsettings.contains("Import/loadFoundVideo")
+    assert settings_file.qsettings.value("Import/loadFoundVideo") == stored
 
 
 def test_last_directory_video_defaults_to_the_movies_location(import_settings_service):
@@ -78,30 +115,139 @@ def test_every_write_lands_under_its_stored_key_in_the_import_ini_section(import
 
     section = ini_section("Import")
     assert section["loadFoundVideo"] == "2"
-    # QSettings serializes a QUrl into an opaque variant, so only the key name is readable for the directories
-    assert "lastDirectoryVideo" in section
-    assert "lastDirectoryDocuments" in section
-    assert "lastDirectorySubtitles" in section
+    assert section["lastDirectoryVideo"].startswith("@Variant(")
+    assert section["lastDirectoryDocuments"].startswith("@Variant(")
+    assert section["lastDirectorySubtitles"].startswith("@Variant(")
 
 
-def test_a_settings_file_from_an_earlier_run_reads_back_unchanged(settings_file, tmp_path):
-    settings_file.qsettings.setValue("Import/loadFoundVideo", 0)
-    settings_file.qsettings.setValue("Import/lastDirectoryVideo", QUrl.fromLocalFile("/videos"))
-    settings_file.qsettings.setValue("Import/lastDirectoryDocuments", QUrl.fromLocalFile("/documents"))
-    settings_file.qsettings.setValue("Import/lastDirectorySubtitles", QUrl.fromLocalFile("/subtitles"))
+def test_synced_writes_read_back_in_a_fresh_process(import_settings_service, settings_file):
+    import_settings_service.import_found_video = LoadFoundVideo.ALWAYS
+    import_settings_service.last_directory_video = QUrl("file:///videos")
+    import_settings_service.last_directory_documents = QUrl("file:///documents")
+    import_settings_service.last_directory_subtitles = QUrl("file:///subtitles")
     settings_file.qsettings.sync()
+    assert settings_file.qsettings.status() == QSettings.Status.NoError
 
-    # a fresh handle on the same file, so the values come off disk rather than out of the write cache
-    reopened = QSettings(str(tmp_path / "test_settings.ini"), QSettings.Format.IniFormat)
-    service = ImportSettingsService(reopened)
+    reader = dedent("""
+        import json
+        import sys
+        from PySide6.QtCore import QSettings, QUrl
+        from mpvqc.importing.services import ImportSettingsService
 
-    assert service.import_found_video == LoadFoundVideo.ALWAYS
-    assert service.last_directory_video == QUrl.fromLocalFile("/videos")
-    assert service.last_directory_documents == QUrl.fromLocalFile("/documents")
-    assert service.last_directory_subtitles == QUrl.fromLocalFile("/subtitles")
+        qsettings = QSettings(sys.argv[1], QSettings.Format.IniFormat)
+        service = ImportSettingsService(qsettings)
+        print(json.dumps({
+            "stored": {
+                key: [type(value).__name__, value.toString() if isinstance(value, QUrl) else value]
+                for key in qsettings.allKeys()
+                for value in [qsettings.value(key)]
+            },
+            "effective": [
+                service.import_found_video.value,
+                service.last_directory_video.toString(),
+                service.last_directory_documents.toString(),
+                service.last_directory_subtitles.toString(),
+            ],
+        }))
+    """)
+    process = QProcess()
+    process.setWorkingDirectory(str(Path(__file__).resolve().parents[3]))
+    process.start(sys.executable, ["-c", reader, settings_file.qsettings.fileName()])
+    finished = process.waitForFinished(30_000)
+    if not finished:
+        process.kill()
+        process.waitForFinished()
+    assert finished, process.errorString()
+    assert process.exitStatus() == QProcess.ExitStatus.NormalExit
+    assert process.exitCode() == 0, bytes(process.readAllStandardError().data()).decode("utf-8")
+    assert json.loads(bytes(process.readAllStandardOutput().data())) == {
+        "stored": {
+            "Import/loadFoundVideo": ["str", "0"],
+            "Import/lastDirectoryVideo": ["QUrl", "file:///videos"],
+            "Import/lastDirectoryDocuments": ["QUrl", "file:///documents"],
+            "Import/lastDirectorySubtitles": ["QUrl", "file:///subtitles"],
+        },
+        "effective": [0, "file:///videos", "file:///documents", "file:///subtitles"],
+    }
 
 
 def test_the_previous_builds_found_video_key_is_ignored(import_settings_service, settings_file):
     settings_file.qsettings.setValue("Import/importFoundVideo", LoadFoundVideo.ALWAYS.value)
 
     assert import_settings_service.import_found_video == LoadFoundVideo.ASK_EVERY_TIME
+    assert settings_file.qsettings.value("Import/importFoundVideo") == 0
+    assert not settings_file.qsettings.contains("Import/loadFoundVideo")
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param("/directory", id="path"),
+        pytest.param("file:///directory", id="url-text"),
+        pytest.param(42, id="number"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_malformed_directories_use_lazy_fallback_without_repair(settings_file, stored):
+    store = settings_file.qsettings
+    keys = ("Import/lastDirectoryVideo", "Import/lastDirectoryDocuments", "Import/lastDirectorySubtitles")
+    with patch.object(QStandardPaths, "writableLocation", side_effect=["/first"] * 3 + ["/second"] * 3) as location:
+        service = ImportSettingsService(store)
+        location.assert_not_called()
+        assert (service.last_directory_video, service.last_directory_documents, service.last_directory_subtitles) == (
+            QUrl.fromLocalFile("/first"),
+            QUrl.fromLocalFile("/first"),
+            QUrl.fromLocalFile("/first"),
+        )
+        assert store.allKeys() == []
+        for key in keys:
+            store.setValue(key, stored)
+        assert (service.last_directory_video, service.last_directory_documents, service.last_directory_subtitles) == (
+            QUrl.fromLocalFile("/second"),
+            QUrl.fromLocalFile("/second"),
+            QUrl.fromLocalFile("/second"),
+        )
+        assert (
+            location.call_args_list
+            == [
+                call(QStandardPaths.StandardLocation.MoviesLocation),
+                call(QStandardPaths.StandardLocation.DocumentsLocation),
+                call(QStandardPaths.StandardLocation.DocumentsLocation),
+            ]
+            * 2
+        )
+    assert [store.value(key) for key in keys] == [stored] * 3
+    assert all(store.contains(key) for key in keys)
+
+
+def test_plain_owner_writes_defaults_and_equal_values_unconditionally(import_settings_service, settings_file):
+    service = import_settings_service
+    store = settings_file.qsettings
+    assert not isinstance(service, QObject)
+    video, documents, subtitles = (
+        service.last_directory_video,
+        service.last_directory_documents,
+        service.last_directory_subtitles,
+    )
+    assert store.allKeys() == []
+
+    with patch.object(store, "setValue", wraps=store.setValue) as write:
+        for _ in range(2):
+            service.import_found_video = LoadFoundVideo.ASK_EVERY_TIME
+            service.last_directory_video = video
+            service.last_directory_documents = documents
+            service.last_directory_subtitles = subtitles
+        assert (
+            write.call_args_list
+            == [
+                call("Import/loadFoundVideo", 1),
+                call("Import/lastDirectoryVideo", video),
+                call("Import/lastDirectoryDocuments", documents),
+                call("Import/lastDirectorySubtitles", subtitles),
+            ]
+            * 2
+        )
+    assert type(store.value("Import/loadFoundVideo")) is int
+    assert isinstance(store.value("Import/lastDirectoryVideo"), QUrl)
+    assert isinstance(store.value("Import/lastDirectoryDocuments"), QUrl)
+    assert isinstance(store.value("Import/lastDirectorySubtitles"), QUrl)

--- a/test/services/settings_typing.py
+++ b/test/services/settings_typing.py
@@ -9,14 +9,23 @@ from typing import assert_type
 
 from PySide6.QtCore import QUrl
 
+from mpvqc.comments.services import CommentsSettingsService
+from mpvqc.i18n.services import I18nSettingsService
 from mpvqc.importing.services import ImportSettingsService, LoadFoundVideo
 from mpvqc.shell.services import ShellSettingsService, TimeDisplayMode, WindowTitleFormat
 
 
-def reads_keep_their_declared_types(shell: ShellSettingsService, importing: ImportSettingsService) -> None:
+def reads_keep_their_declared_types(
+    shell: ShellSettingsService,
+    importing: ImportSettingsService,
+    i18n: I18nSettingsService,
+    comments: CommentsSettingsService,
+) -> None:
     assert_type(shell.show_percentage, bool)
     assert_type(shell.layout_orientation, int)
     assert_type(shell.time_display_mode, TimeDisplayMode)
     assert_type(shell.window_title_format, WindowTitleFormat)
     assert_type(importing.import_found_video, LoadFoundVideo)
     assert_type(importing.last_directory_video, QUrl)
+    assert_type(i18n.language, str)
+    assert_type(comments.comment_types, list[str])

--- a/test/services/settings_typing.py
+++ b/test/services/settings_typing.py
@@ -7,11 +7,16 @@
 
 from typing import assert_type
 
+from PySide6.QtCore import QUrl
+
+from mpvqc.importing.services import ImportSettingsService, LoadFoundVideo
 from mpvqc.shell.services import ShellSettingsService, TimeDisplayMode, WindowTitleFormat
 
 
-def reads_keep_their_declared_types(shell: ShellSettingsService) -> None:
+def reads_keep_their_declared_types(shell: ShellSettingsService, importing: ImportSettingsService) -> None:
     assert_type(shell.show_percentage, bool)
     assert_type(shell.layout_orientation, int)
     assert_type(shell.time_display_mode, TimeDisplayMode)
     assert_type(shell.window_title_format, WindowTitleFormat)
+    assert_type(importing.import_found_video, LoadFoundVideo)
+    assert_type(importing.last_directory_video, QUrl)

--- a/test/services/settings_typing.py
+++ b/test/services/settings_typing.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: mpvQC developers
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Pyrefly checks this file through the project hook; pytest never collects it. A setting that stops reading
+# back as its declared type fails the hook here, where nothing else would notice.
+
+from typing import assert_type
+
+from mpvqc.shell.services import ShellSettingsService, TimeDisplayMode, WindowTitleFormat
+
+
+def reads_keep_their_declared_types(shell: ShellSettingsService) -> None:
+    assert_type(shell.show_percentage, bool)
+    assert_type(shell.layout_orientation, int)
+    assert_type(shell.time_display_mode, TimeDisplayMode)
+    assert_type(shell.window_title_format, WindowTitleFormat)

--- a/test/services/settings_typing.py
+++ b/test/services/settings_typing.py
@@ -10,6 +10,7 @@ from typing import assert_type
 from PySide6.QtCore import QUrl
 
 from mpvqc.comments.services import CommentsSettingsService
+from mpvqc.exporting.services import ExportSettingsService
 from mpvqc.i18n.services import I18nSettingsService
 from mpvqc.importing.services import ImportSettingsService, LoadFoundVideo
 from mpvqc.shell.services import ShellSettingsService, TimeDisplayMode, WindowTitleFormat
@@ -17,6 +18,7 @@ from mpvqc.shell.services import ShellSettingsService, TimeDisplayMode, WindowTi
 
 def reads_keep_their_declared_types(
     shell: ShellSettingsService,
+    exporting: ExportSettingsService,
     importing: ImportSettingsService,
     i18n: I18nSettingsService,
     comments: CommentsSettingsService,
@@ -25,6 +27,7 @@ def reads_keep_their_declared_types(
     assert_type(shell.layout_orientation, int)
     assert_type(shell.time_display_mode, TimeDisplayMode)
     assert_type(shell.window_title_format, WindowTitleFormat)
+    assert_type(exporting.nickname, str)
     assert_type(importing.import_found_video, LoadFoundVideo)
     assert_type(importing.last_directory_video, QUrl)
     assert_type(i18n.language, str)

--- a/test/shell/services/test_settings.py
+++ b/test/shell/services/test_settings.py
@@ -6,9 +6,13 @@ from collections.abc import Callable
 from typing import NamedTuple
 
 import pytest
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QSettings, Qt
 
-from mpvqc.shell.services import ShellSettingsService, TimeDisplayMode, WindowTitleFormat
+from mpvqc.shell.services import (
+    ShellSettingsService,
+    TimeDisplayMode,
+    WindowTitleFormat,
+)
 
 VERTICAL = Qt.Orientation.Vertical.value
 HORIZONTAL = Qt.Orientation.Horizontal.value
@@ -20,6 +24,16 @@ def existing_settings_service(read_existing_settings) -> Callable[[str], ShellSe
         return ShellSettingsService(read_existing_settings(content))
 
     return read
+
+
+@pytest.fixture
+def shell_settings_spies(shell_settings_service, make_spy):
+    return (
+        make_spy(shell_settings_service.show_percentage_changed),
+        make_spy(shell_settings_service.time_display_mode_changed),
+        make_spy(shell_settings_service.layout_orientation_changed),
+        make_spy(shell_settings_service.window_title_format_changed),
+    )
 
 
 def test_show_percentage_defaults_to_on(shell_settings_service):
@@ -51,10 +65,19 @@ def test_time_display_mode_set_and_get(shell_settings_service, mode):
     assert shell_settings_service.time_display_mode is mode
 
 
-def test_layout_orientation_set_and_get(shell_settings_service):
-    shell_settings_service.layout_orientation = HORIZONTAL
+@pytest.mark.parametrize(
+    "orientation",
+    [
+        HORIZONTAL,
+        42,
+        -1,
+    ],
+)
+def test_layout_orientation_set_and_get(shell_settings_service, orientation):
+    shell_settings_service.layout_orientation = orientation
 
-    assert shell_settings_service.layout_orientation == HORIZONTAL
+    assert shell_settings_service.layout_orientation == orientation
+    assert type(shell_settings_service.layout_orientation) is int
 
 
 @pytest.mark.parametrize("title_format", list(WindowTitleFormat))
@@ -64,48 +87,46 @@ def test_window_title_format_set_and_get(shell_settings_service, title_format):
     assert shell_settings_service.window_title_format is title_format
 
 
-def test_show_percentage_signals_a_change(shell_settings_service, make_spy):
-    spy = make_spy(shell_settings_service.show_percentage_changed)
+def test_each_change_is_stored_before_its_one_signal(shell_settings_service, settings_file):
+    service = shell_settings_service
+    store = settings_file.qsettings
+    remaining = TimeDisplayMode.REMAINING_TIME
+    file_path = WindowTitleFormat.FILE_PATH
+    deliveries: list[tuple[str, object, object, object]] = []
+    service.show_percentage_changed.connect(
+        lambda payload: deliveries.append(
+            ("show_percentage", payload, store.value("StatusBar/statusbarPercentage"), service.show_percentage)
+        )
+    )
+    service.time_display_mode_changed.connect(
+        lambda payload: deliveries.append(
+            ("time_display_mode", payload, store.value("StatusBar/timeFormat"), service.time_display_mode)
+        )
+    )
+    service.layout_orientation_changed.connect(
+        lambda payload: deliveries.append(
+            ("layout_orientation", payload, store.value("SplitView/layoutOrientation"), service.layout_orientation)
+        )
+    )
+    service.window_title_format_changed.connect(
+        lambda payload: deliveries.append(
+            ("window_title_format", payload, store.value("Window/titleFormat"), service.window_title_format)
+        )
+    )
 
-    shell_settings_service.show_percentage = False
-    assert spy.count() == 1
-    assert spy.at(0, 0) is False
+    for _ in range(2):
+        service.show_percentage = False
+        service.time_display_mode = remaining
+        service.layout_orientation = HORIZONTAL
+        service.window_title_format = file_path
 
-    shell_settings_service.show_percentage = False
-    assert spy.count() == 1
-
-
-def test_time_display_mode_signals_a_change(shell_settings_service, make_spy):
-    spy = make_spy(shell_settings_service.time_display_mode_changed)
-
-    shell_settings_service.time_display_mode = TimeDisplayMode.REMAINING_TIME
-    assert spy.count() == 1
-    assert spy.at(0, 0) == TimeDisplayMode.REMAINING_TIME
-
-    shell_settings_service.time_display_mode = TimeDisplayMode.REMAINING_TIME
-    assert spy.count() == 1
-
-
-def test_layout_orientation_signals_a_change(shell_settings_service, make_spy):
-    spy = make_spy(shell_settings_service.layout_orientation_changed)
-
-    shell_settings_service.layout_orientation = HORIZONTAL
-    assert spy.count() == 1
-    assert spy.at(0, 0) == HORIZONTAL
-
-    shell_settings_service.layout_orientation = HORIZONTAL
-    assert spy.count() == 1
-
-
-def test_window_title_format_signals_a_change(shell_settings_service, make_spy):
-    spy = make_spy(shell_settings_service.window_title_format_changed)
-
-    shell_settings_service.window_title_format = WindowTitleFormat.FILE_NAME
-    assert spy.count() == 1
-    assert spy.at(0, 0) == WindowTitleFormat.FILE_NAME
-
-    shell_settings_service.window_title_format = WindowTitleFormat.FILE_NAME
-    assert spy.count() == 1
+    assert deliveries == [
+        ("show_percentage", False, False, False),
+        ("time_display_mode", remaining.value, remaining.value, remaining),
+        ("layout_orientation", HORIZONTAL, HORIZONTAL, HORIZONTAL),
+        ("window_title_format", file_path.value, file_path.value, file_path),
+    ]
+    assert [type(payload) for _, payload, _, _ in deliveries] == [bool, int, int, int]
 
 
 def test_every_write_lands_under_its_stored_key(shell_settings_service, ini_section):
@@ -148,8 +169,15 @@ class FallbackCase(NamedTuple):
 
 @pytest.mark.parametrize(
     "stored",
-    [42, -1, "banana", "", True],
-    ids=["out-of-range", "negative", "text", "empty", "bool"],
+    [
+        pytest.param(42, id="out-of-range"),
+        pytest.param("42", id="text-out-of-range"),
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param("1.0", id="decimal"),
+        pytest.param(True, id="bool"),
+        pytest.param(1.5, id="float"),
+    ],
 )
 @pytest.mark.parametrize(
     "case",
@@ -169,14 +197,135 @@ class FallbackCase(NamedTuple):
     ],
     ids=lambda case: case.name,
 )
-def test_an_unreadable_member_falls_back_to_its_default(shell_settings_service, settings_file, case, stored):
+def test_an_unreadable_member_falls_back_to_its_default(
+    shell_settings_service, settings_file, case: FallbackCase, stored
+):
     settings_file.qsettings.setValue(case.key, stored)
 
     assert case.read(shell_settings_service) is case.default
 
 
-@pytest.mark.parametrize("stored", ["banana", "", True], ids=["text", "empty", "bool"])
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param("banana", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param("1.0", id="decimal"),
+        pytest.param(True, id="true"),
+        pytest.param(False, id="false"),
+        pytest.param(1.5, id="float"),
+    ],
+)
 def test_an_unreadable_layout_orientation_falls_back_to_vertical(shell_settings_service, settings_file, stored):
     settings_file.qsettings.setValue("SplitView/layoutOrientation", stored)
 
     assert shell_settings_service.layout_orientation == VERTICAL
+    assert type(shell_settings_service.layout_orientation) is int
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("false", False),
+        ("TrUe", True),
+        ("FaLsE", False),
+    ],
+)
+def test_show_percentage_reads_native_and_text_booleans(shell_settings_service, settings_file, stored, expected):
+    settings_file.qsettings.setValue("StatusBar/statusbarPercentage", stored)
+
+    assert shell_settings_service.show_percentage is expected
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param(1, id="number"),
+        pytest.param(0.0, id="float"),
+        pytest.param("1", id="text-number"),
+        pytest.param("yes", id="yes"),
+        pytest.param("", id="empty"),
+        pytest.param(" true ", id="padded"),
+        pytest.param("banana", id="text"),
+    ],
+)
+def test_an_unreadable_percentage_falls_back_to_on(shell_settings_service, settings_file, stored):
+    settings_file.qsettings.setValue("StatusBar/statusbarPercentage", stored)
+
+    assert shell_settings_service.show_percentage is True
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (0, 0),
+        (42, 42),
+        (-1, -1),
+        ("0", 0),
+        ("42", 42),
+        ("-1", -1),
+        (" +42 ", 42),
+    ],
+)
+def test_layout_orientation_reads_native_and_text_integers(shell_settings_service, settings_file, stored, expected):
+    settings_file.qsettings.setValue("SplitView/layoutOrientation", stored)
+
+    assert shell_settings_service.layout_orientation == expected
+    assert type(shell_settings_service.layout_orientation) is int
+
+
+@pytest.mark.parametrize(
+    "storage",
+    [
+        "missing",
+        "malformed",
+        "text-defaults",
+    ],
+)
+def test_reads_and_no_op_assignments_leave_storage_untouched(
+    shell_settings_service, settings_file, shell_settings_spies, storage
+):
+    qsettings = settings_file.qsettings
+    defaults = {
+        "StatusBar/statusbarPercentage": "true",
+        "StatusBar/timeFormat": "3",
+        "SplitView/layoutOrientation": "2",
+        "Window/titleFormat": "0",
+    }
+    if storage != "missing":
+        for key, value in defaults.items():
+            qsettings.setValue(key, "banana" if storage == "malformed" else value)
+    before = {key: qsettings.value(key) for key in qsettings.allKeys()}
+
+    assert shell_settings_service.show_percentage is True
+    assert shell_settings_service.time_display_mode is TimeDisplayMode.CURRENT_TOTAL_TIME
+    assert shell_settings_service.layout_orientation == VERTICAL
+    assert shell_settings_service.window_title_format is WindowTitleFormat.DEFAULT
+    assert {key: qsettings.value(key) for key in qsettings.allKeys()} == before
+    assert [spy.count() for spy in shell_settings_spies] == [0, 0, 0, 0]
+
+    shell_settings_service.show_percentage = True
+    shell_settings_service.time_display_mode = TimeDisplayMode.CURRENT_TOTAL_TIME
+    shell_settings_service.layout_orientation = VERTICAL
+    shell_settings_service.window_title_format = WindowTitleFormat.DEFAULT
+
+    assert {key: qsettings.value(key) for key in qsettings.allKeys()} == before
+    assert [spy.count() for spy in shell_settings_spies] == [0, 0, 0, 0]
+
+
+def test_instances_share_a_file_but_never_a_value(shell_settings_service, settings_file, tmp_path):
+    same_file = ShellSettingsService(QSettings(settings_file.qsettings.fileName(), QSettings.Format.IniFormat))
+    other_file = ShellSettingsService(QSettings(str(tmp_path / "other.ini"), QSettings.Format.IniFormat))
+
+    shell_settings_service.show_percentage = False
+    shell_settings_service.time_display_mode = TimeDisplayMode.REMAINING_TIME
+    other_file.layout_orientation = 42
+    other_file.window_title_format = WindowTitleFormat.FILE_NAME
+
+    assert (same_file.show_percentage, same_file.time_display_mode) == (False, TimeDisplayMode.REMAINING_TIME)
+    assert (same_file.layout_orientation, same_file.window_title_format) == (VERTICAL, WindowTitleFormat.DEFAULT)
+    assert (other_file.show_percentage, other_file.time_display_mode) == (True, TimeDisplayMode.CURRENT_TOTAL_TIME)
+    assert (other_file.layout_orientation, other_file.window_title_format) == (42, WindowTitleFormat.FILE_NAME)


### PR DESCRIPTION
## Manual checks before merging

### 🌐 Anywhere

#### Footer

- [x] Percentage off and "remaining time" picked in the footer menu, quit, relaunch: the footer opens without the percentage and with a remaining time, both items marked

#### Title bar

- [x] Options ▸ Application Title ▸ "Video Path" picked, quit, relaunch, open a video: the title bar shows the full path and the radio marks "Video Path"

#### Layout

- [x] Options ▸ Application Layout ▸ "Video Next to Comments" picked, quit, relaunch: the split opens horizontal and the radio marks it

#### Export settings

- [x] A nickname typed and OK pressed, quit, relaunch: the Nickname field holds the typed name, not the login name
- [x] The Nickname field cleared and OK pressed, quit, relaunch: the field is still empty, not the login name
- [x] All five Document Header switches flipped and OK pressed, quit, relaunch: the switches reopen flipped

#### Backup settings

- [x] Backup Enabled off and the interval at 15 s with OK pressed, quit, relaunch: the dialog reopens with the switch off and 15 s

#### Comment types

- [x] A custom type added and moved to the top with OK pressed, quit, relaunch: the dialog and the new-comment menu list the custom type first

#### Language

- [x] Hebrew picked in Options ▸ Language, quit, relaunch: the app opens in Hebrew and the submenu marks Hebrew
